### PR TITLE
[Tournament] Add minted_at attribute to Avatar

### DIFF
--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -48,7 +48,7 @@ type CollectionIdOf<T> = <<T as AvatarsConfig>::NftHandler as NftHandler<
 	AvatarIdOf<T>,
 	KeyLimitOf<T>,
 	ValueLimitOf<T>,
-	Avatar,
+	AvatarOf<T>,
 >>::CollectionId;
 
 type NftCollectionConfigOf<T> =

--- a/pallets/ajuna-awesome-avatars/benchmarking/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/mock.rs
@@ -21,7 +21,7 @@ use frame_support::{
 	traits::{AsEnsureOriginWithArg, ConstU16, ConstU64},
 	PalletId,
 };
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::{pallet_prelude::BlockNumberFor, EnsureRoot, EnsureSigned};
 use pallet_ajuna_awesome_avatars::{
 	types::{AffiliateMethods, Avatar, SeasonId},
 	FeePropagationOf,
@@ -238,7 +238,7 @@ impl pallet_ajuna_tournament::Config<TournamentInstance1> for Runtime {
 	type Currency = Balances;
 	type SeasonId = SeasonId;
 	type EntityId = crate::AvatarIdOf<Runtime>;
-	type RankedEntity = Avatar;
+	type RankedEntity = Avatar<BlockNumberFor<Runtime>>;
 	type MinimumTournamentPhaseDuration = MinimumTournamentPhaseDuration;
 }
 

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -238,7 +238,7 @@ impl pallet_ajuna_tournament::Config<TournamentInstance1> for Test {
 	type Currency = Balances;
 	type SeasonId = SeasonId;
 	type EntityId = AvatarIdOf<Test>;
-	type RankedEntity = Avatar;
+	type RankedEntity = AvatarOf<Test>;
 	type MinimumTournamentPhaseDuration = MinimumTournamentPhaseDuration;
 }
 

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -3598,6 +3598,7 @@ mod nft_transfer {
 						],
 						souls: 60,
 						encoding: DnaEncoding::V2,
+						minted_at: season_schedule.start,
 					}
 				);
 
@@ -3606,14 +3607,14 @@ mod nft_transfer {
 					<Nft as Inspect<MockAccountId>>::system_attribute(
 						&CollectionId::<Test>::get().unwrap(),
 						Some(&avatar_id),
-						<Avatar as NftConvertible<KeyLimit, ValueLimit>>::ITEM_CODE,
+						<AvatarOf<Test> as NftConvertible<KeyLimit, ValueLimit>>::ITEM_CODE,
 					)
 					.unwrap(),
 					avatar.encode(),
 				);
 
 				// Ensure attributes encoding
-				for (attribute_code, attribute) in <Avatar as NftConvertible<
+				for (attribute_code, attribute) in <AvatarOf<Test> as NftConvertible<
 					KeyLimit,
 					ValueLimit,
 				>>::get_attribute_codes()

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/mod.rs
@@ -57,14 +57,18 @@ pub enum DnaEncoding {
 }
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq, Eq)]
-pub struct Avatar {
+pub struct Avatar<BlockNumber> {
 	pub season_id: SeasonId,
 	pub encoding: DnaEncoding,
 	pub dna: Dna,
 	pub souls: SoulCount,
+	pub minted_at: BlockNumber,
 }
 
-impl Avatar {
+impl<BlockNumber> Avatar<BlockNumber>
+where
+	BlockNumber: sp_runtime::traits::BlockNumber,
+{
 	pub(crate) fn rarity(&self) -> u8 {
 		match self.encoding {
 			DnaEncoding::V1 => AttributeMapperV1::rarity(self),

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/nft.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/nft.rs
@@ -21,10 +21,11 @@ use parity_scale_codec::alloc::string::ToString;
 use scale_info::prelude::format;
 use sp_std::prelude::*;
 
-impl<KL, VL> NftConvertible<KL, VL> for Avatar
+impl<KL, VL, BlockNumber> NftConvertible<KL, VL> for Avatar<BlockNumber>
 where
 	KL: Get<u32>,
 	VL: Get<u32>,
+	BlockNumber: sp_runtime::traits::BlockNumber,
 {
 	const ITEM_CODE: &'static [u8] = b"AVATAR";
 	const IPFS_URL_CODE: &'static [u8] = b"IPFS_URL";
@@ -36,6 +37,7 @@ where
 			BoundedVec::try_from(b"RARITY".to_vec()).unwrap(),
 			BoundedVec::try_from(b"FORCE".to_vec()).unwrap(),
 			BoundedVec::try_from(b"SEASON_ID".to_vec()).unwrap(),
+			BoundedVec::try_from(b"MINTED_AT".to_vec()).unwrap(),
 		]
 	}
 
@@ -70,6 +72,10 @@ where
 			(
 				BoundedVec::try_from(b"SEASON_ID".to_vec()).unwrap(),
 				BoundedVec::try_from(format!("{}", self.season_id).into_bytes()).unwrap(),
+			),
+			(
+				BoundedVec::try_from(b"MINTED_AT".to_vec()).unwrap(),
+				BoundedVec::try_from(format!("{}", self.minted_at).into_bytes()).unwrap(),
 			),
 		]
 	}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tournament.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tournament.rs
@@ -10,17 +10,18 @@ pub enum AvatarRankingCategory {
 }
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq, Eq)]
-pub struct AvatarRanker<T> {
+pub struct AvatarRanker<Id, BlockNumber> {
 	pub category: AvatarRankingCategory,
-	pub _marker: PhantomData<T>,
+	pub _marker: PhantomData<(Id, BlockNumber)>,
 }
 
-impl<T> EntityRank for AvatarRanker<T>
+impl<Id, BlockNumber> EntityRank for AvatarRanker<Id, BlockNumber>
 where
-	T: Member,
+	Id: Member,
+	BlockNumber: sp_runtime::traits::BlockNumber,
 {
-	type EntityId = T;
-	type Entity = Avatar;
+	type EntityId = Id;
+	type Entity = Avatar<BlockNumber>;
 
 	fn rank_against(
 		&self,

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/mod.rs
@@ -8,12 +8,12 @@ use crate::*;
 use frame_support::pallet_prelude::*;
 use sp_std::vec::Vec;
 
-pub(crate) trait AttributeMapper {
+pub(crate) trait AttributeMapper<BlockNumber> {
 	/// Used to obtain the RarityTier of a given avatar as an u8.
-	fn rarity(target: &Avatar) -> u8;
+	fn rarity(target: &Avatar<BlockNumber>) -> u8;
 
 	/// Used to get the Force of a given avatar as an u8.
-	fn force(target: &Avatar) -> u8;
+	fn force(target: &Avatar<BlockNumber>) -> u8;
 }
 
 pub(crate) trait Minter<T: Config> {
@@ -25,7 +25,7 @@ pub(crate) trait Minter<T: Config> {
 }
 
 /// A tuple containing and avatar identifier with its represented avatar, used as forging inputs.
-pub(crate) type ForgeItem<T> = (AvatarIdOf<T>, Avatar);
+pub(crate) type ForgeItem<T> = (AvatarIdOf<T>, AvatarOf<T>);
 /// Number of components upgraded after a forge in a given Avatar.
 pub(crate) type UpgradedComponents = u8;
 
@@ -43,7 +43,7 @@ pub(crate) enum ForgeOutput<T: Config> {
 	/// The avatar was forged (mutate) in some way.
 	Forged(ForgeItem<T>, UpgradedComponents),
 	/// A new avatar was created from the forging process.
-	Minted(Avatar),
+	Minted(AvatarOf<T>),
 	/// The avatar was consumed in the forging process.
 	Consumed(AvatarIdOf<T>),
 }

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/avatar_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/avatar_utils.rs
@@ -4,7 +4,10 @@ use crate::{
 	ByteConvertible, Config, Force, Ranged, RarityTier,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
-use sp_runtime::{traits::Hash, SaturatedConversion};
+use sp_runtime::{
+	traits::{BlockNumber, Hash},
+	SaturatedConversion,
+};
 use sp_std::{
 	cmp::Ordering,
 	marker::PhantomData,
@@ -13,17 +16,20 @@ use sp_std::{
 };
 
 #[derive(Clone)]
-pub(crate) struct WrappedAvatar {
-	inner: Avatar,
+pub(crate) struct WrappedAvatar<BlockNumber> {
+	inner: Avatar<BlockNumber>,
 }
 
 #[allow(dead_code)]
-impl WrappedAvatar {
-	pub fn new(avatar: Avatar) -> Self {
+impl<BlockNumber> WrappedAvatar<BlockNumber>
+where
+	BlockNumber: sp_runtime::traits::BlockNumber,
+{
+	pub fn new(avatar: Avatar<BlockNumber>) -> Self {
 		Self { inner: avatar }
 	}
 
-	pub fn unwrap(self) -> Avatar {
+	pub fn unwrap(self) -> Avatar<BlockNumber> {
 		self.inner
 	}
 
@@ -101,7 +107,7 @@ impl WrappedAvatar {
 		DnaUtils::write_attribute(&mut self.inner, AvatarAttr::ItemType, &item_type)
 	}
 
-	pub fn same_item_type(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_item_type(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.get_item_type().cmp(&other.get_item_type()).is_eq()
 	}
 
@@ -119,7 +125,7 @@ impl WrappedAvatar {
 		DnaUtils::write_attribute::<T>(&mut self.inner, AvatarAttr::ItemSubType, &item_sub_type)
 	}
 
-	pub fn same_item_sub_type(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_item_sub_type(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.get_item_sub_type::<u8>().cmp(&other.get_item_sub_type::<u8>()).is_eq()
 	}
 
@@ -137,7 +143,7 @@ impl WrappedAvatar {
 		DnaUtils::write_attribute::<T>(&mut self.inner, AvatarAttr::ClassType1, &class_type_1)
 	}
 
-	pub fn same_class_type_1(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_class_type_1(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.get_class_type_1::<u8>().cmp(&other.get_class_type_1::<u8>()).is_eq()
 	}
 
@@ -155,7 +161,7 @@ impl WrappedAvatar {
 		DnaUtils::write_attribute::<T>(&mut self.inner, AvatarAttr::ClassType2, &class_type_2)
 	}
 
-	pub fn same_class_type_2(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_class_type_2(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.get_class_type_2::<u8>().cmp(&other.get_class_type_2::<u8>()).is_eq()
 	}
 
@@ -173,7 +179,7 @@ impl WrappedAvatar {
 		DnaUtils::write_attribute::<T>(&mut self.inner, AvatarAttr::CustomType1, &custom_type_1)
 	}
 
-	pub fn same_custom_type_1(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_custom_type_1(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.get_custom_type_1::<u8>().cmp(&other.get_custom_type_1::<u8>()).is_eq()
 	}
 
@@ -191,7 +197,7 @@ impl WrappedAvatar {
 		DnaUtils::write_attribute::<T>(&mut self.inner, AvatarAttr::CustomType2, &custom_type_2)
 	}
 
-	pub fn same_custom_type_2(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_custom_type_2(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.get_custom_type_2::<u8>().cmp(&other.get_custom_type_2::<u8>()).is_eq()
 	}
 
@@ -203,7 +209,7 @@ impl WrappedAvatar {
 		DnaUtils::write_attribute::<RarityTier>(&mut self.inner, AvatarAttr::RarityTier, &rarity)
 	}
 
-	pub fn same_rarity(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_rarity(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.get_rarity().cmp(&other.get_rarity()).is_eq()
 	}
 
@@ -215,7 +221,7 @@ impl WrappedAvatar {
 		DnaUtils::write_attribute_raw(&mut self.inner, AvatarAttr::Quantity, quantity)
 	}
 
-	pub fn same_quantity(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_quantity(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.get_quantity().cmp(&other.get_quantity()).is_eq()
 	}
 
@@ -238,11 +244,11 @@ impl WrappedAvatar {
 		DnaUtils::write_specs(&mut self.inner, spec_bytes)
 	}
 
-	pub fn same_specs(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_specs(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.get_specs() == other.get_specs()
 	}
 
-	pub fn same_spec_at(&self, other: &WrappedAvatar, position: SpecIdx) -> bool {
+	pub fn same_spec_at(&self, other: &WrappedAvatar<BlockNumber>, position: SpecIdx) -> bool {
 		DnaUtils::read_spec_raw(&self.inner, position) ==
 			DnaUtils::read_spec_raw(&other.inner, position)
 	}
@@ -255,7 +261,7 @@ impl WrappedAvatar {
 		DnaUtils::write_progress(&mut self.inner, progress_array)
 	}
 
-	pub fn same_progress(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_progress(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.get_progress() == other.get_progress()
 	}
 
@@ -281,15 +287,15 @@ impl WrappedAvatar {
 		self.get_class_type_1::<u8>() == 0 && self.get_class_type_2::<u8>() == 0
 	}
 
-	pub fn same_full_type(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_full_type(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.same_item_type(other) && self.same_item_sub_type(other)
 	}
 
-	pub fn same_full_and_class_types(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_full_and_class_types(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.same_full_type(other) && self.same_class_type_1(other) && self.same_class_type_2(other)
 	}
 
-	pub fn same_assemble_version(&self, other: &WrappedAvatar) -> bool {
+	pub fn same_assemble_version(&self, other: &WrappedAvatar<BlockNumber>) -> bool {
 		self.same_item_type(other) && self.same_class_type_1(other) && self.same_class_type_2(other)
 	}
 }
@@ -335,16 +341,19 @@ pub enum SpecIdx {
 }
 
 #[derive(Default)]
-pub(crate) struct AvatarBuilder {
-	inner: Avatar,
+pub(crate) struct AvatarBuilder<BlockNumber> {
+	inner: Avatar<BlockNumber>,
 }
 
-impl AvatarBuilder {
-	pub fn with_dna(season_id: SeasonId, dna: Dna) -> Self {
-		Self { inner: Avatar { season_id, encoding: DnaEncoding::V2, dna, souls: 0 } }
+impl<BlockNumber> AvatarBuilder<BlockNumber>
+where
+	BlockNumber: sp_runtime::traits::BlockNumber,
+{
+	pub fn with_dna(season_id: SeasonId, dna: Dna, minted_at: BlockNumber) -> Self {
+		Self { inner: Avatar { season_id, encoding: DnaEncoding::V2, dna, souls: 0, minted_at } }
 	}
 
-	pub fn with_base_avatar(avatar: Avatar) -> Self {
+	pub fn with_base_avatar(avatar: Avatar<BlockNumber>) -> Self {
 		Self { inner: avatar }
 	}
 
@@ -356,17 +365,17 @@ impl AvatarBuilder {
 	}
 
 	pub fn with_attribute_raw(mut self, attribute: AvatarAttr, value: u8) -> Self {
-		DnaUtils::write_attribute_raw(&mut self.inner, attribute, value);
+		DnaUtils::<BlockNumber>::write_attribute_raw(&mut self.inner, attribute, value);
 		self
 	}
 
 	pub fn with_spec_byte_raw(mut self, spec_byte: SpecIdx, value: u8) -> Self {
-		DnaUtils::write_spec(&mut self.inner, spec_byte, value);
+		DnaUtils::<BlockNumber>::write_spec(&mut self.inner, spec_byte, value);
 		self
 	}
 
 	pub fn with_spec_bytes(mut self, spec_bytes: [u8; 16]) -> Self {
-		DnaUtils::write_specs(&mut self.inner, spec_bytes);
+		DnaUtils::<BlockNumber>::write_specs(&mut self.inner, spec_bytes);
 		self
 	}
 
@@ -376,7 +385,7 @@ impl AvatarBuilder {
 	}
 
 	pub fn with_progress_array(mut self, progress_array: [u8; 11]) -> Self {
-		DnaUtils::write_progress(&mut self.inner, progress_array);
+		DnaUtils::<BlockNumber>::write_progress(&mut self.inner, progress_array);
 		self
 	}
 
@@ -405,7 +414,7 @@ impl AvatarBuilder {
 		let custom_type_1 = HexType::X1;
 
 		let spec_bytes = {
-			let mut spec_bytes = DnaUtils::read_specs(&self.inner);
+			let mut spec_bytes = DnaUtils::<BlockNumber>::read_specs(&self.inner);
 
 			for slot_index in slot_types.iter().map(|slot_type| slot_type.as_byte() as usize) {
 				spec_bytes[slot_index] = spec_bytes[slot_index].saturating_add(1);
@@ -431,19 +440,19 @@ impl AvatarBuilder {
 		let custom_type_1 = HexType::X1;
 
 		let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-		let base_0 = DnaUtils::create_pattern::<NibbleType>(
+		let base_0 = DnaUtils::<BlockNumber>::create_pattern::<NibbleType>(
 			base_seed,
 			EquippableItemType::ArmorBase.as_byte() as usize,
 		);
-		let comp_1 = DnaUtils::create_pattern::<NibbleType>(
+		let comp_1 = DnaUtils::<BlockNumber>::create_pattern::<NibbleType>(
 			base_seed,
 			EquippableItemType::ArmorComponent1.as_byte() as usize,
 		);
-		let comp_2 = DnaUtils::create_pattern::<NibbleType>(
+		let comp_2 = DnaUtils::<BlockNumber>::create_pattern::<NibbleType>(
 			base_seed,
 			EquippableItemType::ArmorComponent2.as_byte() as usize,
 		);
-		let comp_3 = DnaUtils::create_pattern::<NibbleType>(
+		let comp_3 = DnaUtils::<BlockNumber>::create_pattern::<NibbleType>(
 			base_seed,
 			EquippableItemType::ArmorComponent3.as_byte() as usize,
 		);
@@ -457,14 +466,38 @@ impl AvatarBuilder {
 			.with_attribute_raw(AvatarAttr::Quantity, quantity)
 			// Unused
 			.with_attribute(AvatarAttr::CustomType2, &HexType::X0)
-			.with_spec_byte_raw(SpecIdx::Byte1, DnaUtils::enums_to_bits(&base_0) as u8)
-			.with_spec_byte_raw(SpecIdx::Byte2, DnaUtils::enums_order_to_bits(&base_0) as u8)
-			.with_spec_byte_raw(SpecIdx::Byte3, DnaUtils::enums_to_bits(&comp_1) as u8)
-			.with_spec_byte_raw(SpecIdx::Byte4, DnaUtils::enums_order_to_bits(&comp_1) as u8)
-			.with_spec_byte_raw(SpecIdx::Byte5, DnaUtils::enums_to_bits(&comp_2) as u8)
-			.with_spec_byte_raw(SpecIdx::Byte6, DnaUtils::enums_order_to_bits(&comp_2) as u8)
-			.with_spec_byte_raw(SpecIdx::Byte7, DnaUtils::enums_to_bits(&comp_3) as u8)
-			.with_spec_byte_raw(SpecIdx::Byte8, DnaUtils::enums_order_to_bits(&comp_3) as u8)
+			.with_spec_byte_raw(
+				SpecIdx::Byte1,
+				DnaUtils::<BlockNumber>::enums_to_bits(&base_0) as u8,
+			)
+			.with_spec_byte_raw(
+				SpecIdx::Byte2,
+				DnaUtils::<BlockNumber>::enums_order_to_bits(&base_0) as u8,
+			)
+			.with_spec_byte_raw(
+				SpecIdx::Byte3,
+				DnaUtils::<BlockNumber>::enums_to_bits(&comp_1) as u8,
+			)
+			.with_spec_byte_raw(
+				SpecIdx::Byte4,
+				DnaUtils::<BlockNumber>::enums_order_to_bits(&comp_1) as u8,
+			)
+			.with_spec_byte_raw(
+				SpecIdx::Byte5,
+				DnaUtils::<BlockNumber>::enums_to_bits(&comp_2) as u8,
+			)
+			.with_spec_byte_raw(
+				SpecIdx::Byte6,
+				DnaUtils::<BlockNumber>::enums_order_to_bits(&comp_2) as u8,
+			)
+			.with_spec_byte_raw(
+				SpecIdx::Byte7,
+				DnaUtils::<BlockNumber>::enums_to_bits(&comp_3) as u8,
+			)
+			.with_spec_byte_raw(
+				SpecIdx::Byte8,
+				DnaUtils::<BlockNumber>::enums_order_to_bits(&comp_3) as u8,
+			)
 			.with_soul_count(quantity as SoulCount * custom_type_1 as SoulCount)
 	}
 
@@ -652,7 +685,7 @@ impl AvatarBuilder {
 
 		let (armor_assemble_progress, color_flag) = {
 			let mut color_flag = 0b0000_0000;
-			let mut progress = DnaUtils::enums_to_bits(equippable_type) as u8;
+			let mut progress = DnaUtils::<BlockNumber>::enums_to_bits(equippable_type) as u8;
 
 			if color_pair.0 != ColorType::Null && color_pair.1 != ColorType::Null {
 				color_flag = 0b0000_1000;
@@ -666,7 +699,7 @@ impl AvatarBuilder {
 		// Guaranteed to work because of check above
 		let first_equippable = equippable_type.first().unwrap();
 
-		let progress_array = DnaUtils::generate_progress(
+		let progress_array = DnaUtils::<BlockNumber>::generate_progress(
 			rarity,
 			SCALING_FACTOR_PERC,
 			Some(PROGRESS_PROBABILITY_PERC),
@@ -711,7 +744,7 @@ impl AvatarBuilder {
 
 		let (weapon_info, color_flag) = {
 			let mut color_flag = 0b0000_0000;
-			let mut info = DnaUtils::enums_to_bits(&[*equippable_type]) as u8 >> 4;
+			let mut info = DnaUtils::<BlockNumber>::enums_to_bits(&[*equippable_type]) as u8 >> 4;
 
 			if color_pair.0 != ColorType::Null && color_pair.1 != ColorType::Null {
 				color_flag = 0b0000_1000;
@@ -724,8 +757,12 @@ impl AvatarBuilder {
 
 		let rarity = RarityTier::Legendary;
 
-		let progress_array =
-			DnaUtils::generate_progress(&rarity, SCALING_FACTOR_PERC, None, hash_provider);
+		let progress_array = DnaUtils::<BlockNumber>::generate_progress(
+			&rarity,
+			SCALING_FACTOR_PERC,
+			None,
+			hash_provider,
+		);
 
 		Ok(self
 			.with_attribute(AvatarAttr::ItemType, &ItemType::Equippable)
@@ -775,8 +812,14 @@ impl AvatarBuilder {
 			.with_attribute_raw(AvatarAttr::Quantity, quantity)
 			// Unused
 			.with_attribute(AvatarAttr::CustomType2, &HexType::X0)
-			.with_spec_byte_raw(SpecIdx::Byte1, DnaUtils::enums_to_bits(pattern) as u8)
-			.with_spec_byte_raw(SpecIdx::Byte2, DnaUtils::enums_order_to_bits(pattern) as u8)
+			.with_spec_byte_raw(
+				SpecIdx::Byte1,
+				DnaUtils::<BlockNumber>::enums_to_bits(pattern) as u8,
+			)
+			.with_spec_byte_raw(
+				SpecIdx::Byte2,
+				DnaUtils::<BlockNumber>::enums_order_to_bits(pattern) as u8,
+			)
 			.with_spec_byte_raw(SpecIdx::Byte3, equippable_item_type.as_byte())
 			.with_spec_byte_raw(SpecIdx::Byte4, mat_req1)
 			.with_spec_byte_raw(SpecIdx::Byte5, mat_req2)
@@ -834,26 +877,36 @@ impl AvatarBuilder {
 			.with_soul_count(soul_points)
 	}
 
-	pub fn build(self) -> Avatar {
+	pub fn build(self) -> Avatar<BlockNumber> {
 		self.inner
 	}
 
 	#[allow(dead_code)]
-	pub fn build_wrapped(self) -> WrappedAvatar {
+	pub fn build_wrapped(self) -> WrappedAvatar<BlockNumber> {
 		WrappedAvatar::new(self.inner)
 	}
 }
 
 /// Struct to wrap DNA interactions with Avatars from V2 upwards.
 /// Don't use with Avatars with V1.
-pub(crate) struct DnaUtils;
+pub(crate) struct DnaUtils<BlockNumber> {
+	_marker: PhantomData<BlockNumber>,
+}
 
-impl DnaUtils {
-	fn read_strand(avatar: &Avatar, position: usize, byte_type: ByteType) -> u8 {
+impl<BlockNumber> DnaUtils<BlockNumber>
+where
+	BlockNumber: sp_runtime::traits::BlockNumber,
+{
+	fn read_strand(avatar: &Avatar<BlockNumber>, position: usize, byte_type: ByteType) -> u8 {
 		Self::read_at(avatar.dna.as_slice(), position, byte_type)
 	}
 
-	fn write_strand(avatar: &mut Avatar, position: usize, byte_type: ByteType, value: u8) {
+	fn write_strand(
+		avatar: &mut Avatar<BlockNumber>,
+		position: usize,
+		byte_type: ByteType,
+		value: u8,
+	) {
 		match byte_type {
 			ByteType::Full => avatar.dna[position] = value,
 			ByteType::High =>
@@ -892,14 +945,14 @@ impl DnaUtils {
 		byte & 0x0F
 	}
 
-	pub fn read_attribute<T>(avatar: &Avatar, attribute: AvatarAttr) -> T
+	pub fn read_attribute<T>(avatar: &Avatar<BlockNumber>, attribute: AvatarAttr) -> T
 	where
 		T: ByteConvertible,
 	{
 		T::from_byte(Self::read_attribute_raw(avatar, attribute))
 	}
 
-	pub fn read_attribute_raw(avatar: &Avatar, attribute: AvatarAttr) -> u8 {
+	pub fn read_attribute_raw(avatar: &Avatar<BlockNumber>, attribute: AvatarAttr) -> u8 {
 		match attribute {
 			AvatarAttr::ItemType => Self::read_strand(avatar, 0, ByteType::High),
 			AvatarAttr::ItemSubType => Self::read_strand(avatar, 0, ByteType::Low),
@@ -912,14 +965,14 @@ impl DnaUtils {
 		}
 	}
 
-	pub fn write_attribute<T>(avatar: &mut Avatar, attribute: AvatarAttr, value: &T)
+	pub fn write_attribute<T>(avatar: &mut Avatar<BlockNumber>, attribute: AvatarAttr, value: &T)
 	where
 		T: ByteConvertible,
 	{
 		Self::write_attribute_raw(avatar, attribute, value.as_byte())
 	}
 
-	pub fn write_attribute_raw(avatar: &mut Avatar, attribute: AvatarAttr, value: u8) {
+	pub fn write_attribute_raw(avatar: &mut Avatar<BlockNumber>, attribute: AvatarAttr, value: u8) {
 		match attribute {
 			AvatarAttr::ItemType => Self::write_strand(avatar, 0, ByteType::High, value),
 			AvatarAttr::ItemSubType => Self::write_strand(avatar, 0, ByteType::Low, value),
@@ -932,13 +985,13 @@ impl DnaUtils {
 		}
 	}
 
-	pub fn read_specs(avatar: &Avatar) -> [u8; 16] {
+	pub fn read_specs(avatar: &Avatar<BlockNumber>) -> [u8; 16] {
 		let mut out = [0; 16];
 		out.copy_from_slice(&avatar.dna[5..21]);
 		out
 	}
 
-	pub fn read_spec_raw(avatar: &Avatar, index: SpecIdx) -> u8 {
+	pub fn read_spec_raw(avatar: &Avatar<BlockNumber>, index: SpecIdx) -> u8 {
 		match index {
 			SpecIdx::Byte1 => Self::read_strand(avatar, 5, ByteType::Full),
 			SpecIdx::Byte2 => Self::read_strand(avatar, 6, ByteType::Full),
@@ -959,18 +1012,18 @@ impl DnaUtils {
 		}
 	}
 
-	pub fn read_spec<T>(avatar: &Avatar, spec_byte: SpecIdx) -> T
+	pub fn read_spec<T>(avatar: &Avatar<BlockNumber>, spec_byte: SpecIdx) -> T
 	where
 		T: ByteConvertible,
 	{
 		T::from_byte(Self::read_spec_raw(avatar, spec_byte))
 	}
 
-	pub fn write_specs(avatar: &mut Avatar, value: [u8; 16]) {
+	pub fn write_specs(avatar: &mut Avatar<BlockNumber>, value: [u8; 16]) {
 		(avatar.dna[5..21]).copy_from_slice(&value);
 	}
 
-	pub fn write_spec(avatar: &mut Avatar, spec_byte: SpecIdx, value: u8) {
+	pub fn write_spec(avatar: &mut Avatar<BlockNumber>, spec_byte: SpecIdx, value: u8) {
 		match spec_byte {
 			SpecIdx::Byte1 => Self::write_strand(avatar, 5, ByteType::Full, value),
 			SpecIdx::Byte2 => Self::write_strand(avatar, 6, ByteType::Full, value),
@@ -991,13 +1044,13 @@ impl DnaUtils {
 		}
 	}
 
-	pub fn read_progress(avatar: &Avatar) -> [u8; 11] {
+	pub fn read_progress(avatar: &Avatar<BlockNumber>) -> [u8; 11] {
 		let mut out = [0; 11];
 		out.copy_from_slice(&avatar.dna[21..32]);
 		out
 	}
 
-	pub fn write_progress(avatar: &mut Avatar, value: [u8; 11]) {
+	pub fn write_progress(avatar: &mut Avatar<BlockNumber>, value: [u8; 11]) {
 		(avatar.dna[21..32]).copy_from_slice(&value);
 	}
 
@@ -1324,7 +1377,7 @@ mod test {
 	fn test_bits_to_enums_consistency_1() {
 		let bits = 0b_01_01_01_01;
 
-		let result = DnaUtils::bits_to_enums::<NibbleType>(bits);
+		let result = DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<NibbleType>(bits);
 		let expected = vec![NibbleType::X0, NibbleType::X2, NibbleType::X4, NibbleType::X6];
 
 		assert_eq!(result, expected);
@@ -1334,7 +1387,7 @@ mod test {
 	fn test_bits_to_enums_consistency_2() {
 		let bits = 0b_11_01_10_01;
 
-		let result = DnaUtils::bits_to_enums::<MaterialItemType>(bits);
+		let result = DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<MaterialItemType>(bits);
 		let expected = vec![
 			MaterialItemType::Polymers,
 			MaterialItemType::Optics,
@@ -1351,14 +1404,15 @@ mod test {
 		let bit_order = 0b_01_10_11_00;
 		let enum_list = vec![NibbleType::X0, NibbleType::X2, NibbleType::X4, NibbleType::X6];
 
-		let result = DnaUtils::bits_order_to_enum(bit_order, 4, enum_list);
+		let result = DnaUtils::<BlockNumberFor<Test>>::bits_order_to_enum(bit_order, 4, enum_list);
 		let expected = vec![NibbleType::X2, NibbleType::X4, NibbleType::X6, NibbleType::X0];
 		assert_eq!(result, expected);
 
 		let bit_order_2 = 0b_01_11_00_10;
 		let enum_list_2 = vec![NibbleType::X4, NibbleType::X5, NibbleType::X6, NibbleType::X7];
 
-		let result_2 = DnaUtils::bits_order_to_enum(bit_order_2, 4, enum_list_2);
+		let result_2 =
+			DnaUtils::<BlockNumberFor<Test>>::bits_order_to_enum(bit_order_2, 4, enum_list_2);
 		let expected_2 = vec![NibbleType::X5, NibbleType::X7, NibbleType::X4, NibbleType::X6];
 		assert_eq!(result_2, expected_2);
 	}
@@ -1368,7 +1422,7 @@ mod test {
 		let bit_order = 0b_01_10_00_10;
 		let enum_list = vec![PetType::FoxishDude, PetType::FireDino, PetType::GiantWoodStick];
 
-		let result = DnaUtils::bits_order_to_enum(bit_order, 4, enum_list);
+		let result = DnaUtils::<BlockNumberFor<Test>>::bits_order_to_enum(bit_order, 4, enum_list);
 		let expected = vec![
 			PetType::FireDino,
 			PetType::GiantWoodStick,
@@ -1384,7 +1438,7 @@ mod test {
 		let pattern = vec![NibbleType::X2, NibbleType::X4, NibbleType::X1, NibbleType::X3];
 		let expected = 0b_00_01_11_10;
 
-		assert_eq!(DnaUtils::enums_to_bits(&pattern), expected);
+		assert_eq!(DnaUtils::<BlockNumberFor<Test>>::enums_to_bits(&pattern), expected);
 	}
 
 	#[test]
@@ -1392,7 +1446,7 @@ mod test {
 		let pattern = vec![PetType::FoxishDude, PetType::BigHybrid, PetType::GiantWoodStick];
 		let expected = 0b_00_11_00_10;
 
-		assert_eq!(DnaUtils::enums_to_bits(&pattern), expected);
+		assert_eq!(DnaUtils::<BlockNumberFor<Test>>::enums_to_bits(&pattern), expected);
 	}
 
 	#[test]
@@ -1408,7 +1462,7 @@ mod test {
 		// We group by 3 because the output is grouped by 3
 		let expected = 0b_010_000_011_100_001;
 
-		assert_eq!(DnaUtils::enums_order_to_bits(&pattern), expected);
+		assert_eq!(DnaUtils::<BlockNumberFor<Test>>::enums_order_to_bits(&pattern), expected);
 	}
 
 	#[test]
@@ -1425,18 +1479,20 @@ mod test {
 			MaterialItemType::Superconductors,
 		];
 
-		let bits = DnaUtils::enums_to_bits(&pattern);
+		let bits = DnaUtils::<BlockNumberFor<Test>>::enums_to_bits(&pattern);
 		assert_eq!(bits, 0b_01_10_00_01);
 
-		let enums = DnaUtils::bits_to_enums::<MaterialItemType>(bits);
+		let enums = DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<MaterialItemType>(bits);
 		assert_eq!(enums, expected);
 	}
 
 	#[test]
 	fn test_create_pattern_consistency() {
 		let base_seed = SlotType::Head.as_byte() as usize;
-		let pattern =
-			DnaUtils::create_pattern::<NibbleType>(base_seed, SlotType::Breast.as_byte() as usize);
+		let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<NibbleType>(
+			base_seed,
+			SlotType::Breast.as_byte() as usize,
+		);
 
 		let expected = vec![NibbleType::X7, NibbleType::X5, NibbleType::X4, NibbleType::X3];
 
@@ -1447,25 +1503,27 @@ mod test {
 	fn tests_pattern_and_order() {
 		let base_seed = (PetType::FoxishDude.as_byte() + SlotType::Head.as_byte()) as usize;
 
-		let pattern_1 = DnaUtils::create_pattern::<NibbleType>(
+		let pattern_1 = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<NibbleType>(
 			base_seed,
 			EquippableItemType::ArmorBase.as_byte() as usize,
 		);
-		let p10 = DnaUtils::enums_to_bits(&pattern_1);
-		let p11 = DnaUtils::enums_order_to_bits(&pattern_1);
+		let p10 = DnaUtils::<BlockNumberFor<Test>>::enums_to_bits(&pattern_1);
+		let p11 = DnaUtils::<BlockNumberFor<Test>>::enums_order_to_bits(&pattern_1);
 
 		assert_eq!(p10, 0b_01_10_11_00);
 		assert_eq!(p11, 0b_01_11_10_00);
 
 		// Decode Blueprint
-		let unordered_1 = DnaUtils::bits_to_enums::<NibbleType>(p10);
-		let pattern_1_check = DnaUtils::bits_order_to_enum(p11, 4, unordered_1);
+		let unordered_1 = DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<NibbleType>(p10);
+		let pattern_1_check =
+			DnaUtils::<BlockNumberFor<Test>>::bits_order_to_enum(p11, 4, unordered_1);
 		assert_eq!(pattern_1_check, pattern_1);
 
 		// Pattern number and enum number only match if they are according to the index in the list
-		let unordered_material = DnaUtils::bits_to_enums::<MaterialItemType>(p10);
+		let unordered_material =
+			DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<MaterialItemType>(p10);
 		assert_eq!(
-			DnaUtils::bits_order_to_enum(p11, 4, unordered_material)[0],
+			DnaUtils::<BlockNumberFor<Test>>::bits_order_to_enum(p11, 4, unordered_material)[0],
 			MaterialItemType::Optics
 		);
 
@@ -1476,18 +1534,23 @@ mod test {
 		];
 
 		for (armor_component, enum_to_bits, enum_order_to_bits) in test_set {
-			let pattern_base = DnaUtils::create_pattern::<NibbleType>(
+			let pattern_base = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<NibbleType>(
 				base_seed,
 				armor_component.as_byte() as usize,
 			);
-			let p_enum_to_bits = DnaUtils::enums_to_bits(&pattern_base);
-			let p_enum_order_to_bits = DnaUtils::enums_order_to_bits(&pattern_base);
+			let p_enum_to_bits = DnaUtils::<BlockNumberFor<Test>>::enums_to_bits(&pattern_base);
+			let p_enum_order_to_bits =
+				DnaUtils::<BlockNumberFor<Test>>::enums_order_to_bits(&pattern_base);
 			assert_eq!(p_enum_to_bits, enum_to_bits);
 			assert_eq!(p_enum_order_to_bits, enum_order_to_bits);
 			// Decode Blueprint
-			let unordered_base = DnaUtils::bits_to_enums::<NibbleType>(p_enum_to_bits);
-			let pattern_base_check =
-				DnaUtils::bits_order_to_enum(p_enum_order_to_bits, 4, unordered_base);
+			let unordered_base =
+				DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<NibbleType>(p_enum_to_bits);
+			let pattern_base_check = DnaUtils::<BlockNumberFor<Test>>::bits_order_to_enum(
+				p_enum_order_to_bits,
+				4,
+				unordered_base,
+			);
 			assert_eq!(pattern_base_check, pattern_base);
 		}
 	}
@@ -1498,77 +1561,77 @@ mod test {
 
 		let arr_1 = [0x00; 11];
 		let arr_2 = [0x00; 11];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x10; 11];
 		let arr_2 = [0x00; 11];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x00];
 		let arr_2 = [0x00; 11];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_mirrors: Vec<u32> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, expected_mirrors);
 
 		let arr_1 = [0x00; 11];
 		let arr_2 = [0x10; 11];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x10; 11];
 		let arr_2 = [0x10; 11];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x00];
 		let arr_2 = [0x10; 11];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_mirrors: Vec<u32> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, expected_mirrors);
 
 		let arr_1 = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00];
 		let arr_2 = [0x01, 0x02, 0x03, 0x04, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x05];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 		assert_eq!(matches, expected_matches);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10];
 		let arr_2 = [0x01, 0x02, 0x03, 0x04, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x05];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10];
 		let arr_2 = [0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x15];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 		assert_eq!(matches, expected_matches);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x00];
 		let arr_2 = [0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x15];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00];
 		let arr_2 = [0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x15];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x00, 0x11, 0x02, 0x13, 0x04, 0x15, 0x04, 0x13, 0x02, 0x11, 0x00];
 		let arr_2 = [0x01, 0x01, 0x12, 0x13, 0x04, 0x04, 0x13, 0x12, 0x01, 0x01, 0x15];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![0, 8];
 		let expected_mirrors: Vec<u32> = vec![1, 3, 9];
 		assert_eq!(matches, expected_matches);
@@ -1581,7 +1644,7 @@ mod test {
 
 		let arr_1 = [0x14, 0x12, 0x10, 0x11, 0x20, 0x21, 0x10, 0x15, 0x11, 0x25, 0x13];
 		let arr_2 = [0x12, 0x13, 0x14, 0x13, 0x14, 0x11, 0x22, 0x10, 0x14, 0x22, 0x11];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![1, 7];
 		let expected_mirrors: Vec<u32> = vec![5];
 		assert_eq!(matches, expected_matches);
@@ -1589,14 +1652,14 @@ mod test {
 
 		let arr_1 = [0x14, 0x12, 0x10, 0x11, 0x20, 0x21, 0x10, 0x15, 0x11, 0x25, 0x13];
 		let arr_2 = [0x10, 0x10, 0x10, 0x14, 0x14, 0x13, 0x13, 0x12, 0x15, 0x14, 0x14];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![10];
 		assert_eq!(matches, expected_matches);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x14, 0x12, 0x10, 0x11, 0x20, 0x21, 0x10, 0x15, 0x11, 0x25, 0x13];
 		let arr_2 = [0x15, 0x10, 0x14, 0x13, 0x13, 0x11, 0x10, 0x14, 0x12, 0x20, 0x11];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![0, 7, 8];
 		let expected_mirrors: Vec<u32> = vec![5];
 		assert_eq!(matches, expected_matches);
@@ -1604,7 +1667,7 @@ mod test {
 
 		let arr_1 = [0x14, 0x12, 0x10, 0x11, 0x20, 0x21, 0x10, 0x15, 0x11, 0x25, 0x13];
 		let arr_2 = [0x11, 0x11, 0x11, 0x10, 0x15, 0x12, 0x11, 0x11, 0x13, 0x12, 0x14];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![1, 2, 3, 6, 10];
 		assert_eq!(matches, expected_matches);
 		assert_eq!(mirrors, empty_vec);
@@ -1616,21 +1679,21 @@ mod test {
 
 		let arr_1 = [0x42, 0x40, 0x40, 0x44, 0x43, 0x42, 0x41, 0x44, 0x44, 0x42, 0x45];
 		let arr_2 = [0x41, 0x51, 0x52, 0x53, 0x44, 0x52, 0x45, 0x41, 0x40, 0x41, 0x43];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![0, 4, 9];
 		assert_eq!(matches, expected_matches);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x42, 0x40, 0x40, 0x44, 0x43, 0x42, 0x41, 0x44, 0x44, 0x42, 0x45];
 		let arr_2 = [0x52, 0x41, 0x43, 0x41, 0x53, 0x45, 0x43, 0x44, 0x52, 0x43, 0x43];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![1, 9];
 		assert_eq!(matches, expected_matches);
 		assert_eq!(mirrors, empty_vec);
 
 		let arr_1 = [0x42, 0x40, 0x40, 0x44, 0x43, 0x42, 0x41, 0x54, 0x44, 0x42, 0x53];
 		let arr_2 = [0x52, 0x40, 0x43, 0x41, 0x53, 0x45, 0x41, 0x44, 0x52, 0x43, 0x43];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![9];
 		let expected_mirrors: Vec<u32> = vec![7, 10];
 		assert_eq!(matches, expected_matches);
@@ -1638,7 +1701,7 @@ mod test {
 
 		let arr_1 = [0x45, 0x45, 0x45, 0x45, 0x45, 0x45, 0x45, 0x30, 0x30, 0x30, 0x30];
 		let arr_2 = [0x45, 0x45, 0x45, 0x45, 0x45, 0x35, 0x45, 0x31, 0x30, 0x45, 0x45];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		let expected_matches: Vec<u32> = vec![7];
 		let expected_mirrors: Vec<u32> = vec![0, 1, 2, 3, 4, 5, 6];
 		assert_eq!(matches, expected_matches);
@@ -1646,7 +1709,7 @@ mod test {
 
 		let arr_1 = [0x31, 0x30, 0x35, 0x33, 0x30, 0x33, 0x31, 0x32, 0x32, 0x32, 0x34];
 		let arr_2 = [0x21, 0x21, 0x35, 0x34, 0x24, 0x33, 0x23, 0x22, 0x22, 0x22, 0x22];
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, empty_vec);
 	}
@@ -1659,7 +1722,7 @@ mod test {
 			hex::decode("3130353330333132323234").expect("Decode").try_into().unwrap();
 		let arr_2: [u8; 11] =
 			hex::decode("2121353424332322222222").expect("Decode").try_into().unwrap();
-		let (mirrors, matches) = DnaUtils::match_progress(arr_1, arr_2, 0);
+		let (mirrors, matches) = DnaUtils::<BlockNumberFor<Test>>::match_progress(arr_1, arr_2, 0);
 		assert_eq!(matches, empty_vec);
 		assert_eq!(mirrors, empty_vec);
 	}
@@ -1667,23 +1730,34 @@ mod test {
 	#[test]
 	fn test_indexes_of_max() {
 		ExtBuilder::default().build().execute_with(|| {
-			assert_eq!(DnaUtils::indexes_of_max(&[0, 2, 1, 1]), vec![1]);
-			assert_eq!(DnaUtils::indexes_of_max(&[9, 5, 3, 9, 7, 2, 1]), vec![0, 3]);
-			assert_eq!(DnaUtils::indexes_of_max(&[0, 0, 0, 0, 0]), vec![0, 1, 2, 3, 4]);
-			assert_eq!(DnaUtils::indexes_of_max(&[1, 4, 9, 2, 3, 11, 10, 11, 0, 1]), vec![5, 7]);
+			assert_eq!(DnaUtils::<BlockNumberFor<Test>>::indexes_of_max(&[0, 2, 1, 1]), vec![1]);
+			assert_eq!(
+				DnaUtils::<BlockNumberFor<Test>>::indexes_of_max(&[9, 5, 3, 9, 7, 2, 1]),
+				vec![0, 3]
+			);
+			assert_eq!(
+				DnaUtils::<BlockNumberFor<Test>>::indexes_of_max(&[0, 0, 0, 0, 0]),
+				vec![0, 1, 2, 3, 4]
+			);
+			assert_eq!(
+				DnaUtils::<BlockNumberFor<Test>>::indexes_of_max(&[
+					1, 4, 9, 2, 3, 11, 10, 11, 0, 1
+				]),
+				vec![5, 7]
+			);
 		});
 	}
 
 	#[test]
 	fn test_current_period() {
 		ExtBuilder::default().build().execute_with(|| {
-			assert_eq!(DnaUtils::current_period::<Test>(10, 14, 0), 0);
-			assert_eq!(DnaUtils::current_period::<Test>(10, 14, 9), 0);
-			assert_eq!(DnaUtils::current_period::<Test>(10, 14, 10), 1);
-			assert_eq!(DnaUtils::current_period::<Test>(10, 14, 19), 1);
-			assert_eq!(DnaUtils::current_period::<Test>(10, 14, 130), 13);
-			assert_eq!(DnaUtils::current_period::<Test>(10, 14, 139), 13);
-			assert_eq!(DnaUtils::current_period::<Test>(10, 14, 140), 0);
+			assert_eq!(DnaUtils::<BlockNumberFor<Test>>::current_period::<Test>(10, 14, 0), 0);
+			assert_eq!(DnaUtils::<BlockNumberFor<Test>>::current_period::<Test>(10, 14, 9), 0);
+			assert_eq!(DnaUtils::<BlockNumberFor<Test>>::current_period::<Test>(10, 14, 10), 1);
+			assert_eq!(DnaUtils::<BlockNumberFor<Test>>::current_period::<Test>(10, 14, 19), 1);
+			assert_eq!(DnaUtils::<BlockNumberFor<Test>>::current_period::<Test>(10, 14, 130), 13);
+			assert_eq!(DnaUtils::<BlockNumberFor<Test>>::current_period::<Test>(10, 14, 139), 13);
+			assert_eq!(DnaUtils::<BlockNumberFor<Test>>::current_period::<Test>(10, 14, 140), 0);
 		});
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/assemble.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/assemble.rs
@@ -28,7 +28,7 @@ impl<T: Config> AvatarCombinator<T> {
 					.same_full_and_class_types(&input_leader)
 					.not()
 					.then(|| {
-						DnaUtils::is_progress_match(
+						DnaUtils::<BlockNumberFor<T>>::is_progress_match(
 							leader_progress_array,
 							sacrifice.get_progress(),
 							MATCH_ALGO_START_RARITY.as_byte(),
@@ -38,10 +38,11 @@ impl<T: Config> AvatarCombinator<T> {
 					.unwrap_or(false)
 			});
 
-		let progress_rarity = RarityTier::from_byte(DnaUtils::lowest_progress_byte(
-			&input_leader.get_progress(),
-			ByteType::High,
-		));
+		let progress_rarity =
+			RarityTier::from_byte(DnaUtils::<BlockNumberFor<T>>::lowest_progress_byte(
+				&input_leader.get_progress(),
+				ByteType::High,
+			));
 
 		if input_leader.has_full_type(ItemType::Equippable, EquippableItemType::ArmorBase) &&
 			input_leader.get_rarity() < progress_rarity
@@ -315,7 +316,7 @@ mod test {
 				[0x21, 0x10, 0x25, 0x23, 0x20, 0x23, 0x21, 0x22, 0x22, 0x22, 0x24];
 			assert_eq!(leader_armor_component.1.get_progress(), expected_progress_array);
 
-			let pre_assemble = DnaUtils::bits_to_enums::<EquippableItemType>(
+			let pre_assemble = DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<EquippableItemType>(
 				leader_armor_component.1.get_spec::<u8>(SpecIdx::Byte1) as u32,
 			);
 			assert_eq!(pre_assemble.len(), 1);
@@ -336,9 +337,9 @@ mod test {
 				let wrapped = WrappedAvatar::new(avatar);
 				assert_eq!(wrapped.get_souls(), 10);
 
-				let post_assemble = DnaUtils::bits_to_enums::<EquippableItemType>(
-					wrapped.get_spec::<u8>(SpecIdx::Byte1) as u32,
-				);
+				let post_assemble = DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<
+					EquippableItemType,
+				>(wrapped.get_spec::<u8>(SpecIdx::Byte1) as u32);
 				assert_eq!(post_assemble.len(), 2);
 				assert_eq!(post_assemble[0], EquippableItemType::ArmorBase);
 				assert_eq!(post_assemble[1], EquippableItemType::ArmorComponent1);
@@ -443,9 +444,9 @@ mod test {
 				let wrapped = WrappedAvatar::new(avatar);
 				assert_eq!(wrapped.get_souls(), 10);
 
-				let post_assemble = DnaUtils::bits_to_enums::<EquippableItemType>(
-					wrapped.get_spec::<u8>(SpecIdx::Byte1) as u32,
-				);
+				let post_assemble = DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<
+					EquippableItemType,
+				>(wrapped.get_spec::<u8>(SpecIdx::Byte1) as u32);
 				assert_eq!(post_assemble.len(), 2);
 				assert_eq!(post_assemble[0], EquippableItemType::ArmorBase);
 				assert_eq!(post_assemble[1], EquippableItemType::ArmorComponent2);
@@ -557,9 +558,9 @@ mod test {
 				let wrapped = WrappedAvatar::new(avatar);
 				assert_eq!(wrapped.get_souls(), 10);
 
-				let post_assemble = DnaUtils::bits_to_enums::<EquippableItemType>(
-					wrapped.get_spec::<u8>(SpecIdx::Byte1) as u32,
-				);
+				let post_assemble = DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<
+					EquippableItemType,
+				>(wrapped.get_spec::<u8>(SpecIdx::Byte1) as u32);
 				assert_eq!(post_assemble.len(), 2);
 				assert_eq!(post_assemble[0], EquippableItemType::ArmorBase);
 				assert_eq!(post_assemble[1], EquippableItemType::ArmorComponent3);
@@ -671,9 +672,9 @@ mod test {
 				let wrapped = WrappedAvatar::new(avatar);
 				assert_eq!(wrapped.get_souls(), 10);
 
-				let post_assemble = DnaUtils::bits_to_enums::<EquippableItemType>(
-					wrapped.get_spec::<u8>(SpecIdx::Byte1) as u32,
-				);
+				let post_assemble = DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<
+					EquippableItemType,
+				>(wrapped.get_spec::<u8>(SpecIdx::Byte1) as u32);
 				assert_eq!(post_assemble.len(), 3);
 				assert_eq!(post_assemble[0], EquippableItemType::ArmorBase);
 				assert_eq!(post_assemble[1], EquippableItemType::ArmorComponent1);
@@ -786,9 +787,9 @@ mod test {
 				let wrapped = WrappedAvatar::new(avatar);
 				assert_eq!(wrapped.get_souls(), 10);
 
-				let post_assemble = DnaUtils::bits_to_enums::<EquippableItemType>(
-					wrapped.get_spec::<u8>(SpecIdx::Byte1) as u32,
-				);
+				let post_assemble = DnaUtils::<BlockNumberFor<Test>>::bits_to_enums::<
+					EquippableItemType,
+				>(wrapped.get_spec::<u8>(SpecIdx::Byte1) as u32);
 				assert_eq!(post_assemble.len(), 2);
 				assert_eq!(post_assemble[0], EquippableItemType::ArmorBase);
 				assert_eq!(post_assemble[1], EquippableItemType::ArmorComponent1);
@@ -1075,7 +1076,7 @@ mod test {
 				],
 			];
 
-			let unit_fn = |avatar: Avatar| {
+			let unit_fn = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 100;
 				WrappedAvatar::new(avatar)
@@ -1088,8 +1089,11 @@ mod test {
 			let sac_4 = create_random_avatar::<Test, _>(&ALICE, Some(hash_base[4]), Some(unit_fn));
 
 			let leader_progress_array = leader.1.get_progress();
-			let lowest_count =
-				DnaUtils::lowest_progress_indexes(&leader_progress_array, ByteType::High).len();
+			let lowest_count = DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+				&leader_progress_array,
+				ByteType::High,
+			)
+			.len();
 			assert_eq!(lowest_count, 3);
 
 			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::assemble_avatars(
@@ -1106,9 +1110,11 @@ mod test {
 			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
 				let wrapped = WrappedAvatar::new(avatar);
 				let out_leader_progress_array = wrapped.get_progress();
-				let out_lowest_count =
-					DnaUtils::lowest_progress_indexes(&out_leader_progress_array, ByteType::High)
-						.len();
+				let out_lowest_count = DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+					&out_leader_progress_array,
+					ByteType::High,
+				)
+				.len();
 				assert_eq!(out_lowest_count, 11);
 
 				let expected_dna = [
@@ -1156,7 +1162,7 @@ mod test {
 				],
 			];
 
-			let unit_fn = |avatar: Avatar| {
+			let unit_fn = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 100;
 				WrappedAvatar::new(avatar)
@@ -1195,8 +1201,10 @@ mod test {
 			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
 				assert_eq!(avatar.souls, total_souls);
 
-				let leader_rarity =
-					DnaUtils::read_attribute::<RarityTier>(&avatar, AvatarAttr::RarityTier);
+				let leader_rarity = DnaUtils::<BlockNumberFor<Test>>::read_attribute::<RarityTier>(
+					&avatar,
+					AvatarAttr::RarityTier,
+				);
 				assert_eq!(leader_rarity, RarityTier::Legendary);
 			} else {
 				panic!("LeaderForgeOutput should have been Forged!")
@@ -1238,7 +1246,7 @@ mod test {
 			];
 
 			let avatar_fn = |souls: SoulCount| {
-				let mutate_fn = move |avatar: Avatar| {
+				let mutate_fn = move |avatar: AvatarOf<Test>| {
 					let mut avatar = avatar;
 					avatar.souls = souls;
 					WrappedAvatar::new(avatar)
@@ -1260,8 +1268,11 @@ mod test {
 					sac_3.1.get_souls() + sac_4.1.get_souls();
 
 			let leader_progress = leader.1.get_progress();
-			let lowest_count =
-				DnaUtils::lowest_progress_indexes(&leader_progress, ByteType::High).len();
+			let lowest_count = DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+				&leader_progress,
+				ByteType::High,
+			)
+			.len();
 			assert_eq!(lowest_count, 11);
 
 			assert_eq!(
@@ -1286,9 +1297,12 @@ mod test {
 			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
 				assert_eq!(avatar.souls, total_souls);
 
-				let leader_progress = DnaUtils::read_progress(&avatar);
-				let lowest_count =
-					DnaUtils::lowest_progress_indexes(&leader_progress, ByteType::High).len();
+				let leader_progress = DnaUtils::<BlockNumberFor<Test>>::read_progress(&avatar);
+				let lowest_count = DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+					&leader_progress,
+					ByteType::High,
+				)
+				.len();
 				assert_eq!(lowest_count, 11);
 
 				let expected_dna = [

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/breed.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/breed.rs
@@ -14,10 +14,11 @@ impl<T: Config> AvatarCombinator<T> {
 			hash_provider,
 		);
 
-		let progress_rarity = RarityTier::from_byte(DnaUtils::lowest_progress_byte(
-			&input_leader.get_progress(),
-			ByteType::High,
-		));
+		let progress_rarity =
+			RarityTier::from_byte(DnaUtils::<BlockNumberFor<T>>::lowest_progress_byte(
+				&input_leader.get_progress(),
+				ByteType::High,
+			));
 
 		let is_leader_egg = input_leader.has_full_type(ItemType::Pet, PetItemType::Egg);
 		let is_leader_legendary = progress_rarity == RarityTier::Legendary;
@@ -26,10 +27,11 @@ impl<T: Config> AvatarCombinator<T> {
 
 		if is_leader_egg && is_leader_legendary && pet_variation > 0 {
 			let pet_type_list = {
-				let mut pet_type_list = DnaUtils::bits_to_enums::<PetType>(pet_variation as u32);
+				let mut pet_type_list =
+					DnaUtils::<BlockNumberFor<T>>::bits_to_enums::<PetType>(pet_variation as u32);
 
 				let pet_type_add = PetType::from_byte(
-					(DnaUtils::current_period::<T>(
+					(DnaUtils::<BlockNumberFor<T>>::current_period::<T>(
 						PET_MOON_PHASE_SIZE,
 						PET_MOON_PHASE_AMOUNT,
 						block_number,
@@ -244,7 +246,7 @@ mod test {
 		ExtBuilder::default().build().execute_with(|| {
 			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
 
-			let unit_fn = |avatar: Avatar| {
+			let unit_fn = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 100;
 				WrappedAvatar::new(avatar)
@@ -314,8 +316,11 @@ mod test {
 
 			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
 				let progress_array = DnaUtils::read_progress(&avatar);
-				let lowest_count =
-					DnaUtils::lowest_progress_indexes(&progress_array, ByteType::High).len();
+				let lowest_count = DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+					&progress_array,
+					ByteType::High,
+				)
+				.len();
 				assert_eq!(lowest_count, 7);
 			} else {
 				panic!("LeaderForgeOutput should have been Forged!")
@@ -333,7 +338,7 @@ mod test {
 			];
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
-			let unit_fn = |avatar: Avatar| {
+			let unit_fn = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 100;
 				WrappedAvatar::new(avatar)
@@ -391,8 +396,11 @@ mod test {
 				);
 
 				let leader_progress_array = leader.1.get_progress();
-				let lowest_count =
-					DnaUtils::lowest_progress_indexes(&leader_progress_array, ByteType::High).len();
+				let lowest_count = DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+					&leader_progress_array,
+					ByteType::High,
+				)
+				.len();
 				assert_eq!(lowest_count, 7);
 
 				let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::breed_avatars(
@@ -409,11 +417,12 @@ mod test {
 
 				if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
 					let out_leader_progress_array = DnaUtils::read_progress(&avatar);
-					let out_lowest_count = DnaUtils::lowest_progress_indexes(
-						&out_leader_progress_array,
-						ByteType::High,
-					)
-					.len();
+					let out_lowest_count =
+						DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+							&out_leader_progress_array,
+							ByteType::High,
+						)
+						.len();
 					assert_eq!(out_lowest_count, 3);
 				} else {
 					panic!("LeaderForgeOutput should be Forged!");
@@ -431,7 +440,7 @@ mod test {
 				0x23, 0xAF, 0xCF, 0x4E,
 			];
 
-			let unit_fn = |avatar: Avatar| {
+			let unit_fn = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 100;
 				WrappedAvatar::new(avatar)
@@ -583,8 +592,11 @@ mod test {
 					create_random_avatar::<Test, _>(&ALICE, Some(dna_set[4]), Some(unit_fn));
 
 				let leader_progress_array = leader.1.get_progress();
-				let lowest_count =
-					DnaUtils::lowest_progress_indexes(&leader_progress_array, ByteType::High).len();
+				let lowest_count = DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+					&leader_progress_array,
+					ByteType::High,
+				)
+				.len();
 				assert_eq!(lowest_count, lc);
 
 				let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::breed_avatars(
@@ -601,11 +613,12 @@ mod test {
 
 				if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
 					let out_leader_progress_array = DnaUtils::read_progress(&avatar);
-					let out_lowest_count = DnaUtils::lowest_progress_indexes(
-						&out_leader_progress_array,
-						ByteType::High,
-					)
-					.len();
+					let out_lowest_count =
+						DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+							&out_leader_progress_array,
+							ByteType::High,
+						)
+						.len();
 					assert_eq!(out_lowest_count, out_lc);
 				} else {
 					panic!("LeaderForgeOutput should be Forged!");
@@ -623,7 +636,7 @@ mod test {
 				0x23, 0xAF, 0xCF, 0x4E,
 			];
 
-			let unit_fn = |avatar: Avatar| {
+			let unit_fn = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 100;
 				WrappedAvatar::new(avatar)
@@ -775,8 +788,11 @@ mod test {
 					create_random_avatar::<Test, _>(&ALICE, Some(dna_set[4]), Some(unit_fn));
 
 				let leader_progress_array = leader.1.get_progress();
-				let lowest_count =
-					DnaUtils::lowest_progress_indexes(&leader_progress_array, ByteType::High).len();
+				let lowest_count = DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+					&leader_progress_array,
+					ByteType::High,
+				)
+				.len();
 				assert_eq!(lowest_count, lwst_count);
 
 				let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::breed_avatars(
@@ -793,11 +809,12 @@ mod test {
 
 				if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
 					let out_leader_progress_array = DnaUtils::read_progress(&avatar);
-					let out_lowest_count = DnaUtils::lowest_progress_indexes(
-						&out_leader_progress_array,
-						ByteType::High,
-					)
-					.len();
+					let out_lowest_count =
+						DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(
+							&out_leader_progress_array,
+							ByteType::High,
+						)
+						.len();
 					assert_eq!(out_lowest_count, out_lwst_count);
 				} else {
 					panic!("LeaderForgeOutput should be Forged!");
@@ -833,7 +850,7 @@ mod test {
 						&RarityTier::Epic,
 						16,
 						100,
-						DnaUtils::generate_progress(
+						DnaUtils::<BlockNumberFor<Test>>::generate_progress(
 							&RarityTier::Epic,
 							SCALING_FACTOR_PERC,
 							Some(PROGRESS_PROBABILITY_PERC),
@@ -846,7 +863,7 @@ mod test {
 						&RarityTier::Epic,
 						16,
 						100,
-						DnaUtils::generate_progress(
+						DnaUtils::<BlockNumberFor<Test>>::generate_progress(
 							&RarityTier::Epic,
 							SCALING_FACTOR_PERC,
 							Some(PROGRESS_PROBABILITY_PERC),
@@ -859,7 +876,7 @@ mod test {
 						&RarityTier::Epic,
 						16,
 						100,
-						DnaUtils::generate_progress(
+						DnaUtils::<BlockNumberFor<Test>>::generate_progress(
 							&RarityTier::Epic,
 							SCALING_FACTOR_PERC,
 							Some(PROGRESS_PROBABILITY_PERC),
@@ -872,7 +889,7 @@ mod test {
 						&RarityTier::Epic,
 						16,
 						100,
-						DnaUtils::generate_progress(
+						DnaUtils::<BlockNumberFor<Test>>::generate_progress(
 							&RarityTier::Epic,
 							SCALING_FACTOR_PERC,
 							Some(SPARK_PROGRESS_PROB_PERC),
@@ -957,7 +974,7 @@ mod test {
 						&RarityTier::Epic,
 						16,
 						100,
-						DnaUtils::generate_progress(
+						DnaUtils::<BlockNumberFor<Test>>::generate_progress(
 							&RarityTier::Epic,
 							SCALING_FACTOR_PERC,
 							Some(PROGRESS_PROBABILITY_PERC),
@@ -970,7 +987,7 @@ mod test {
 						&RarityTier::Epic,
 						16,
 						100,
-						DnaUtils::generate_progress(
+						DnaUtils::<BlockNumberFor<Test>>::generate_progress(
 							&RarityTier::Epic,
 							SCALING_FACTOR_PERC,
 							Some(PROGRESS_PROBABILITY_PERC),
@@ -983,7 +1000,7 @@ mod test {
 						&RarityTier::Epic,
 						16,
 						100,
-						DnaUtils::generate_progress(
+						DnaUtils::<BlockNumberFor<Test>>::generate_progress(
 							&RarityTier::Epic,
 							SCALING_FACTOR_PERC,
 							Some(PROGRESS_PROBABILITY_PERC),
@@ -996,7 +1013,7 @@ mod test {
 						&RarityTier::Epic,
 						16,
 						100,
-						DnaUtils::generate_progress(
+						DnaUtils::<BlockNumberFor<Test>>::generate_progress(
 							&RarityTier::Epic,
 							SCALING_FACTOR_PERC,
 							Some(SPARK_PROGRESS_PROB_PERC),
@@ -1064,7 +1081,7 @@ mod test {
 			];
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
-			let unit_fn = |avatar: Avatar| {
+			let unit_fn = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 100;
 				WrappedAvatar::new(avatar)

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/build.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/build.rs
@@ -12,8 +12,14 @@ impl<T: Config> AvatarCombinator<T> {
 		let mut output_sacrifices = Vec::with_capacity(input_sacrifices.len());
 
 		let leader_spec_bytes = leader.get_specs();
-		let unord_1 = DnaUtils::bits_to_enums::<MaterialItemType>(leader_spec_bytes[0] as u32);
-		let pat_1 = DnaUtils::bits_order_to_enum(leader_spec_bytes[1] as u32, 4, unord_1);
+		let unord_1 = DnaUtils::<BlockNumberFor<T>>::bits_to_enums::<MaterialItemType>(
+			leader_spec_bytes[0] as u32,
+		);
+		let pat_1 = DnaUtils::<BlockNumberFor<T>>::bits_order_to_enum(
+			leader_spec_bytes[1] as u32,
+			4,
+			unord_1,
+		);
 
 		let quantities = [
 			leader_spec_bytes[3],
@@ -69,6 +75,8 @@ impl<T: Config> AvatarCombinator<T> {
 
 			let mut generated_equippables = Vec::with_capacity(3);
 
+			let current_block = <frame_system::Pallet<T>>::block_number();
+
 			for i in 0..max_build {
 				if soul_points > 0 &&
 					(build_prop * MAX_BYTE >= hash_provider.hash[i] as u32 * SCALING_FACTOR_PERC)
@@ -101,19 +109,20 @@ impl<T: Config> AvatarCombinator<T> {
 					};
 
 					let dna = MinterV2::<T>::generate_empty_dna::<32>()?;
-					let generated_equippable = AvatarBuilder::with_dna(season_id, dna)
-						.try_into_armor_and_component(
-							&pet_type,
-							&slot_type,
-							&[equippable_item_type],
-							&rarity_value,
-							&(ColorType::Null, ColorType::Null),
-							&Force::Null,
-							item_sp,
-							hash_provider,
-						)
-						.map_err(|_| Error::<T>::IncompatibleForgeComponents)?
-						.build();
+					let generated_equippable =
+						AvatarBuilder::with_dna(season_id, dna, current_block)
+							.try_into_armor_and_component(
+								&pet_type,
+								&slot_type,
+								&[equippable_item_type],
+								&rarity_value,
+								&(ColorType::Null, ColorType::Null),
+								&Force::Null,
+								item_sp,
+								hash_provider,
+							)
+							.map_err(|_| Error::<T>::IncompatibleForgeComponents)?
+							.build();
 
 					generated_equippables.push(generated_equippable);
 
@@ -170,7 +179,7 @@ mod test {
 			let equip_type = EquippableItemType::ArmorBase;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				equip_type.as_byte() as usize,
 			);
@@ -252,7 +261,7 @@ mod test {
 			let equip_type = EquippableItemType::ArmorBase;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				equip_type.as_byte() as usize,
 			);
@@ -350,7 +359,7 @@ mod test {
 			let equip_type = EquippableItemType::ArmorBase;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				equip_type.as_byte() as usize,
 			);
@@ -448,7 +457,7 @@ mod test {
 			let equip_type = EquippableItemType::ArmorBase;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				equip_type.as_byte() as usize,
 			);
@@ -533,7 +542,7 @@ mod test {
 			let equip_type = EquippableItemType::ArmorBase;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				equip_type.as_byte() as usize,
 			);
@@ -627,7 +636,7 @@ mod test {
 			let equip_type = EquippableItemType::ArmorComponent2;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				equip_type.as_byte() as usize,
 			);
@@ -733,7 +742,7 @@ mod test {
 			];
 
 			let avatar_fn = |souls: SoulCount| {
-				let mutate_fn = move |avatar: Avatar| {
+				let mutate_fn = move |avatar: AvatarOf<Test>| {
 					let mut avatar = avatar;
 					avatar.souls = souls;
 					WrappedAvatar::new(avatar)
@@ -840,7 +849,7 @@ mod test {
 			];
 
 			let avatar_fn = |souls: SoulCount| {
-				let mutate_fn = move |avatar: Avatar| {
+				let mutate_fn = move |avatar: AvatarOf<Test>| {
 					let mut avatar = avatar;
 					avatar.souls = souls;
 					WrappedAvatar::new(avatar)

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/flask.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/flask.rs
@@ -27,7 +27,7 @@ impl<T: Config> AvatarCombinator<T> {
 			let mut leader_progress_array = leader.get_progress();
 			let flask_progress_array = flask_avatar.get_progress();
 
-			if let Some(mut matches) = DnaUtils::is_progress_match(
+			if let Some(mut matches) = DnaUtils::<BlockNumberFor<T>>::is_progress_match(
 				leader_progress_array,
 				flask_progress_array,
 				MATCH_ALGO_START_RARITY.as_byte(),
@@ -69,8 +69,10 @@ impl<T: Config> AvatarCombinator<T> {
 					}
 				}
 
-				let rarity_type =
-					DnaUtils::lowest_progress_byte(&leader_progress_array, ByteType::High);
+				let rarity_type = DnaUtils::<BlockNumberFor<T>>::lowest_progress_byte(
+					&leader_progress_array,
+					ByteType::High,
+				);
 				leader.set_rarity(RarityTier::from_byte(rarity_type));
 				leader.set_progress(leader_progress_array);
 			}
@@ -161,7 +163,7 @@ mod test {
 			let sacrifice_progress_array = paint_flask.1.get_progress();
 			assert_eq!(sacrifice_progress_array, expected_sacrifice_progress_array);
 
-			assert!(DnaUtils::is_progress_match(
+			assert!(DnaUtils::<BlockNumberFor<Test>>::is_progress_match(
 				leader_progress_array,
 				sacrifice_progress_array,
 				MATCH_ALGO_START_RARITY.as_byte()
@@ -210,7 +212,7 @@ mod test {
 				0x45, 0x41, 0x55, 0x43,
 			];
 
-			let unit_closure = |avatar: Avatar| {
+			let unit_closure = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 623;
 				WrappedAvatar::new(avatar)
@@ -246,7 +248,7 @@ mod test {
 				[0x45, 0x43, 0x54, 0x53, 0x54, 0x51, 0x52, 0x50, 0x54, 0x55, 0x42];
 			assert_eq!(sacrifice_progress_array, expected_progress_array_other);
 
-			assert!(DnaUtils::is_progress_match(
+			assert!(DnaUtils::<BlockNumberFor<Test>>::is_progress_match(
 				leader_progress_array,
 				sacrifice_progress_array,
 				MATCH_ALGO_START_RARITY.as_byte()
@@ -338,7 +340,7 @@ mod test {
 				[0x45, 0x43, 0x54, 0x53, 0x54, 0x51, 0x52, 0x50, 0x54, 0x55, 0x42];
 			assert_eq!(sacrifice_progress_array, expected_progress_array_other);
 
-			assert!(DnaUtils::is_progress_match(
+			assert!(DnaUtils::<BlockNumberFor<Test>>::is_progress_match(
 				leader_progress_array,
 				sacrifice_progress_array,
 				MATCH_ALGO_START_RARITY.as_byte()
@@ -397,7 +399,7 @@ mod test {
 				],
 			];
 
-			let unit_fn = |avatar: Avatar| {
+			let unit_fn = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 623;
 				WrappedAvatar::new(avatar)
@@ -411,7 +413,7 @@ mod test {
 
 			let total_soul_points = leader.1.get_souls() + sac_1.1.get_souls();
 
-			assert!(DnaUtils::is_progress_match(
+			assert!(DnaUtils::<BlockNumberFor<Test>>::is_progress_match(
 				leader_progress_array,
 				sacrifice_progress_array,
 				MATCH_ALGO_START_RARITY.as_byte()
@@ -457,7 +459,7 @@ mod test {
 				0x45, 0x41, 0x55, 0x43,
 			];
 
-			let unit_closure = |avatar: Avatar| {
+			let unit_closure = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 623;
 				WrappedAvatar::new(avatar)
@@ -493,7 +495,7 @@ mod test {
 				[0x45, 0x43, 0x54, 0x53, 0x54, 0x51, 0x52, 0x50, 0x54, 0x55, 0x41];
 			assert_eq!(sacrifice_progress_array, expected_progress_array_other);
 
-			assert!(DnaUtils::is_progress_match(
+			assert!(DnaUtils::<BlockNumberFor<Test>>::is_progress_match(
 				leader_progress_array,
 				sacrifice_progress_array,
 				MATCH_ALGO_START_RARITY.as_byte()

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/glimmer.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/glimmer.rs
@@ -15,6 +15,8 @@ impl<T: Config> AvatarCombinator<T> {
 
 		let mut other_output = Vec::new();
 
+		let current_block = <frame_system::Pallet<T>>::block_number();
+
 		for (i, (sacrifice_id, mut sacrifice)) in input_sacrifices.into_iter().enumerate() {
 			if leader_consumed {
 				// If we consumed the leader in a previous step, we collect all
@@ -55,11 +57,11 @@ impl<T: Config> AvatarCombinator<T> {
 
 			let dna = MinterV2::<T>::generate_empty_dna::<32>()?;
 
-			let mut gen_avatar = AvatarBuilder::with_dna(season_id, dna);
+			let mut gen_avatar = AvatarBuilder::with_dna(season_id, dna, current_block);
 
 			if rand_0 as u32 * SCALING_FACTOR_PERC < GLIMMER_PROB_PERC * MAX_BYTE {
 				if rand_1 == rand_2 {
-					let progress_array = DnaUtils::generate_progress(
+					let progress_array = DnaUtils::<BlockNumberFor<T>>::generate_progress(
 						&RarityTier::Rare,
 						SCALING_FACTOR_PERC,
 						Some(SPARK_PROGRESS_PROB_PERC),
@@ -68,7 +70,8 @@ impl<T: Config> AvatarCombinator<T> {
 					gen_avatar =
 						gen_avatar.into_egg(&RarityTier::Rare, 0x00, soul_points, progress_array);
 				} else if rand_1 ==
-					(DnaUtils::high_nibble_of(rand_1) + DnaUtils::low_nibble_of(rand_2))
+					(DnaUtils::<BlockNumberFor<T>>::high_nibble_of(rand_1) +
+						DnaUtils::<BlockNumberFor<T>>::low_nibble_of(rand_2))
 				{
 					let color_pair = (
 						ColorType::from_byte(rand_1 % (color_types + 1)),
@@ -82,7 +85,7 @@ impl<T: Config> AvatarCombinator<T> {
 						ColorType::from_byte(rand_2 % (color_types + 1)),
 						ColorType::from_byte(rand_3 % (color_types + 1)),
 					);
-					let progress_array = DnaUtils::generate_progress(
+					let progress_array = DnaUtils::<BlockNumberFor<T>>::generate_progress(
 						&RarityTier::Rare,
 						SCALING_FACTOR_PERC,
 						Some(SPARK_PROGRESS_PROB_PERC),
@@ -92,7 +95,7 @@ impl<T: Config> AvatarCombinator<T> {
 						gen_avatar.into_color_spark(&color_pair, soul_points, progress_array);
 				} else {
 					let force = Force::from_byte((rand_2 % forces) + 1);
-					let progress_array = DnaUtils::generate_progress(
+					let progress_array = DnaUtils::<BlockNumberFor<T>>::generate_progress(
 						&RarityTier::Rare,
 						SCALING_FACTOR_PERC,
 						Some(SPARK_PROGRESS_PROB_PERC),
@@ -817,7 +820,7 @@ mod test {
 				],
 			];
 
-			let unit_fn = |avatar: Avatar| {
+			let unit_fn = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 100;
 				WrappedAvatar::new(avatar)

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/mod.rs
@@ -13,7 +13,7 @@ mod tinker;
 
 use super::*;
 
-pub(super) type WrappedForgeItem<T> = (AvatarIdOf<T>, WrappedAvatar);
+pub(super) type WrappedForgeItem<T> = (AvatarIdOf<T>, WrappedAvatar<BlockNumberFor<T>>);
 
 pub(super) struct AvatarCombinator<T: Config>(pub PhantomData<T>);
 
@@ -91,7 +91,7 @@ impl<T: Config> AvatarCombinator<T> {
 		for (_, sacrifice) in sacrifices.iter() {
 			let sacrifice_progress_array = sacrifice.get_progress();
 
-			if let Some(matched_indexes) = DnaUtils::is_progress_match(
+			if let Some(matched_indexes) = DnaUtils::<BlockNumberFor<T>>::is_progress_match(
 				leader_progress_array,
 				sacrifice_progress_array,
 				rarity_level,

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/spark.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/spark.rs
@@ -15,10 +15,11 @@ impl<T: Config> AvatarCombinator<T> {
 			hash_provider,
 		);
 
-		let progress_rarity = RarityTier::from_byte(DnaUtils::lowest_progress_byte(
-			&leader.get_progress(),
-			ByteType::High,
-		));
+		let progress_rarity =
+			RarityTier::from_byte(DnaUtils::<BlockNumberFor<T>>::lowest_progress_byte(
+				&leader.get_progress(),
+				ByteType::High,
+			));
 		let essence_type = leader.get_item_sub_type::<EssenceItemType>();
 
 		if essence_type == EssenceItemType::ColorSpark && progress_rarity == RarityTier::Epic {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/stack.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/stack.rs
@@ -55,6 +55,8 @@ impl<T: Config> AvatarCombinator<T> {
 			LeaderForgeOutput::Consumed(leader_id)
 		};
 
+		let current_block = <frame_system::Pallet<T>>::block_number();
+
 		let glimmer_avatar = if total_soul_points > 0 {
 			let glimmer_quantity = total_soul_points / GLIMMER_SP as SoulCount;
 			dust_quantity += total_soul_points % GLIMMER_SP as SoulCount;
@@ -62,7 +64,7 @@ impl<T: Config> AvatarCombinator<T> {
 			if glimmer_quantity > 0 {
 				let dna = MinterV2::<T>::generate_empty_dna::<32>()?;
 				Some(
-					AvatarBuilder::with_dna(season_id, dna)
+					AvatarBuilder::with_dna(season_id, dna, current_block)
 						.into_glimmer(glimmer_quantity as u8)
 						.build(),
 				)
@@ -83,8 +85,11 @@ impl<T: Config> AvatarCombinator<T> {
 				let soul_points = if dust_qty > MAX_BYTE { MAX_BYTE } else { dust_qty };
 
 				let dna = MinterV2::<T>::generate_empty_dna::<32>()?;
-				dust_avatars
-					.push(AvatarBuilder::with_dna(season_id, dna).into_dust(soul_points).build());
+				dust_avatars.push(
+					AvatarBuilder::with_dna(season_id, dna, current_block)
+						.into_dust(soul_points)
+						.build(),
+				);
 				dust_qty = dust_qty.saturating_sub(MAX_BYTE);
 
 				if dust_qty == 0 {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/statue.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/statue.rs
@@ -25,8 +25,11 @@ impl<T: Config> AvatarCombinator<T> {
 		let max_quantity = 16;
 		if new_quantity > max_quantity {
 			let dna = MinterV2::<T>::generate_empty_dna::<32>()?;
+			let current_block = <frame_system::Pallet<T>>::block_number();
 			let dust_avatar = vec![ForgeOutput::Minted(
-				AvatarBuilder::with_dna(season_id, dna).into_dust(new_souls).build(),
+				AvatarBuilder::with_dna(season_id, dna, current_block)
+					.into_dust(new_souls)
+					.build(),
 			)];
 
 			return Ok((
@@ -51,7 +54,7 @@ impl<T: Config> AvatarCombinator<T> {
 				}
 			}
 
-			let pet_type_index = (DnaUtils::current_period::<T>(
+			let pet_type_index = (DnaUtils::<BlockNumberFor<T>>::current_period::<T>(
 				PET_MOON_PHASE_SIZE,
 				PET_MOON_PHASE_AMOUNT,
 				block_number,
@@ -64,10 +67,12 @@ impl<T: Config> AvatarCombinator<T> {
 		};
 
 		if updated_spec_bytes.iter().take(8).skip(1).all(|spec_byte| *spec_byte > 0) {
-			let slot_types = DnaUtils::indexes_of_max(&updated_spec_bytes[0..8]);
+			let slot_types =
+				DnaUtils::<BlockNumberFor<T>>::indexes_of_max(&updated_spec_bytes[0..8]);
 			let final_slot_type = slot_types[hash_provider.hash[0] as usize % slot_types.len()];
 
-			let pet_types = DnaUtils::indexes_of_max(&updated_spec_bytes[8..16]);
+			let pet_types =
+				DnaUtils::<BlockNumberFor<T>>::indexes_of_max(&updated_spec_bytes[8..16]);
 			let final_pet_type = pet_types[hash_provider.hash[1] as usize % pet_types.len()];
 
 			leader.set_rarity(RarityTier::Rare);
@@ -76,31 +81,55 @@ impl<T: Config> AvatarCombinator<T> {
 
 			let base_seed = final_slot_type + final_pet_type;
 
-			let base_0 = DnaUtils::create_pattern::<NibbleType>(
+			let base_0 = DnaUtils::<BlockNumberFor<T>>::create_pattern::<NibbleType>(
 				base_seed,
 				EquippableItemType::ArmorBase.as_byte() as usize,
 			);
-			let comp_1 = DnaUtils::create_pattern::<NibbleType>(
+			let comp_1 = DnaUtils::<BlockNumberFor<T>>::create_pattern::<NibbleType>(
 				base_seed,
 				EquippableItemType::ArmorComponent1.as_byte() as usize,
 			);
-			let comp_2 = DnaUtils::create_pattern::<NibbleType>(
+			let comp_2 = DnaUtils::<BlockNumberFor<T>>::create_pattern::<NibbleType>(
 				base_seed,
 				EquippableItemType::ArmorComponent2.as_byte() as usize,
 			);
-			let comp_3 = DnaUtils::create_pattern::<NibbleType>(
+			let comp_3 = DnaUtils::<BlockNumberFor<T>>::create_pattern::<NibbleType>(
 				base_seed,
 				EquippableItemType::ArmorComponent3.as_byte() as usize,
 			);
 
-			leader.set_spec(SpecIdx::Byte1, DnaUtils::enums_to_bits(&base_0) as u8);
-			leader.set_spec(SpecIdx::Byte2, DnaUtils::enums_order_to_bits(&base_0) as u8);
-			leader.set_spec(SpecIdx::Byte3, DnaUtils::enums_to_bits(&comp_1) as u8);
-			leader.set_spec(SpecIdx::Byte4, DnaUtils::enums_order_to_bits(&comp_1) as u8);
-			leader.set_spec(SpecIdx::Byte5, DnaUtils::enums_to_bits(&comp_2) as u8);
-			leader.set_spec(SpecIdx::Byte6, DnaUtils::enums_order_to_bits(&comp_2) as u8);
-			leader.set_spec(SpecIdx::Byte7, DnaUtils::enums_to_bits(&comp_3) as u8);
-			leader.set_spec(SpecIdx::Byte8, DnaUtils::enums_order_to_bits(&comp_3) as u8);
+			leader.set_spec(
+				SpecIdx::Byte1,
+				DnaUtils::<BlockNumberFor<T>>::enums_to_bits(&base_0) as u8,
+			);
+			leader.set_spec(
+				SpecIdx::Byte2,
+				DnaUtils::<BlockNumberFor<T>>::enums_order_to_bits(&base_0) as u8,
+			);
+			leader.set_spec(
+				SpecIdx::Byte3,
+				DnaUtils::<BlockNumberFor<T>>::enums_to_bits(&comp_1) as u8,
+			);
+			leader.set_spec(
+				SpecIdx::Byte4,
+				DnaUtils::<BlockNumberFor<T>>::enums_order_to_bits(&comp_1) as u8,
+			);
+			leader.set_spec(
+				SpecIdx::Byte5,
+				DnaUtils::<BlockNumberFor<T>>::enums_to_bits(&comp_2) as u8,
+			);
+			leader.set_spec(
+				SpecIdx::Byte6,
+				DnaUtils::<BlockNumberFor<T>>::enums_order_to_bits(&comp_2) as u8,
+			);
+			leader.set_spec(
+				SpecIdx::Byte7,
+				DnaUtils::<BlockNumberFor<T>>::enums_to_bits(&comp_3) as u8,
+			);
+			leader.set_spec(
+				SpecIdx::Byte8,
+				DnaUtils::<BlockNumberFor<T>>::enums_order_to_bits(&comp_3) as u8,
+			);
 		}
 
 		let output_vec: Vec<ForgeOutput<T>> = input_sacrifices

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/tinker.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/tinker.rs
@@ -22,10 +22,12 @@ impl<T: Config> AvatarCombinator<T> {
 			.take(4)
 			.map(|chunk| {
 				sacrifice_pattern ==
-					DnaUtils::bits_order_to_enum(
+					DnaUtils::<BlockNumberFor<T>>::bits_order_to_enum(
 						chunk[1] as u32,
 						4,
-						DnaUtils::bits_to_enums::<MaterialItemType>(chunk[0] as u32),
+						DnaUtils::<BlockNumberFor<T>>::bits_to_enums::<MaterialItemType>(
+							chunk[0] as u32,
+						),
 					)
 			})
 			.collect::<Vec<_>>();
@@ -84,7 +86,8 @@ impl<T: Config> AvatarCombinator<T> {
 			let slot_type = leader.get_class_type_1::<SlotType>();
 
 			let dna = MinterV2::<T>::generate_empty_dna::<32>()?;
-			let generated_blueprint = AvatarBuilder::with_dna(season_id, dna)
+			let current_block = <frame_system::Pallet<T>>::block_number();
+			let generated_blueprint = AvatarBuilder::with_dna(season_id, dna, current_block)
 				.into_blueprint(
 					&BlueprintItemType::Blueprint,
 					&pet_type,
@@ -129,7 +132,7 @@ mod test {
 			let slot_type = SlotType::Head;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				EquippableItemType::ArmorBase.as_byte() as usize,
 			);
@@ -203,7 +206,7 @@ mod test {
 			let slot_type = SlotType::Head;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				EquippableItemType::ArmorBase.as_byte() as usize,
 			);
@@ -286,7 +289,7 @@ mod test {
 			let slot_type = SlotType::Head;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				EquippableItemType::ArmorBase.as_byte() as usize,
 			);
@@ -358,7 +361,7 @@ mod test {
 			let slot_type = SlotType::Head;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				EquippableItemType::ArmorBase.as_byte() as usize,
 			);
@@ -432,7 +435,7 @@ mod test {
 			let slot_type = SlotType::Head;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				EquippableItemType::ArmorBase.as_byte() as usize,
 			);
@@ -508,7 +511,7 @@ mod test {
 			let slot_type = SlotType::Breast;
 
 			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-			let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+			let pattern = DnaUtils::<BlockNumberFor<Test>>::create_pattern::<MaterialItemType>(
 				base_seed,
 				EquippableItemType::ArmorComponent3.as_byte() as usize,
 			);
@@ -584,7 +587,7 @@ mod test {
 		ExtBuilder::default().build().execute_with(|| {
 			let season_id = 0 as SeasonId;
 
-			let unit_fn = |avatar: Avatar| {
+			let unit_fn = |avatar: AvatarOf<Test>| {
 				let mut avatar = avatar;
 				avatar.souls = 1;
 				WrappedAvatar::new(avatar)

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/mutator.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/mutator.rs
@@ -4,17 +4,17 @@ use crate::types::Avatar;
 pub(crate) trait AvatarMutator<T: Config> {
 	fn mutate_from_base(
 		&self,
-		base_avatar: Avatar,
+		base_avatar: AvatarOf<T>,
 		hash_provider: &mut HashProvider<T, 32>,
-	) -> Result<Avatar, ()>;
+	) -> Result<AvatarOf<T>, ()>;
 }
 
 impl<T: Config> AvatarMutator<T> for PetItemType {
 	fn mutate_from_base(
 		&self,
-		base_avatar: Avatar,
+		base_avatar: AvatarOf<T>,
 		hash_provider: &mut HashProvider<T, 32>,
-	) -> Result<Avatar, ()> {
+	) -> Result<AvatarOf<T>, ()> {
 		let avatar = match self {
 			PetItemType::Pet => {
 				let pet_type = PetType::from_byte((hash_provider.next() % 4) + 1);
@@ -22,7 +22,7 @@ impl<T: Config> AvatarMutator<T> for PetItemType {
 
 				let spec_bytes = [0; 16];
 
-				let progress_array = DnaUtils::generate_progress(
+				let progress_array = DnaUtils::<BlockNumberFor<T>>::generate_progress(
 					&RarityTier::Legendary,
 					SCALING_FACTOR_PERC,
 					None,
@@ -57,7 +57,7 @@ impl<T: Config> AvatarMutator<T> for PetItemType {
 
 				let egg_rarity = RarityTier::Rare;
 
-				let progress_array = DnaUtils::generate_progress(
+				let progress_array = DnaUtils::<BlockNumberFor<T>>::generate_progress(
 					&egg_rarity,
 					SCALING_FACTOR_PERC,
 					Some(PROGRESS_PROBABILITY_PERC),
@@ -81,9 +81,9 @@ impl<T: Config> AvatarMutator<T> for PetItemType {
 impl<T: Config> AvatarMutator<T> for MaterialItemType {
 	fn mutate_from_base(
 		&self,
-		base_avatar: Avatar,
+		base_avatar: AvatarOf<T>,
 		hash_provider: &mut HashProvider<T, 32>,
-	) -> Result<Avatar, ()> {
+	) -> Result<AvatarOf<T>, ()> {
 		let avatar = AvatarBuilder::with_base_avatar(base_avatar)
 			.into_material(self, (hash_provider.next() % MAX_QUANTITY) + 1)
 			.build();
@@ -95,9 +95,9 @@ impl<T: Config> AvatarMutator<T> for MaterialItemType {
 impl<T: Config> AvatarMutator<T> for EssenceItemType {
 	fn mutate_from_base(
 		&self,
-		base_avatar: Avatar,
+		base_avatar: AvatarOf<T>,
 		hash_provider: &mut HashProvider<T, 32>,
-	) -> Result<Avatar, ()> {
+	) -> Result<AvatarOf<T>, ()> {
 		let souls = (hash_provider.next() % 99) + 1;
 
 		let avatar = match *self {
@@ -106,12 +106,12 @@ impl<T: Config> AvatarMutator<T> for EssenceItemType {
 			EssenceItemType::ColorSpark | EssenceItemType::PaintFlask => {
 				let hash_byte = hash_provider.next();
 				let color_pair = (
-					ColorType::from_byte(DnaUtils::high_nibble_of(hash_byte)),
-					ColorType::from_byte(DnaUtils::low_nibble_of(hash_byte)),
+					ColorType::from_byte(DnaUtils::<BlockNumberFor<T>>::high_nibble_of(hash_byte)),
+					ColorType::from_byte(DnaUtils::<BlockNumberFor<T>>::low_nibble_of(hash_byte)),
 				);
 
 				if *self == EssenceItemType::ColorSpark {
-					let progress_array = DnaUtils::generate_progress(
+					let progress_array = DnaUtils::<BlockNumberFor<T>>::generate_progress(
 						&RarityTier::Rare,
 						SCALING_FACTOR_PERC,
 						Some(SPARK_PROGRESS_PROB_PERC),
@@ -124,7 +124,7 @@ impl<T: Config> AvatarMutator<T> for EssenceItemType {
 						progress_array,
 					)
 				} else {
-					let progress_array = DnaUtils::generate_progress(
+					let progress_array = DnaUtils::<BlockNumberFor<T>>::generate_progress(
 						&RarityTier::Epic,
 						SCALING_FACTOR_PERC,
 						Some(SPARK_PROGRESS_PROB_PERC),
@@ -142,7 +142,7 @@ impl<T: Config> AvatarMutator<T> for EssenceItemType {
 				let force = Force::from_byte(hash_provider.next() % Force::range().end as u8);
 
 				if *self == EssenceItemType::GlowSpark {
-					let progress_array = DnaUtils::generate_progress(
+					let progress_array = DnaUtils::<BlockNumberFor<T>>::generate_progress(
 						&RarityTier::Rare,
 						SCALING_FACTOR_PERC,
 						Some(SPARK_PROGRESS_PROB_PERC),
@@ -155,7 +155,7 @@ impl<T: Config> AvatarMutator<T> for EssenceItemType {
 						progress_array,
 					)
 				} else {
-					let progress_array = DnaUtils::generate_progress(
+					let progress_array = DnaUtils::<BlockNumberFor<T>>::generate_progress(
 						&RarityTier::Epic,
 						SCALING_FACTOR_PERC,
 						Some(SPARK_PROGRESS_PROB_PERC),
@@ -179,9 +179,9 @@ impl<T: Config> AvatarMutator<T> for EssenceItemType {
 impl<T: Config> AvatarMutator<T> for EquippableItemType {
 	fn mutate_from_base(
 		&self,
-		base_avatar: Avatar,
+		base_avatar: AvatarOf<T>,
 		hash_provider: &mut HashProvider<T, 32>,
-	) -> Result<Avatar, ()> {
+	) -> Result<AvatarOf<T>, ()> {
 		let soul_count = (hash_provider.next() as SoulCount % 25) + 1;
 		let pet_type = SlotRoller::<T>::roll_on(&PET_TYPE_PROBABILITIES, hash_provider);
 
@@ -218,8 +218,8 @@ impl<T: Config> AvatarMutator<T> for EquippableItemType {
 
 				let hash_byte = hash_provider.next();
 				let color_pair = (
-					ColorType::from_byte(DnaUtils::high_nibble_of(hash_byte)),
-					ColorType::from_byte(DnaUtils::low_nibble_of(hash_byte)),
+					ColorType::from_byte(DnaUtils::<BlockNumberFor<T>>::high_nibble_of(hash_byte)),
+					ColorType::from_byte(DnaUtils::<BlockNumberFor<T>>::low_nibble_of(hash_byte)),
 				);
 				let force = Force::from_byte(hash_provider.next() % 7);
 
@@ -243,9 +243,9 @@ impl<T: Config> AvatarMutator<T> for EquippableItemType {
 impl<T: Config> AvatarMutator<T> for BlueprintItemType {
 	fn mutate_from_base(
 		&self,
-		base_avatar: Avatar,
+		base_avatar: AvatarOf<T>,
 		hash_provider: &mut HashProvider<T, 32>,
-	) -> Result<Avatar, ()> {
+	) -> Result<AvatarOf<T>, ()> {
 		let soul_count = (hash_provider.next() % 25) + 1;
 
 		let pet_type = SlotRoller::<T>::roll_on(&PET_TYPE_PROBABILITIES, hash_provider);
@@ -254,7 +254,7 @@ impl<T: Config> AvatarMutator<T> for BlueprintItemType {
 			SlotRoller::<T>::roll_on(&EQUIPMENT_TYPE_PROBABILITIES, hash_provider);
 
 		let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
-		let pattern = DnaUtils::create_pattern::<MaterialItemType>(
+		let pattern = DnaUtils::<BlockNumberFor<T>>::create_pattern::<MaterialItemType>(
 			base_seed,
 			equippable_item_type.as_byte() as usize,
 		);
@@ -277,17 +277,17 @@ impl<T: Config> AvatarMutator<T> for BlueprintItemType {
 impl<T: Config> AvatarMutator<T> for SpecialItemType {
 	fn mutate_from_base(
 		&self,
-		base_avatar: Avatar,
+		base_avatar: AvatarOf<T>,
 		hash_provider: &mut HashProvider<T, 32>,
-	) -> Result<Avatar, ()> {
+	) -> Result<AvatarOf<T>, ()> {
 		let avatar = match self {
 			SpecialItemType::Dust => AvatarBuilder::with_base_avatar(base_avatar).into_dust(1),
 			SpecialItemType::Unidentified => {
 				let soul_count = (hash_provider.next() as SoulCount % 25) + 1;
 				let hash_byte = hash_provider.next();
 				let color_pair = (
-					ColorType::from_byte(DnaUtils::high_nibble_of(hash_byte)),
-					ColorType::from_byte(DnaUtils::low_nibble_of(hash_byte)),
+					ColorType::from_byte(DnaUtils::<BlockNumberFor<T>>::high_nibble_of(hash_byte)),
+					ColorType::from_byte(DnaUtils::<BlockNumberFor<T>>::low_nibble_of(hash_byte)),
 				);
 				let force = Force::from_byte(hash_provider.next() % 7);
 

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/test_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/test_utils.rs
@@ -11,8 +11,9 @@ use crate::{
 		},
 		Avatar, DnaEncoding, ForgeOutput, LeaderForgeOutput, RarityTier, SoulCount,
 	},
-	Config, Force, Pallet,
+	AvatarOf, Config, Force, Pallet,
 };
+use frame_system::pallet_prelude::BlockNumberFor;
 use sp_core::bounded::BoundedVec;
 
 pub const HASH_BYTES: [u8; 32] = [
@@ -24,17 +25,18 @@ pub(crate) fn create_random_avatar<T, F>(
 	creator: &T::AccountId,
 	initial_dna: Option<[u8; 32]>,
 	avatar_build_fn: Option<F>,
-) -> (AvatarIdOf<T>, WrappedAvatar)
+) -> (AvatarIdOf<T>, WrappedAvatar<BlockNumberFor<T>>)
 where
-	F: FnOnce(Avatar) -> WrappedAvatar,
+	F: FnOnce(AvatarOf<T>) -> WrappedAvatar<BlockNumberFor<T>>,
 	T: Config,
 {
-	let base_avatar = Avatar {
+	let base_avatar = AvatarOf::<T> {
 		season_id: 0,
 		encoding: DnaEncoding::V2,
 		dna: BoundedVec::try_from(initial_dna.unwrap_or([0_u8; 32]).to_vec())
 			.expect("Should create DNA!"),
 		souls: 0,
+		minted_at: 0_u32.into(),
 	};
 
 	let avatar = match avatar_build_fn {
@@ -48,7 +50,7 @@ pub(crate) fn create_random_material(
 	account: &MockAccountId,
 	material_type: &MaterialItemType,
 	quantity: u8,
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		None,
@@ -65,7 +67,7 @@ pub(crate) fn create_random_pet_part(
 	pet_type: &PetType,
 	slot_type: &SlotType,
 	quantity: u8,
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		None,
@@ -81,7 +83,7 @@ pub(crate) fn create_random_generic_part(
 	account: &MockAccountId,
 	slot_types: &[SlotType],
 	quantity: u8,
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		None,
@@ -100,7 +102,7 @@ pub(crate) fn create_random_pet(
 	spec_bytes: [u8; 16],
 	progress_array: [u8; 11],
 	soul_points: SoulCount,
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		None,
@@ -119,7 +121,7 @@ pub(crate) fn create_random_blueprint(
 	equippable_type: &EquippableItemType,
 	material_pattern: &[MaterialItemType],
 	soul_points: SoulCount,
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		None,
@@ -149,7 +151,7 @@ pub(crate) fn create_random_armor_component(
 	force: &Force,
 	soul_points: SoulCount,
 	hash_provider: &mut HashProvider<Test, 32>,
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		Some(base_dna),
@@ -181,7 +183,7 @@ pub(crate) fn create_random_weapon(
 	force: &Force,
 	soul_points: SoulCount,
 	hash_provider: &mut HashProvider<Test, 32>,
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		Some(base_dna),
@@ -206,7 +208,7 @@ pub(crate) fn create_random_toolbox(
 	base_dna: [u8; 32],
 	account: &MockAccountId,
 	soul_points: SoulCount,
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		Some(base_dna),
@@ -225,7 +227,7 @@ pub(crate) fn create_random_egg(
 	pet_variation: u8,
 	soul_points: SoulCount,
 	progress_array: [u8; 11],
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		base_dna,
@@ -243,7 +245,7 @@ pub(crate) fn create_random_glow_spark(
 	force: &Force,
 	soul_points: SoulCount,
 	progress_array: [u8; 11],
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		base_dna,
@@ -258,7 +260,7 @@ pub(crate) fn create_random_glow_spark(
 pub(crate) fn create_random_glimmer(
 	account: &MockAccountId,
 	quantity: u8,
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		None,
@@ -273,7 +275,7 @@ pub(crate) fn create_random_paint_flask(
 	color_pair: &(ColorType, ColorType),
 	soul_points: SoulCount,
 	progress_array: [u8; 11],
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		None,
@@ -290,7 +292,7 @@ pub(crate) fn create_random_glow_flask(
 	force_type: &Force,
 	soul_points: SoulCount,
 	progress_array: [u8; 11],
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		None,
@@ -305,7 +307,7 @@ pub(crate) fn create_random_glow_flask(
 pub(crate) fn create_random_dust(
 	account: &MockAccountId,
 	soul_points: SoulCount,
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		None,
@@ -321,7 +323,7 @@ pub(crate) fn create_random_color_spark(
 	color_pair: &(ColorType, ColorType),
 	soul_points: SoulCount,
 	progress_array: [u8; 11],
-) -> (AvatarIdOf<Test>, WrappedAvatar) {
+) -> (AvatarIdOf<Test>, WrappedAvatar<BlockNumberFor<Test>>) {
 	create_random_avatar::<Test, _>(
 		account,
 		base_dna,

--- a/pallets/ajuna-awesome-avatars/src/types/season.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/season.rs
@@ -91,7 +91,7 @@ impl DerefMut for TradeFilters {
 }
 
 impl TradeFilters {
-	pub(crate) fn is_tradable(&self, avatar: &Avatar) -> bool {
+	pub(crate) fn is_tradable<BlockNumber>(&self, avatar: &Avatar<BlockNumber>) -> bool {
 		// No filter means we allow everything to be traded.
 		if self.is_empty() {
 			return true;


### PR DESCRIPTION
## Description

This PR adds the attribute `minted_at` to the `Avatar` struct, along with the migration and tournament related logic to it.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
