### PR TITLE
[AJUN-229] Tournament ranker storage

### DIFF
--- a/pallets/ajuna-tournament/src/tests.rs
+++ b/pallets/ajuna-tournament/src/tests.rs
@@ -88,7 +88,7 @@ mod tournament_inspector {
 
 			assert_eq!(
 				TournamentAlpha::get_active_tournament_config_for(&SEASON_ID_1),
-				Some(tournament_config)
+				Some((0, tournament_config))
 			);
 			assert_eq!(TournamentAlpha::get_active_tournament_config_for(&SEASON_ID_2), None);
 		});
@@ -1007,7 +1007,7 @@ fn test_full_tournament_workflow() {
 			);
 			assert_eq!(
 				TournamentAlpha::get_active_tournament_config_for(&SEASON_ID_1),
-				Some(tournament_config)
+				Some((0, tournament_config))
 			);
 
 			// Ranking some entities

--- a/pallets/ajuna-tournament/src/traits.rs
+++ b/pallets/ajuna-tournament/src/traits.rs
@@ -14,7 +14,7 @@ pub trait EntityRank {
 pub trait TournamentInspector<SeasonId, BlockNumber, Balance, AccountId> {
 	fn get_active_tournament_config_for(
 		season_id: &SeasonId,
-	) -> Option<TournamentConfig<BlockNumber, Balance>>;
+	) -> Option<(TournamentId, TournamentConfig<BlockNumber, Balance>)>;
 
 	fn get_active_tournament_state_for(season_id: &SeasonId) -> TournamentState<Balance>;
 


### PR DESCRIPTION
## Description

Refactored Tournament ranker storage in AAA and Tournament pallet so its easier to check.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
