### PR TITLE
[AJUN-244] Tournament reward claim is broken

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -1503,6 +1503,8 @@ pub mod pallet {
 			avatar_id: AvatarIdOf<T>,
 		) -> DispatchResult {
 			let account = ensure_signed(origin)?;
+			Self::ensure_ownership(&account, &avatar_id)?;
+
 			T::TournamentHandler::try_claim_tournament_reward_for(&season_id, &account, &avatar_id)
 		}
 
@@ -1514,6 +1516,8 @@ pub mod pallet {
 			avatar_id: AvatarIdOf<T>,
 		) -> DispatchResult {
 			let account = ensure_signed(origin)?;
+			Self::ensure_ownership(&account, &avatar_id)?;
+
 			T::TournamentHandler::try_claim_golden_duck_for(&season_id, &account, &avatar_id)
 		}
 	}


### PR DESCRIPTION
## Description

* Fixes issue in which any account could claim the reward for a tournament without owning the winning entity.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
