### PR TITLE
[Forging/V3] Limit forging to only non max rarity leaders

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -1980,6 +1980,7 @@ pub mod pallet {
 				},
 				LeaderForgeOutput::Consumed(leader_id) =>
 					Self::remove_avatar_from(player, season_id, &leader_id),
+				LeaderForgeOutput::Unchanged(_) => {},
 			}
 
 			Ok(())
@@ -2007,6 +2008,7 @@ pub mod pallet {
 					},
 					ForgeOutput::Consumed(avatar_id) =>
 						Self::remove_avatar_from(player, season_id, &avatar_id),
+					ForgeOutput::Unchanged(_) => {},
 				}
 			}
 

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/mod.rs
@@ -38,6 +38,8 @@ pub(crate) enum LeaderForgeOutput<T: Config> {
 	Forged(ForgeItem<T>, UpgradedComponents),
 	/// The leader avatar was consumed in the forging process.
 	Consumed(AvatarIdOf<T>),
+	/// The leader avatar was left unchanged.
+	Unchanged(ForgeItem<T>),
 }
 /// Enum used to express the possible results of the forge on the other avatars, also called
 /// sacrifices.
@@ -48,6 +50,8 @@ pub(crate) enum ForgeOutput<T: Config> {
 	Minted(AvatarOf<T>),
 	/// The avatar was consumed in the forging process.
 	Consumed(AvatarIdOf<T>),
+	/// The avatar was not changed in the forging process.
+	Unchanged(ForgeItem<T>),
 }
 
 /// Trait used to define the surface logic of the forging algorithm.

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v3.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v3.rs
@@ -104,6 +104,18 @@ impl<T: Config> Forger<T> for ForgerV3<T> {
 		let (leader_id, mut leader) = input_leader;
 
 		let max_tier = season.max_tier() as u8;
+
+		// If the leader is of max rarity we don't allow any forging
+		if leader.rarity() == max_tier {
+			return Ok((
+				LeaderForgeOutput::Unchanged((leader_id, leader)),
+				input_sacrifices
+					.into_iter()
+					.map(|sacrifice| ForgeOutput::Unchanged(sacrifice))
+					.collect(),
+			));
+		}
+
 		let current_block = <frame_system::Pallet<T>>::block_number();
 
 		let (sacrifice_ids, sacrifice_avatars): (Vec<AvatarIdOf<T>>, Vec<AvatarOf<T>>) =


### PR DESCRIPTION
## Description

* Adjusts logic for V3 Forging so that max rarity leaders cannot be forged with other avatars

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
