### PR TITLE
[AJUN-281][AJUN-282] Affiliate pallet fixes

### DIFF
--- a/pallets/ajuna-affiliates/src/tests.rs
+++ b/pallets/ajuna-affiliates/src/tests.rs
@@ -102,7 +102,8 @@ mod affiliate_to {
 	#[test]
 	fn affiliate_to_should_work() {
 		ExtBuilder::default().build().execute_with(|| {
-			let state = AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 };
+			let state =
+				AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 };
 			Affiliators::<Test, Instance1>::insert(BOB, state);
 
 			assert_ok!(
@@ -123,7 +124,8 @@ mod affiliate_to {
 	#[test]
 	fn affiliate_to_should_work_with_chain() {
 		ExtBuilder::default().build().execute_with(|| {
-			let state = AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 };
+			let state =
+				AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 };
 			Affiliators::<Test, Instance1>::insert(BOB, state);
 			Affiliators::<Test, Instance1>::insert(ALICE, state);
 			Affiliators::<Test, Instance1>::insert(CHARLIE, state);
@@ -211,7 +213,8 @@ mod affiliate_to {
 	#[test]
 	fn affiliate_to_rejects_if_account_is_affiliator() {
 		ExtBuilder::default().build().execute_with(|| {
-			let state = AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 };
+			let state =
+				AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 };
 			Affiliators::<Test, Instance1>::insert(BOB, state);
 			Affiliators::<Test, Instance1>::insert(ALICE, state);
 
@@ -233,7 +236,8 @@ mod affiliate_to {
 	#[test]
 	fn affiliate_to_rejects_affiliating_to_more_than_one_account() {
 		ExtBuilder::default().build().execute_with(|| {
-			let state = AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 };
+			let state =
+				AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 };
 			Affiliators::<Test, Instance1>::insert(BOB, state);
 			Affiliators::<Test, Instance1>::insert(CHARLIE, state);
 
@@ -287,7 +291,8 @@ mod clear_affiliation {
 	#[test]
 	fn clear_affiliation_should_work() {
 		ExtBuilder::default().balances(&[(ALICE, 1_000_000)]).build().execute_with(|| {
-			let state = AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 };
+			let state =
+				AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 };
 			Affiliators::<Test, Instance1>::insert(BOB, state);
 
 			assert_ok!(
@@ -337,7 +342,7 @@ mod multi_instance_tests {
 	fn affiliates_in_one_instance_dont_affect_other_instance() {
 		ExtBuilder::default().balances(&[(ALICE, 1_000_000)]).build().execute_with(|| {
 			let state_alpha =
-				AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 };
+				AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 };
 			Affiliators::<Test, Instance1>::insert(BOB, state_alpha);
 
 			assert_ok!(
@@ -358,7 +363,7 @@ mod multi_instance_tests {
 			assert_eq!(Affiliatees::<Test, Instance2>::get(ALICE), None);
 
 			let state_beta =
-				AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 };
+				AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 };
 			Affiliators::<Test, Instance2>::insert(ALICE, state_beta);
 
 			// Trying to affiliate to ALICE on AffiliatesAlpha will fail since

--- a/pallets/ajuna-affiliates/src/traits.rs
+++ b/pallets/ajuna-affiliates/src/traits.rs
@@ -1,6 +1,8 @@
 use frame_support::pallet_prelude::*;
 use sp_std::vec::Vec;
 
+pub type AffiliateId = u32;
+
 pub trait AffiliateInspector<AccountId> {
 	/// Returns a vector of accounts that 'account' is affiliated to.
 	///
@@ -13,17 +15,13 @@ pub trait AffiliateInspector<AccountId> {
 	/// Returns the number of accounts that are affiliated with 'account'.
 	fn get_affiliate_count_for(account: &AccountId) -> u32;
 
-	fn get_account_for_id(affiliate_id: u32) -> Option<AccountId>;
+	fn get_account_for_id(affiliate_id: AffiliateId) -> Option<AccountId>;
 }
 
 pub trait AffiliateMutator<AccountId> {
 	/// Tries to mark an account as [AffiliatableStatus::Affiliatable], fails
 	/// to do so if the account is in the [AffiliatableStatus::Blocked] state.
 	fn try_mark_account_as_affiliatable(account: &AccountId) -> DispatchResult;
-
-	/// Forces the marking on an account as [AffiliatableStatus::Affiliatable] ignoring
-	/// its current state.
-	fn force_mark_account_as_affiliatable(account: &AccountId);
 
 	/// Marks an account as [AffiliatableStatus::Blocked]
 	fn mark_account_as_blocked(account: &AccountId);
@@ -62,7 +60,7 @@ pub trait RuleExecutor<RuleId, Rule> {
 pub enum AffiliatableStatus {
 	#[default]
 	NonAffiliatable,
-	Affiliatable,
+	Affiliatable(AffiliateId),
 	Blocked,
 }
 

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -95,7 +95,7 @@ use sp_std::prelude::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use pallet_ajuna_affiliates::traits::RuleExecutor;
+	use pallet_ajuna_affiliates::traits::{AffiliateId, RuleExecutor};
 	use pallet_ajuna_tournament::{Percentage, TournamentId};
 	use sp_std::collections::vec_deque::VecDeque;
 
@@ -1238,7 +1238,7 @@ pub mod pallet {
 		#[pallet::weight({1000})]
 		pub fn add_affiliation(
 			origin: OriginFor<T>,
-			affiliate_id: u32,
+			affiliate_id: AffiliateId,
 			season_id: SeasonId,
 		) -> DispatchResult {
 			let account = ensure_signed(origin)?;
@@ -1282,7 +1282,7 @@ pub mod pallet {
 					}
 				},
 				UnlockTarget::OneselfPaying => {
-					// Substract amout for paying if account not affiliator
+					// Subtract an amount for paying if account not affiliator
 					let GlobalConfig { affiliate_config, .. } = GlobalConfigs::<T>::get();
 					T::Currency::transfer(
 						&account,
@@ -1293,7 +1293,7 @@ pub mod pallet {
 					T::AffiliateHandler::try_mark_account_as_affiliatable(&account)
 				},
 				UnlockTarget::OtherPaying(other) => {
-					// Substract amout for paying if other not affiliator
+					// Subtract an amount for paying if other not affiliator
 					let GlobalConfig { affiliate_config, .. } = GlobalConfigs::<T>::get();
 					T::Currency::transfer(
 						&account,

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -383,7 +383,7 @@ impl ExtBuilder {
 					self.affiliators.len() as u32,
 				);
 				for (i, account) in self.affiliators.into_iter().enumerate() {
-					let _ = Affiliates::try_mark_account_as_affiliatable(&account)
+					Affiliates::try_mark_account_as_affiliatable(&account)
 						.expect("Should mark as affiliatable");
 					pallet_ajuna_affiliates::AffiliateIdMapping::<Test, AffiliatesInstance1>::insert(i as u32, account);
 				}

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -383,7 +383,8 @@ impl ExtBuilder {
 					self.affiliators.len() as u32,
 				);
 				for (i, account) in self.affiliators.into_iter().enumerate() {
-					Affiliates::force_mark_account_as_affiliatable(&account);
+					let _ = Affiliates::try_mark_account_as_affiliatable(&account)
+						.expect("Should mark as affiliatable");
 					pallet_ajuna_affiliates::AffiliateIdMapping::<Test, AffiliatesInstance1>::insert(i as u32, account);
 				}
 			}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -4211,7 +4211,7 @@ mod affiliates {
 			.execute_with(|| {
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(1), affiliates: 0 }
 				);
 
 				assert_ok!(AAvatars::add_affiliation(RuntimeOrigin::signed(BOB), 0, SEASON_ID));
@@ -4227,7 +4227,7 @@ mod affiliates {
 
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 1 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(1), affiliates: 1 }
 				);
 			});
 	}
@@ -4396,7 +4396,7 @@ mod affiliates {
 			.execute_with(|| {
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(1), affiliates: 0 }
 				);
 
 				assert_ok!(AAvatars::add_affiliation(RuntimeOrigin::signed(BOB), 0, SEASON_ID));
@@ -4408,7 +4408,7 @@ mod affiliates {
 
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 1 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(1), affiliates: 1 }
 				);
 
 				assert_ok!(AAvatars::remove_affiliation(RuntimeOrigin::signed(ALICE), BOB));
@@ -4420,7 +4420,7 @@ mod affiliates {
 
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(1), affiliates: 0 }
 				);
 			});
 	}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -4211,7 +4211,7 @@ mod affiliates {
 			.execute_with(|| {
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 }
 				);
 
 				assert_ok!(AAvatars::add_affiliation(RuntimeOrigin::signed(BOB), 0, SEASON_ID));
@@ -4227,7 +4227,7 @@ mod affiliates {
 
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 1 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 1 }
 				);
 			});
 	}
@@ -4268,7 +4268,7 @@ mod affiliates {
 
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 }
 				);
 				assert_eq!(
 					pallet_ajuna_affiliates::NextAffiliateId::<Test, AffiliatesInstance1>::get(),
@@ -4310,7 +4310,7 @@ mod affiliates {
 
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 }
 				);
 				assert_eq!(
 					pallet_ajuna_affiliates::NextAffiliateId::<Test, AffiliatesInstance1>::get(),
@@ -4359,7 +4359,7 @@ mod affiliates {
 				);
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(BOB),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 }
 				);
 				assert_eq!(
 					pallet_ajuna_affiliates::NextAffiliateId::<Test, AffiliatesInstance1>::get(),
@@ -4396,7 +4396,7 @@ mod affiliates {
 			.execute_with(|| {
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 }
 				);
 
 				assert_ok!(AAvatars::add_affiliation(RuntimeOrigin::signed(BOB), 0, SEASON_ID));
@@ -4408,7 +4408,7 @@ mod affiliates {
 
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 1 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 1 }
 				);
 
 				assert_ok!(AAvatars::remove_affiliation(RuntimeOrigin::signed(ALICE), BOB));
@@ -4420,7 +4420,7 @@ mod affiliates {
 
 				assert_eq!(
 					pallet_ajuna_affiliates::Affiliators::<Test, AffiliatesInstance1>::get(ALICE),
-					AffiliatorState { status: AffiliatableStatus::Affiliatable, affiliates: 0 }
+					AffiliatorState { status: AffiliatableStatus::Affiliatable(0), affiliates: 0 }
 				);
 			});
 	}


### PR DESCRIPTION
## Description

* Fixes bug related to affiliate enablement: https://ajunanetwork.atlassian.net/browse/AJUN-282
* Adds information about the affiliate id in the affiliator state: https://ajunanetwork.atlassian.net/browse/AJUN-281

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
