### PR TITLE
[AJUN-289] Freezeing is limited to the stash size of avatars

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -3654,7 +3654,7 @@ mod nft_transfer {
 				PlayerSeasonConfigs::<Test>::insert(technical_account, SEASON_ID, config);
 
 				assert!(!Owners::<Test>::get(ALICE, SEASON_ID).contains(&avatar_id));
-				assert_eq!(Owners::<Test>::get(technical_account, SEASON_ID)[0], avatar_id);
+				assert!(Owners::<Test>::get(technical_account, SEASON_ID).is_empty());
 				assert_eq!(Avatars::<Test>::get(avatar_id).unwrap().0, technical_account);
 
 				// Ensure locked avatars cannot be used in trading, transferring and forging


### PR DESCRIPTION
## Description

This PR changes the way we managed locking an avatar so that we can lock an unlimited number of avatars, compared to the previous version in which we were limited by the same limitations players have in their avatar storage.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
