### PR TITLE
[AJUN-297] Remove latest inactive tournaments

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -1513,6 +1513,16 @@ pub mod pallet {
 
 		#[pallet::call_index(31)]
 		#[pallet::weight({10_000})]
+		pub fn remove_latest_tournament(
+			origin: OriginFor<T>,
+			season_id: SeasonId,
+		) -> DispatchResult {
+			let _ = Self::ensure_organizer(origin)?;
+			T::TournamentHandler::try_remove_latest_tournament_for(&season_id)
+		}
+
+		#[pallet::call_index(32)]
+		#[pallet::weight({10_000})]
 		pub fn claim_tournament_reward_for(
 			origin: OriginFor<T>,
 			season_id: SeasonId,
@@ -1524,7 +1534,7 @@ pub mod pallet {
 			T::TournamentHandler::try_claim_tournament_reward_for(&season_id, &account, &avatar_id)
 		}
 
-		#[pallet::call_index(32)]
+		#[pallet::call_index(33)]
 		#[pallet::weight({10_000})]
 		pub fn claim_golden_duck_for(
 			origin: OriginFor<T>,

--- a/pallets/ajuna-tournament/src/config.rs
+++ b/pallets/ajuna-tournament/src/config.rs
@@ -52,6 +52,7 @@ pub enum TournamentState<Balance> {
 	Inactive,
 	ActivePeriod(TournamentId),
 	ClaimPeriod(TournamentId, Balance),
+	Finished(TournamentId),
 }
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]

--- a/pallets/ajuna-tournament/src/tests.rs
+++ b/pallets/ajuna-tournament/src/tests.rs
@@ -1283,7 +1283,7 @@ fn test_full_tournament_workflow() {
 
 			assert_eq!(
 				ActiveTournaments::<Test, Instance1>::get(SEASON_ID_1),
-				TournamentState::Inactive
+				TournamentState::Finished(tournament_id)
 			);
 		});
 }

--- a/pallets/ajuna-tournament/src/traits.rs
+++ b/pallets/ajuna-tournament/src/traits.rs
@@ -29,6 +29,8 @@ pub trait TournamentMutator<AccountId, SeasonId, BlockNumber, Balance> {
 		season_id: &SeasonId,
 		config: TournamentConfig<BlockNumber, Balance>,
 	) -> Result<TournamentId, DispatchError>;
+
+	fn try_remove_latest_tournament_for(season_id: &SeasonId) -> DispatchResult;
 }
 
 pub trait TournamentRanker<SeasonId, Entity, EntityId> {


### PR DESCRIPTION
## Description

This PR adds the ability to remove the latest tournament create for a given season as long as its inactive

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
