### PR TITLE
[AJUN-298] Bugfix multiple reward claim

### DIFF
--- a/pallets/ajuna-tournament/src/config.rs
+++ b/pallets/ajuna-tournament/src/config.rs
@@ -4,6 +4,15 @@ use frame_support::{
 	BoundedVec,
 };
 
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
+pub enum RewardClaimState<Account> {
+	#[default]
+	Unclaimed,
+	Claimed(Account),
+}
+
+pub type RankingTableIndex = u32;
+
 pub type Percentage = u8;
 
 pub type RewardDistributionTable = BoundedVec<Percentage, ConstU32<MAX_PLAYERS>>;


### PR DESCRIPTION
## Description

Fixes bug in tournament pallet where an account can claim a reward multiple times

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
