### PR TITLE
Implement generic orml benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "orml-pallets-benchmarking"
+version = "0.6.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "orml-vesting",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "orml-vesting"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e848c6c92c5100f98f210fe1fab797cddeceee631aa0de28cfcf97c630e2d7d8"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-ajuna-affiliates"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ version    = "0.6.0"
 [workspace]
 resolver = "2"
 members = [
+    "orml-pallets-benchmarking",
     "pallets/*",
     "pallets/ajuna-awesome-avatars/benchmarking",
     "pallets/ajuna-nft-staking/benchmarking",
@@ -36,6 +37,9 @@ sp-core                                    = { version = "32.0.0", default-featu
 sp-io                                      = { version = "34.0.0", default-features = false }
 sp-runtime                                 = { version = "35.0.0", default-features = false }
 sp-std                                     = { version = "14.0.0", default-features = false }
+
+# orml
+orml-vesting = { version = "0.10.0", default-features = false }
 
 # Ajuna
 pallet-ajuna-affiliates                   = { path = "pallets/ajuna-affiliates", default-features = false }

--- a/orml-pallets-benchmarking/Cargo.toml
+++ b/orml-pallets-benchmarking/Cargo.toml
@@ -27,7 +27,7 @@ sp-runtime = { workspace = true }
 [features]
 default = ["std"]
 # Note: Either the `benchmarks!` or the `define_benchmarks!` macro demand the
-# existence of this feature flags, otherwise the benchmarks can't be found in the
+# existence of this feature flag. Otherwise, the benchmarks can't be found in the
 # node.
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",

--- a/orml-pallets-benchmarking/Cargo.toml
+++ b/orml-pallets-benchmarking/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+description = "Implement benchmarks for orml pallets"
+name = "orml-pallets-benchmarking"
+
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+parity-scale-codec = { workspace = true }
+scale-info         = { workspace = true }
+
+orml-vesting = { features = ["runtime-benchmarks"], workspace = true }
+
+frame-benchmarking = { features = ["runtime-benchmarks"], workspace = true }
+frame-support = { features = ["runtime-benchmarks"], workspace = true }
+frame-system = { features = ["runtime-benchmarks"], workspace = true }
+pallet-balances = {features = ["runtime-benchmarks"], workspace = true }
+
+sp-io = { workspace = true }
+sp-std = { workspace = true }
+sp-runtime = { features = ["runtime-benchmarks"], workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "orml-vesting/std",
+    "frame-benchmarking/std",
+    "frame-support/std",
+    "frame-system/std",
+    "pallet-balances/std",
+    "sp-io/std",
+    "sp-std/std",
+    "sp-runtime/std",
+]

--- a/orml-pallets-benchmarking/Cargo.toml
+++ b/orml-pallets-benchmarking/Cargo.toml
@@ -13,19 +13,30 @@ version.workspace = true
 parity-scale-codec = { workspace = true }
 scale-info         = { workspace = true }
 
-orml-vesting = { features = ["runtime-benchmarks"], workspace = true }
+orml-vesting = { workspace = true }
 
-frame-benchmarking = { features = ["runtime-benchmarks"], workspace = true }
-frame-support = { features = ["runtime-benchmarks"], workspace = true }
-frame-system = { features = ["runtime-benchmarks"], workspace = true }
-pallet-balances = {features = ["runtime-benchmarks"], workspace = true }
+frame-benchmarking = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-balances = { workspace = true }
 
 sp-io = { workspace = true }
 sp-std = { workspace = true }
-sp-runtime = { features = ["runtime-benchmarks"], workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]
+# Note: Either the `benchmarks!` or the `define_benchmarks!` macro demand the
+# existence of this feature flags, otherwise the benchmarks can't be found in the
+# node.
+runtime-benchmarks = [
+    "frame-benchmarking/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "orml-vesting/runtime-benchmarks",
+    "pallet-balances/frame-benchmarking",
+    "sp-runtime/runtime-benchmarks",
+]
 std = [
     "parity-scale-codec/std",
     "scale-info/std",

--- a/orml-pallets-benchmarking/src/lib.rs
+++ b/orml-pallets-benchmarking/src/lib.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg(feature = "runtime-benchmarks")]
 
 pub mod mock;
 pub mod utils;

--- a/orml-pallets-benchmarking/src/lib.rs
+++ b/orml-pallets-benchmarking/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod mock;
 pub mod utils;
 pub mod vesting;

--- a/orml-pallets-benchmarking/src/lib.rs
+++ b/orml-pallets-benchmarking/src/lib.rs
@@ -1,0 +1,19 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod mock;
+pub mod utils;
+pub mod vesting;

--- a/orml-pallets-benchmarking/src/mock.rs
+++ b/orml-pallets-benchmarking/src/mock.rs
@@ -1,0 +1,116 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(test)]
+
+use frame_support::{
+	parameter_types,
+	traits::{ConstU16, ConstU64},
+};
+use frame_system::{pallet_prelude::BlockNumberFor, EnsureSigned};
+use sp_runtime::{
+	testing::H256,
+	traits::{BlakeTwo256, BlockNumberProvider, IdentifyAccount, IdentityLookup, Verify},
+	BuildStorage, MultiSignature,
+};
+
+pub type MockSignature = MultiSignature;
+pub type MockAccountPublic = <MockSignature as Verify>::Signer;
+pub type MockAccountId = <MockAccountPublic as IdentifyAccount>::AccountId;
+pub type MockBlock = frame_system::mocking::MockBlock<Runtime>;
+pub type MockBalance = u64;
+
+frame_support::construct_runtime!(
+	pub struct Runtime {
+		System: frame_system = 0,
+		Balances: pallet_balances = 1,
+		Vesting: orml_vesting = 17,
+	}
+);
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = MockAccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<MockBalance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ConstU16<42>;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type Nonce = u32;
+	type Block = MockBlock;
+	type RuntimeTask = RuntimeTask;
+}
+
+parameter_types! {
+	pub static MockExistentialDeposit: MockBalance = 321;
+}
+
+impl pallet_balances::Config for Runtime {
+	type Balance = MockBalance;
+	type DustRemoval = ();
+	type RuntimeEvent = RuntimeEvent;
+	type ExistentialDeposit = MockExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type FreezeIdentifier = ();
+	type MaxFreezes = ();
+	type RuntimeHoldReason = ();
+	type RuntimeFreezeReason = ();
+}
+
+parameter_types! {
+	pub static MockBlockNumberProvider: u64 = 0;
+}
+
+impl BlockNumberProvider for MockBlockNumberProvider {
+	type BlockNumber = u64;
+
+	fn current_block_number() -> BlockNumberFor<Runtime> {
+		Self::get()
+	}
+}
+
+impl orml_vesting::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type MinVestedTransfer = MockExistentialDeposit;
+	type VestedTransferOrigin = EnsureSigned<MockAccountId>;
+	type WeightInfo = ();
+	type MaxVestingSchedules = frame_support::traits::ConstU32<100>;
+	type BlockNumberProvider = MockBlockNumberProvider;
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+	sp_io::TestExternalities::new(t)
+}

--- a/orml-pallets-benchmarking/src/mock.rs
+++ b/orml-pallets-benchmarking/src/mock.rs
@@ -41,6 +41,8 @@ frame_support::construct_runtime!(
 	}
 );
 
+impl crate::vesting::Config for Runtime {}
+
 impl frame_system::Config for Runtime {
 	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();

--- a/orml-pallets-benchmarking/src/mock.rs
+++ b/orml-pallets-benchmarking/src/mock.rs
@@ -66,6 +66,11 @@ impl frame_system::Config for Runtime {
 	type Nonce = u32;
 	type Block = MockBlock;
 	type RuntimeTask = RuntimeTask;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
 }
 
 parameter_types! {

--- a/orml-pallets-benchmarking/src/utils.rs
+++ b/orml-pallets-benchmarking/src/utils.rs
@@ -1,0 +1,45 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use frame_support::{sp_runtime::traits::StaticLookup, traits::Currency};
+
+pub type CurrencyFor<T> = <T as orml_vesting::Config>::Currency;
+pub type BalanceFor<T> =
+	<CurrencyFor<T> as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+pub type AccountIdFor<T> = <T as frame_system::Config>::AccountId;
+
+pub fn get_vesting_account<T: frame_system::Config>() -> AccountIdFor<T> {
+	account::<T>("VestingAccount")
+}
+
+fn account<T: frame_system::Config>(name: &'static str) -> T::AccountId {
+	let index = 0;
+	let seed = 0;
+	frame_benchmarking::account(name, index, seed)
+}
+
+pub fn lookup_of_account<T: frame_system::Config>(
+	who: AccountIdFor<T>,
+) -> <<T as frame_system::Config>::Lookup as StaticLookup>::Source {
+	<T as frame_system::Config>::Lookup::unlookup(who)
+}
+
+pub fn set_balance<T: orml_vesting::Config>(
+	account: AccountIdFor<T>,
+	schedule_amount: BalanceFor<T>,
+) {
+	CurrencyFor::<T>::make_free_balance_be(&account, schedule_amount);
+}

--- a/orml-pallets-benchmarking/src/vesting.rs
+++ b/orml-pallets-benchmarking/src/vesting.rs
@@ -29,7 +29,7 @@ use orml_vesting::{Call, VestingSchedule};
 
 pub struct Pallet<T: Config>(orml_vesting::Pallet<T>);
 
-pub trait Config: orml_vesting::Config + pallet_balances::Config {}
+pub trait Config: orml_vesting::Config {}
 
 pub type Schedule<T> = VestingSchedule<BlockNumberFor<T>, BalanceFor<T>>;
 

--- a/orml-pallets-benchmarking/src/vesting.rs
+++ b/orml-pallets-benchmarking/src/vesting.rs
@@ -25,9 +25,11 @@ use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use sp_runtime::Saturating;
 use sp_std::prelude::*;
 
-use orml_vesting::{Call, Config, VestingSchedule};
+use orml_vesting::{Call, VestingSchedule};
 
 pub struct Pallet<T: Config>(orml_vesting::Pallet<T>);
+
+pub trait Config: orml_vesting::Config + pallet_balances::Config {}
 
 pub type Schedule<T> = VestingSchedule<BlockNumberFor<T>, BalanceFor<T>>;
 
@@ -39,18 +41,13 @@ pub fn schedule<T: Config>(
 	period_count: u32,
 	per_period: BalanceFor<T>,
 ) -> Schedule<T> {
-	Schedule::<T> {
-		start: start.into(),
-		period: period.into(),
-		period_count,
-		per_period,
-	}
+	Schedule::<T> { start: start.into(), period: period.into(), period_count, per_period }
 }
 
 benchmarks! {
 	vested_transfer {
 		let schedule = schedule::<T>(
-			0, 2,3,<T as Config>::MinVestedTransfer::get()
+			0, 2,3,<T>::MinVestedTransfer::get()
 		);
 
 		let from = get_vesting_account::<T>();
@@ -67,10 +64,10 @@ benchmarks! {
 	}
 
 	claim {
-		let i in 1 .. <T as orml_vesting::Config>::MaxVestingSchedules::get();
+		let i in 1 .. <T>::MaxVestingSchedules::get();
 
 		let mut schedule = schedule::<T>(
-			0, 2,3,<T as Config>::MinVestedTransfer::get()
+			0, 2,3,<T>::MinVestedTransfer::get()
 		);
 
 		let from: AccountIdFor<T> = get_vesting_account::<T>();
@@ -93,10 +90,10 @@ benchmarks! {
 	}
 
 	update_vesting_schedules {
-		let i in 1 .. <T as orml_vesting::Config>::MaxVestingSchedules::get();
+		let i in 1 .. <T>::MaxVestingSchedules::get();
 
 		let mut schedule = schedule::<T>(
-			0, 2,3,<T as Config>::MinVestedTransfer::get()
+			0, 2,3,<T>::MinVestedTransfer::get()
 		);
 
 		let to: AccountIdFor<T>= account("to", 0, SEED);

--- a/orml-pallets-benchmarking/src/vesting.rs
+++ b/orml-pallets-benchmarking/src/vesting.rs
@@ -1,20 +1,18 @@
-// This file is part of Acala.
-
-// Copyright (C) 2020-2024 Acala Foundation.
-// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
 
 // This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
+// it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
 
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::utils::{
 	get_vesting_account, lookup_of_account, set_balance, AccountIdFor, BalanceFor, CurrencyFor,

--- a/orml-pallets-benchmarking/src/vesting.rs
+++ b/orml-pallets-benchmarking/src/vesting.rs
@@ -1,0 +1,124 @@
+// This file is part of Acala.
+
+// Copyright (C) 2020-2024 Acala Foundation.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::utils::{
+	get_vesting_account, lookup_of_account, set_balance, AccountIdFor, BalanceFor, CurrencyFor,
+};
+use frame_benchmarking::{account, benchmarks, whitelisted_caller};
+use frame_support::traits::{Currency, Get};
+use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
+use sp_runtime::Saturating;
+use sp_std::prelude::*;
+
+use orml_vesting::{Call, Config, VestingSchedule};
+
+pub struct Pallet<T: Config>(orml_vesting::Pallet<T>);
+
+pub type Schedule<T> = VestingSchedule<BlockNumberFor<T>, BalanceFor<T>>;
+
+const SEED: u32 = 0;
+
+pub fn schedule<T: Config>(
+	start: u32,
+	period: u32,
+	period_count: u32,
+	per_period: BalanceFor<T>,
+) -> Schedule<T> {
+	Schedule::<T> {
+		start: start.into(),
+		period: period.into(),
+		period_count,
+		per_period,
+	}
+}
+
+benchmarks! {
+	vested_transfer {
+		let schedule = schedule::<T>(
+			0, 2,3,<T as Config>::MinVestedTransfer::get()
+		);
+
+		let from = get_vesting_account::<T>();
+		let ed_times_two = CurrencyFor::<T>::minimum_balance().saturating_mul(2u32.into());
+		set_balance::<T>(from.clone(), schedule.total_amount().unwrap() * ed_times_two);
+
+		let to: AccountIdFor<T> = account("to", 0, SEED);
+		let to_lookup = lookup_of_account::<T>(to.clone());
+	}: _(RawOrigin::Signed(from), to_lookup, schedule.clone())
+	verify {
+		assert_eq!(CurrencyFor::<T>::total_balance(&to),
+			schedule.total_amount().unwrap()
+		);
+	}
+
+	claim {
+		let i in 1 .. <T as orml_vesting::Config>::MaxVestingSchedules::get();
+
+		let mut schedule = schedule::<T>(
+			0, 2,3,<T as Config>::MinVestedTransfer::get()
+		);
+
+		let from: AccountIdFor<T> = get_vesting_account::<T>();
+		let ed_times_two = CurrencyFor::<T>::minimum_balance().saturating_mul(2u32.into());
+		set_balance::<T>(from.clone(), schedule.total_amount().unwrap() * i.into() + ed_times_two);
+		let to: AccountIdFor<T> = whitelisted_caller();
+		let to_lookup = lookup_of_account::<T>(to.clone());
+
+		for _ in 0..i {
+			schedule.start = i.into();
+			orml_vesting::Pallet::<T>::vested_transfer(RawOrigin::Signed(from.clone()).into(), to_lookup.clone(), schedule.clone())?;
+		}
+		frame_system::Pallet::<T>::set_block_number(schedule.end().unwrap() + 1u32.into());
+	}: _(RawOrigin::Signed(to.clone()))
+	verify {
+		assert_eq!(
+			CurrencyFor::<T>::free_balance(&to),
+			schedule.total_amount().unwrap() * i.into(),
+		);
+	}
+
+	update_vesting_schedules {
+		let i in 1 .. <T as orml_vesting::Config>::MaxVestingSchedules::get();
+
+		let mut schedule = schedule::<T>(
+			0, 2,3,<T as Config>::MinVestedTransfer::get()
+		);
+
+		let to: AccountIdFor<T>= account("to", 0, SEED);
+		set_balance::<T>(to.clone(),schedule.total_amount().unwrap() * i.into());
+		let to_lookup = lookup_of_account::<T>(to.clone());
+
+		let mut schedules = vec![];
+		for _ in 0..i {
+			schedule.start = i.into();
+			schedules.push(schedule.clone());
+		}
+	}: _(RawOrigin::Root, to_lookup, schedules)
+	verify {
+		assert_eq!(
+			CurrencyFor::<T>::free_balance(&to),
+			schedule.total_amount().unwrap() * i.into()
+		);
+	}
+
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::new_test_ext(),
+		crate::mock::Runtime
+	);
+}


### PR DESCRIPTION
The ORML pallets use a different benchmarking paradigm, which doesn't really go well hand in hand with the one defined in substrate. So I have rewritten the orml-benchmarks to be generic, now we can use them the same way as we can use substrate benchmarks in the node.

Tested that the benchmarks work in
* https://github.com/ajuna-network/bajun-parachain/pull/24
* https://github.com/ajuna-network/ajuna-parachain/pull/15