### PR TITLE
[AJUN-347] Add dot4gravity and matchmaking pallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -272,7 +272,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -335,6 +335,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bitvec"
@@ -439,9 +445,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-expr"
@@ -467,7 +473,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -606,7 +612,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -649,7 +655,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -705,10 +711,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.59",
+ "syn 2.0.60",
  "termcolor",
  "toml",
  "walkdir",
+]
+
+[[package]]
+name = "dot4gravity"
+version = "0.1.0"
+source = "git+https://github.com/ajuna-network/ajuna-games?rev=polkadot-v0.9.20-dev#fea4a210dae6f6f0c8bfb02cc144aac9b861ffe9"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
 ]
 
 [[package]]
@@ -834,7 +849,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -860,7 +875,7 @@ dependencies = [
  "prettier-please",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -875,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "fixed-hash"
@@ -937,7 +952,7 @@ checksum = "97100a956a2cd152ad4e63a5ec7b5e58503653223a73fff6e916b910b37f12ed"
 dependencies = [
  "aquamarine",
  "array-bytes",
- "bitflags",
+ "bitflags 1.3.2",
  "docify",
  "environmental",
  "frame-metadata",
@@ -988,7 +1003,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1001,7 +1016,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1012,7 +1027,7 @@ checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1108,7 +1123,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1225,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hermit-abi"
@@ -1355,7 +1370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1422,9 +1437,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libsecp256k1"
@@ -1485,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1508,7 +1523,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1522,7 +1537,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1533,7 +1548,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1544,7 +1559,7 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1836,6 +1851,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-ajuna-board"
+version = "0.6.0"
+dependencies = [
+ "dot4gravity",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-ajuna-matchmaker",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-ajuna-matchmaker"
+version = "0.6.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-ajuna-nft-staking"
 version = "0.6.0"
 dependencies = [
@@ -2056,9 +2102,9 @@ checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2066,15 +2112,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2156,7 +2202,7 @@ dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2166,7 +2212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2182,7 +2228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22020dfcf177fcc7bf5deaf7440af371400c67c0de14c399938d8ed4fb4645d3"
 dependencies = [
  "proc-macro2",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2258,7 +2304,7 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2329,11 +2375,11 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -2353,7 +2399,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2606,9 +2652,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
@@ -2624,13 +2670,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2785,7 +2831,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2825,7 +2871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2dac7e47c7ddbb61efe196d5cce99f6ea88926c961fa39909bfeae46fc5a7b"
 dependencies = [
  "array-bytes",
- "bitflags",
+ "bitflags 1.3.2",
  "blake2",
  "bounded-collections",
  "bs58",
@@ -2887,7 +2933,7 @@ checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2898,7 +2944,7 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3054,7 +3100,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3187,7 +3233,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3279,9 +3325,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3305,22 +3351,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3366,7 +3412,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -3413,15 +3459,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.6",
+ "winnow 0.6.7",
 ]
 
 [[package]]
@@ -3443,7 +3489,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3651,7 +3697,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -3673,7 +3719,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3686,9 +3732,9 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wide"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a1851a719f11d1d2fea40e15c72f6c00de8c142d7ac47c1441cc7e4d0d5bc6"
+checksum = "0f0e39d2c603fdc0504b12b458cf1f34e0b937ed2f4f2dc20796e3e86f34e11f"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -3712,11 +3758,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3731,22 +3777,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3755,21 +3795,15 @@ version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3779,21 +3813,9 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3809,21 +3831,9 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3833,21 +3843,9 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3866,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]
@@ -3899,7 +3897,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3919,5 +3917,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,9 +445,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 
 [[package]]
 name = "cfg-expr"
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "dot4gravity"
 version = "0.1.0"
-source = "git+https://github.com/ajuna-network/ajuna-games?rev=polkadot-v0.9.20-dev#fea4a210dae6f6f0c8bfb02cc144aac9b861ffe9"
+source = "git+https://github.com/ajuna-network/ajuna-games?branch=main#7c4722c1f3e4b8d1c284a3f6d604ffb7f6be232c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ orml-vesting = { version = "0.10.0", default-features = false }
 pallet-ajuna-affiliates                   = { path = "pallets/ajuna-affiliates", default-features = false }
 pallet-ajuna-awesome-avatars              = { path = "pallets/ajuna-awesome-avatars", default-features = false }
 pallet-ajuna-battle-mogs                  = { path = "pallets/ajuna-battle-mogs", default-features = false }
+pallet-ajuna-board                        = { path = "pallets/ajuna-board", default-features = false }
+pallet-ajuna-matchmaker                   = { path = "pallets/ajuna-matchmaker", default-features = false }
 pallet-ajuna-awesome-avatars-benchmarking = { path = "pallets/ajuna-awesome-avatars/benchmarking", default-features = false }
 pallet-ajuna-nft-transfer                 = { path = "pallets/ajuna-nft-transfer", default-features = false }
 pallet-ajuna-nft-staking                  = { path = "pallets/ajuna-nft-staking", default-features = false }

--- a/pallets/ajuna-board/Cargo.toml
+++ b/pallets/ajuna-board/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "pallet-ajuna-board"
+description = "Ajuna Network pallet board pallet."
+
+authors.workspace    = true
+edition.workspace    = true
+homepage.workspace   = true
+repository.workspace = true
+version.workspace    = true
+
+[package.metadata.docs.rs]
+targets = [ "x86_64-unknown-linux-gnu" ]
+
+[dependencies]
+# Substrate (wasm)
+frame-benchmarking = { workspace = true, optional = true }
+frame-support      = { workspace = true }
+frame-system       = { workspace = true }
+parity-scale-codec = { workspace = true, features = [ "derive", "max-encoded-len" ] }
+scale-info         = { workspace = true, features = [ "derive" ] }
+sp-std             = { workspace = true }
+sp-runtime         = { workspace = true }
+
+# Ajuna pallets
+dot4gravity             = { default-features = false, git = "https://github.com/ajuna-network/ajuna-games", rev = "polkadot-v0.9.20-dev" }
+pallet-ajuna-matchmaker = { workspace = true }
+
+[dev-dependencies]
+sp-core = { workspace = true }
+sp-io   = { workspace = true }
+
+[features]
+default = [ "std" ]
+std = [
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "frame-benchmarking/std",
+    "frame-support/std",
+    "frame-system/std",
+    "dot4gravity/std",
+    "pallet-ajuna-matchmaker/std"
+]
+try-runtime = [ "frame-support/try-runtime" ]
+runtime-benchmarks = [ "frame-benchmarking" ]

--- a/pallets/ajuna-board/Cargo.toml
+++ b/pallets/ajuna-board/Cargo.toml
@@ -22,7 +22,7 @@ sp-std             = { workspace = true }
 sp-runtime         = { workspace = true }
 
 # Ajuna pallets
-dot4gravity             = { default-features = false, git = "https://github.com/ajuna-network/ajuna-games", rev = "polkadot-v0.9.20-dev" }
+dot4gravity             = { default-features = false, git = "https://github.com/ajuna-network/ajuna-games", branch = "main" }
 pallet-ajuna-matchmaker = { workspace = true }
 
 [dev-dependencies]

--- a/pallets/ajuna-board/README.md
+++ b/pallets/ajuna-board/README.md
@@ -1,0 +1,80 @@
+# Ajuna Network Pallet Board
+
+The Board Game pallet provides an implementation of a turn based board game. The game logic for the board game is implemented with the trait `TurnBasedGame` and provided as part of the configuration of this pallet. Extrinsics are used in the creation and playing of a game with state being temporarily stored on chain. The creation and playing of the game are delegated, after being gated by the pallet, to the core game logic.
+
+## Purpose
+
+Validation and state management of board games
+
+## Dependencies
+
+`ajuna-common` crate
+
+### Traits
+
+In order to use the pallet an implementation of `TurnBasedGame` would need to provided in the configuration.
+
+## Installation
+
+### Runtime `Cargo.toml`
+
+To add this pallet to your runtime, simply include the following to your runtime's `Cargo.toml` file:
+
+```TOML
+# external pallets
+pallet-ajuna-board = { default-features = false, git = "https://github.com/ajuna-network/Ajuna" }
+```
+
+and update your runtime's `std` feature to include this pallet:
+
+```TOML
+std = [
+    'pallet-ajuna-board/std',
+]
+```
+
+### Runtime `lib.rs`
+
+You should implement its trait with something like:
+
+```rust
+impl pallet_ajuna_board::Config for Test {
+	type Event = Event;
+	type Players = Players;
+	type BoardId = u32;
+	type PlayersTurn = u32;
+	type GameState = GameState;
+    type Game = Game;
+    type IdleBoardTimeout = IdleBoardTimeout;
+}
+```
+
+and include it in your `construct_runtime!` macro:
+
+```rust
+construct_runtime!(
+  pub enum Runtime where
+    Block = Block,
+    NodeBlock = Block,
+    UncheckedExtrinsic = UncheckedExtrinsic,
+  {
+    AjunaBoard: pallet_ajuna_board,
+  }
+);
+```
+
+### Genesis Configuration
+
+This `ajuna-board` pallet does not have any genesis configuration.
+
+### Types
+
+No additional types
+
+## Reference Docs
+
+You can view the reference docs for this pallet by running:
+
+```
+cargo doc --open
+```

--- a/pallets/ajuna-board/src/benchmarking.rs
+++ b/pallets/ajuna-board/src/benchmarking.rs
@@ -1,0 +1,112 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+use crate::{
+	dot4gravity::{Coordinates, Side, Turn},
+	Pallet as AjunaBoard,
+};
+use frame_benchmarking::{account, benchmarks};
+use frame_support::assert_ok;
+use frame_system::RawOrigin;
+use sp_runtime::SaturatedConversion;
+
+const SEED: u32 = 0;
+
+fn players<Player: Decode + Ord>(how_many: u32) -> Vec<Player> {
+	(0..how_many).into_iter().map(|i| account("player", i, SEED)).collect()
+}
+
+fn assert_last_event<T: Config>(event: <T as Config>::RuntimeEvent) {
+	frame_system::Pallet::<T>::assert_last_event(event.into());
+}
+
+fn create_new_game<T: Config>(players: Vec<T::AccountId>) {
+	assert_ok!(AjunaBoard::<T>::queue(RawOrigin::Signed(players[0].clone()).into()));
+	assert_ok!(AjunaBoard::<T>::queue(RawOrigin::Signed(players[1].clone()).into()));
+}
+
+fn create_and_play_until_win<T: Config>(players: Vec<T::AccountId>) {
+	// The seed below generates the following board, where o is empty and x is block:
+	// [o, o, o, o, o, o, o, o, o, o],
+	// [o, o, o, x, o, o, o, o, o, o],
+	// [o, o, x, o, o, o, o, o, o, o],
+	// [o, x, o, o, o, o, o, o, x, o],
+	// [o, o, o, o, x, o, x, o, o, o],
+	// [o, o, o, o, o, o, o, o, x, o],
+	// [o, o, o, x, o, o, x, o, o, o],
+	// [o, o, o, o, o, o, o, o, o, o],
+	// [x, o, o, o, o, o, o, o, o, o],
+	// [o, o, o, o, o, o, o, o, o, o],
+	Seed::<T>::put(7357);
+	create_new_game::<T>(players.clone());
+
+	let mut players = players.into_iter();
+	let player_1: T::RuntimeOrigin = RawOrigin::Signed(players.next().unwrap()).into();
+	let player_2: T::RuntimeOrigin = RawOrigin::Signed(players.next().unwrap()).into();
+
+	let each_player_drops_bomb = |coord: Coordinates| {
+		let drop_bomb: T::PlayersTurn = Turn::DropBomb(coord).into();
+		let _ = AjunaBoard::<T>::play(player_1.clone(), drop_bomb.clone());
+		let _ = AjunaBoard::<T>::play(player_2.clone(), drop_bomb);
+	};
+	let each_player_drops_stone = |win_position: (Side, u8), lose_position: (Side, u8)| {
+		let win: T::PlayersTurn = Turn::DropStone(win_position).into();
+		let lose: T::PlayersTurn = Turn::DropStone(lose_position).into();
+		let _ = AjunaBoard::<T>::play(player_1.clone(), win);
+		let _ = AjunaBoard::<T>::play(player_2.clone(), lose);
+	};
+
+	// Bomb phase
+	each_player_drops_bomb(Coordinates::new(9, 9));
+	each_player_drops_bomb(Coordinates::new(8, 8));
+	each_player_drops_bomb(Coordinates::new(7, 7));
+
+	// Stone phase
+	let win_position = (Side::North, 0);
+	let lose_position = (Side::North, 9);
+	each_player_drops_stone(win_position, lose_position);
+	each_player_drops_stone(win_position, lose_position);
+	each_player_drops_stone(win_position, lose_position);
+}
+
+benchmarks! {
+	play {
+		let players = players::<T::AccountId>(T::Players::get());
+		create_new_game::<T>(players.clone());
+
+		let player_1 = players.into_iter().next().unwrap();
+		let turn = Turn::DropBomb(Coordinates::new(1, 2));
+	}: play(RawOrigin::Signed(player_1), turn.into())
+
+	play_turn_until_finished {
+		let board_id = T::BoardId::saturated_from(0_u32);
+		let players = players::<T::AccountId>(T::Players::get());
+		create_and_play_until_win::<T>( players.clone());
+
+		let winner = players.into_iter().next().unwrap();
+		let turn = Turn::DropStone((Side::North, 0));
+	}: play(RawOrigin::Signed(winner.clone()), turn.into())
+	verify {
+		assert_last_event::<T>(Event::GameFinished { board_id, winner }.into());
+	}
+
+	impl_benchmark_test_suite!(
+		AjunaBoard,
+		crate::mock::new_test_ext(),
+		crate::mock::Test,
+	)
+}

--- a/pallets/ajuna-board/src/benchmarking.rs
+++ b/pallets/ajuna-board/src/benchmarking.rs
@@ -27,7 +27,7 @@ use sp_runtime::SaturatedConversion;
 const SEED: u32 = 0;
 
 fn players<Player: Decode + Ord>(how_many: u32) -> Vec<Player> {
-	(0..how_many).into_iter().map(|i| account("player", i, SEED)).collect()
+	(0..how_many).map(|i| account("player", i, SEED)).collect()
 }
 
 fn assert_last_event<T: Config>(event: <T as Config>::RuntimeEvent) {
@@ -81,6 +81,13 @@ fn create_and_play_until_win<T: Config>(players: Vec<T::AccountId>) {
 	each_player_drops_stone(win_position, lose_position);
 	each_player_drops_stone(win_position, lose_position);
 	each_player_drops_stone(win_position, lose_position);
+	each_player_drops_stone(win_position, lose_position);
+
+	let win_position = (Side::South, 1);
+	let lose_position = (Side::South, 7);
+	each_player_drops_stone(win_position, lose_position);
+	each_player_drops_stone(win_position, lose_position);
+	each_player_drops_stone(win_position, lose_position);
 }
 
 benchmarks! {
@@ -95,10 +102,10 @@ benchmarks! {
 	play_turn_until_finished {
 		let board_id = T::BoardId::saturated_from(0_u32);
 		let players = players::<T::AccountId>(T::Players::get());
-		create_and_play_until_win::<T>( players.clone());
+		create_and_play_until_win::<T>(players.clone());
 
 		let winner = players.into_iter().next().unwrap();
-		let turn = Turn::DropStone((Side::North, 0));
+		let turn = Turn::DropStone((Side::South, 1));
 	}: play(RawOrigin::Signed(winner.clone()), turn.into())
 	verify {
 		assert_last_event::<T>(Event::GameFinished { board_id, winner }.into());

--- a/pallets/ajuna-board/src/dot4gravity.rs
+++ b/pallets/ajuna-board/src/dot4gravity.rs
@@ -1,0 +1,194 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{Finished, TurnBasedGame};
+use dot4gravity::Game as Dot4Gravity;
+pub use dot4gravity::{Coordinates, GameState, Side};
+use frame_support::{pallet_prelude::*, Parameter};
+use sp_std::borrow::ToOwned;
+
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebugNoBound, TypeInfo, MaxEncodedLen)]
+pub enum Turn {
+	DropBomb(Coordinates),
+	DropStone((Side, u8)),
+}
+
+pub struct Game<Account>(PhantomData<Account>);
+impl<Account> TurnBasedGame for Game<Account>
+where
+	Account: Parameter,
+{
+	type Turn = Turn;
+	type Player = Account;
+	type State = GameState<Account>;
+
+	fn init(players: &[Self::Player], seed: Option<u32>) -> Option<Self::State> {
+		if let [player_1, player_2] = players {
+			Some(Dot4Gravity::new_game(player_1.to_owned(), player_2.to_owned(), seed))
+		} else {
+			None
+		}
+	}
+
+	fn get_last_player(state: &Self::State) -> Self::Player {
+		state
+			.last_move
+			.clone()
+			.map(|last_move_of| last_move_of.player)
+			.unwrap_or_else(|| state.next_player.clone())
+	}
+
+	fn get_next_player(state: &Self::State) -> Self::Player {
+		state.next_player.clone()
+	}
+
+	fn play_turn(
+		player: Self::Player,
+		state: Self::State,
+		turn: Self::Turn,
+	) -> Option<Self::State> {
+		match turn {
+			Turn::DropBomb(coords) => Dot4Gravity::drop_bomb(state, coords, player),
+			Turn::DropStone((side, pos)) => Dot4Gravity::drop_stone(state, player, side, pos),
+		}
+		.ok()
+	}
+
+	fn abort(state: Self::State, winner: Self::Player) -> Self::State {
+		let mut state = state;
+		state.winner = Some(winner);
+		state
+	}
+
+	fn is_finished(state: &Self::State) -> Finished<Self::Player> {
+		match state.winner.clone() {
+			Some(winner) => Finished::Winner(winner),
+			None => Finished::No,
+		}
+	}
+
+	fn seed(state: &Self::State) -> Option<u32> {
+		Some(state.seed)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const THE_NUMBER: Guess = 42;
+	const MAX_PLAYERS: usize = 2;
+	const PLAYER_1: u32 = 1;
+	const PLAYER_2: u32 = 2;
+
+	type Guess = u32;
+	type Account = u32;
+
+	struct MockGame;
+
+	#[derive(Encode, Decode, Copy, Clone)]
+	struct MockGameState {
+		pub players: [Account; MAX_PLAYERS],
+		pub next_player: u8,
+		pub solution: Guess,
+		pub winner: Option<Account>,
+	}
+
+	impl TurnBasedGame for MockGame {
+		type Turn = Guess;
+		type Player = Account;
+		type State = MockGameState;
+
+		fn init(players: &[Self::Player], _seed: Option<u32>) -> Option<Self::State> {
+			match players.to_vec().try_into() {
+				Ok(players) => Some(MockGameState {
+					players,
+					next_player: 0,
+					solution: THE_NUMBER,
+					winner: None,
+				}),
+				_ => None,
+			}
+		}
+
+		fn get_last_player(state: &Self::State) -> Self::Player {
+			let next_player_index = (state.next_player as usize + 1) % state.players.len();
+			state.players[next_player_index]
+		}
+
+		fn get_next_player(state: &Self::State) -> Self::Player {
+			state.players[state.next_player as usize]
+		}
+
+		fn play_turn(
+			player: Self::Player,
+			state: Self::State,
+			turn: Self::Turn,
+		) -> Option<Self::State> {
+			if state.winner.is_some() ||
+				!state.players.contains(&player) ||
+				state.players[state.next_player as usize] != player
+			{
+				return None
+			}
+
+			let mut state = state;
+			state.next_player = (state.next_player + 1) % state.players.len() as u8;
+
+			if state.solution == turn {
+				state.winner = Some(player);
+			}
+
+			Some(state)
+		}
+
+		fn abort(state: Self::State, winner: Self::Player) -> Self::State {
+			let mut state = state;
+			state.winner = Some(winner);
+			state
+		}
+
+		fn is_finished(state: &Self::State) -> Finished<Self::Player> {
+			let winner = &state.winner;
+			match winner {
+				None => Finished::No,
+				Some(winner) => Finished::Winner(*winner),
+			}
+		}
+
+		fn seed(_state: &Self::State) -> Option<u32> {
+			None
+		}
+	}
+
+	#[test]
+	fn guessing_works() {
+		let state = MockGame::init(&[PLAYER_1, PLAYER_2], None).unwrap();
+		assert_eq!(MockGame::get_next_player(&state), PLAYER_1);
+
+		let state = MockGame::play_turn(PLAYER_1, state, 1).unwrap();
+		assert_eq!(MockGame::get_last_player(&state), PLAYER_1);
+		assert_eq!(MockGame::get_next_player(&state), PLAYER_2);
+
+		let state = MockGame::play_turn(PLAYER_2, state, THE_NUMBER).unwrap();
+		assert_eq!(MockGame::is_finished(&state), Finished::Winner(PLAYER_2));
+
+		// new game
+		let state = MockGame::init(&[PLAYER_1, PLAYER_2], None).unwrap();
+		let state = MockGame::abort(state, PLAYER_1);
+		assert_eq!(MockGame::is_finished(&state), Finished::Winner(PLAYER_1));
+	}
+}

--- a/pallets/ajuna-board/src/lib.rs
+++ b/pallets/ajuna-board/src/lib.rs
@@ -1,0 +1,206 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Codec, Decode, Encode};
+use frame_support::pallet_prelude::*;
+use frame_system::{ensure_signed, pallet_prelude::*};
+pub use pallet::*;
+use pallet_ajuna_matchmaker::{Matchmaker, DEFAULT_BRACKET};
+use sp_runtime::traits::{AtLeast32BitUnsigned, BlockNumberProvider, Saturating};
+use sp_std::vec::Vec;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+pub mod dot4gravity;
+mod types;
+use types::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type Matchmaker: Matchmaker<Player = Self::AccountId>;
+		/// Board id
+		type BoardId: Copy + Default + AtLeast32BitUnsigned + Parameter + MaxEncodedLen;
+		/// A Turn for the game
+		type PlayersTurn: Member + Parameter + From<dot4gravity::Turn>;
+		/// The state of the board
+		type GameState: Codec + TypeInfo + MaxEncodedLen + Clone;
+		/// A turn based game
+		type Game: TurnBasedGame<
+			Player = Self::AccountId,
+			Turn = Self::PlayersTurn,
+			State = Self::GameState,
+		>;
+		/// Number of players required for a game.
+		#[pallet::constant]
+		type Players: Get<u32>;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub (super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub (super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Game has been created
+		GameCreated {
+			board_id: T::BoardId,
+			players: Vec<T::AccountId>,
+		},
+		/// Game has finished with the winner
+		GameFinished {
+			board_id: T::BoardId,
+			winner: T::AccountId,
+		},
+
+		NoMatchFound,
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		InvalidGameState,
+		InvalidTurn,
+		InvalidPlayers,
+		NotPlaying,
+		AlreadyInGame,
+		AlreadyQueued,
+		UnknownBoard,
+		BoardInUse,
+	}
+
+	#[pallet::storage]
+	pub type NextBoardId<T: Config> = StorageValue<_, T::BoardId, ValueQuery>;
+
+	#[pallet::storage]
+	pub type BoardGames<T: Config> = StorageMap<_, Identity, T::BoardId, BoardGameOf<T>>;
+
+	/// Players in boards
+	#[pallet::storage]
+	pub type PlayerBoards<T: Config> = StorageMap<_, Identity, T::AccountId, T::BoardId>;
+
+	/// Random seed
+	#[pallet::storage]
+	pub type Seed<T> = StorageValue<_, u32>;
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::weight(12_345)]
+		pub fn queue(origin: OriginFor<T>) -> DispatchResult {
+			let player = ensure_signed(origin)?;
+			ensure!(T::Matchmaker::enqueue(player, DEFAULT_BRACKET), Error::<T>::AlreadyQueued);
+			if let Some(players) = T::Matchmaker::try_match(DEFAULT_BRACKET, T::Players::get()) {
+				Self::create_game(players)?;
+			};
+			Ok(())
+		}
+
+		#[pallet::weight(12_345)]
+		pub fn play(origin: OriginFor<T>, turn: T::PlayersTurn) -> DispatchResult {
+			let player = ensure_signed(origin)?;
+			let board_id = PlayerBoards::<T>::get(&player).ok_or(Error::<T>::NotPlaying)?;
+
+			let mut board_game = BoardGames::<T>::get(board_id).ok_or(Error::<T>::UnknownBoard)?;
+			let new_state = T::Game::play_turn(player, board_game.state, turn)
+				.ok_or(Error::<T>::InvalidTurn)?;
+
+			if let Finished::Winner::<T::AccountId>(winner) = T::Game::is_finished(&new_state) {
+				Self::finish_game(board_id, winner)?;
+			} else {
+				board_game.state = new_state;
+				BoardGames::<T>::insert(board_id, board_game);
+			}
+			Ok(())
+		}
+
+		#[pallet::weight(12_345)]
+		pub fn clear_board(origin: OriginFor<T>, board_id: T::BoardId) -> DispatchResult {
+			ensure_root(origin)?;
+
+			BoardGames::<T>::try_mutate_exists(board_id, |maybe_board_game| {
+				if let Some(board_game) = maybe_board_game {
+					ensure!(
+						board_game
+							.players
+							.iter()
+							.all(|player| PlayerBoards::<T>::get(player) != Some(board_id)),
+						Error::<T>::BoardInUse
+					);
+
+					*maybe_board_game = None;
+
+					Ok(())
+				} else {
+					Err(Error::<T>::UnknownBoard)
+				}
+			})
+			.map_err(|err| err.into())
+		}
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	fn create_game(players: Vec<PlayerOf<T>>) -> DispatchResult {
+		for player in &players {
+			ensure!(PlayerBoards::<T>::get(player).is_none(), Error::<T>::AlreadyInGame);
+		}
+
+		let board_id = NextBoardId::<T>::get();
+		let seed = Seed::<T>::get();
+		let state = T::Game::init(&players, seed).ok_or(Error::<T>::InvalidGameState)?;
+		Self::seed_for_next(&state);
+
+		let bounded_players = players.clone().try_into().map_err(|_| Error::<T>::InvalidPlayers)?;
+		let now = frame_system::Pallet::<T>::current_block_number();
+		let board_game = BoardGameOf::<T>::new(board_id, bounded_players, state, now);
+
+		players.iter().for_each(|player| PlayerBoards::<T>::insert(player, board_id));
+		BoardGames::<T>::insert(board_id, board_game);
+		NextBoardId::<T>::mutate(|board_id| board_id.saturating_inc());
+		Self::deposit_event(Event::GameCreated { board_id, players });
+		Ok(())
+	}
+
+	fn seed_for_next(game_state: &T::GameState) {
+		match T::Game::seed(game_state) {
+			Some(seed) => Seed::<T>::put(seed),
+			None => Seed::<T>::kill(),
+		}
+	}
+
+	fn finish_game(board_id: T::BoardId, winner: PlayerOf<T>) -> DispatchResult {
+		BoardGames::<T>::get(board_id)
+			.ok_or(Error::<T>::UnknownBoard)?
+			.players
+			.iter()
+			.for_each(PlayerBoards::<T>::remove);
+		Self::deposit_event(Event::GameFinished { board_id, winner });
+		Ok(())
+	}
+}

--- a/pallets/ajuna-board/src/mock.rs
+++ b/pallets/ajuna-board/src/mock.rs
@@ -1,0 +1,98 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{self as pallet_ajuna_board};
+use frame_support::parameter_types;
+use frame_system::mocking::{MockBlock, MockUncheckedExtrinsic};
+use sp_core::H256;
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+use sp_std::prelude::*;
+
+type MockAccountId = u32;
+
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = MockBlock<Test>,
+		NodeBlock = MockBlock<Test>,
+		UncheckedExtrinsic = MockUncheckedExtrinsic<Test>,
+	{
+		System: frame_system,
+		AjunaMatchmaker: pallet_ajuna_matchmaker,
+		AjunaBoard: pallet_ajuna_board,
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const SS58Prefix: u8 = 42;
+}
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = MockAccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+impl pallet_ajuna_matchmaker::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+}
+
+parameter_types! {
+	pub const Players: u8 = 2;
+}
+
+impl pallet_ajuna_board::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type Matchmaker = pallet_ajuna_matchmaker::Matchmaking<Self>;
+	type BoardId = u32;
+	type PlayersTurn = crate::dot4gravity::Turn;
+	type GameState = crate::dot4gravity::GameState<MockAccountId>;
+	type Game = crate::dot4gravity::Game<MockAccountId>;
+	type Players = Players;
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let config = GenesisConfig { system: Default::default() };
+	let mut ext: sp_io::TestExternalities = config.build_storage().unwrap().into();
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}

--- a/pallets/ajuna-board/src/tests.rs
+++ b/pallets/ajuna-board/src/tests.rs
@@ -1,0 +1,126 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{dot4gravity::*, mock::*, *};
+use frame_support::{assert_noop, assert_ok};
+
+const ALICE: u32 = 1;
+const BOB: u32 = 2;
+const ERIN: u32 = 5;
+
+const BOARD_ID: u32 = 0;
+const TEST_COORD: Coordinates = Coordinates::new(0, 0);
+// The seed below generates the following board, where o is empty and x is block:
+// [o, o, o, o, o, o, o, o, o, o],
+// [o, o, o, x, o, o, o, o, o, o],
+// [o, o, x, o, o, o, o, o, o, o],
+// [o, x, o, o, o, o, o, o, x, o],
+// [o, o, o, o, x, o, x, o, o, o],
+// [o, o, o, o, o, o, o, o, x, o],
+// [o, o, o, x, o, o, x, o, o, o],
+// [o, o, o, o, o, o, o, o, o, o],
+// [x, o, o, o, o, o, o, o, o, o],
+// [o, o, o, o, o, o, o, o, o, o],
+const TEST_SEED: u32 = 7357;
+
+#[test]
+fn queue_works() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(AjunaBoard::queue(RuntimeOrigin::signed(ALICE)));
+		System::assert_last_event(RuntimeEvent::AjunaMatchmaker(
+			pallet_ajuna_matchmaker::Event::Queued(ALICE),
+		));
+		assert_noop!(AjunaBoard::queue(RuntimeOrigin::signed(ALICE)), Error::<Test>::AlreadyQueued);
+	});
+}
+
+#[test]
+fn queue_creates_game_on_successful_match() {
+	new_test_ext().execute_with(|| {
+		// nothing persisted before matchmaking
+		assert!(PlayerBoards::<Test>::get(ALICE).is_none());
+		assert!(PlayerBoards::<Test>::get(BOB).is_none());
+		assert!(BoardGames::<Test>::get(BOARD_ID).is_none());
+		assert_eq!(NextBoardId::<Test>::get(), BOARD_ID);
+
+		// queue twice to matchmake
+		assert_ok!(AjunaBoard::queue(RuntimeOrigin::signed(ALICE)));
+		assert_ok!(AjunaBoard::queue(RuntimeOrigin::signed(BOB)));
+
+		let players = vec![ALICE, BOB];
+		System::assert_has_event(RuntimeEvent::AjunaMatchmaker(
+			pallet_ajuna_matchmaker::Event::Matched(players.clone()),
+		));
+		System::assert_last_event(RuntimeEvent::AjunaBoard(crate::Event::GameCreated {
+			board_id: BOARD_ID,
+			players,
+		}));
+
+		assert!(PlayerBoards::<Test>::get(ALICE).is_some());
+		assert!(PlayerBoards::<Test>::get(BOB).is_some());
+		assert!(BoardGames::<Test>::get(BOARD_ID).is_some());
+		assert_eq!(NextBoardId::<Test>::get(), BOARD_ID + 1);
+	});
+}
+
+#[test]
+fn play_works() {
+	new_test_ext().execute_with(|| {
+		Seed::<Test>::put(TEST_SEED);
+		assert_ok!(AjunaBoard::queue(RuntimeOrigin::signed(BOB)));
+		assert_ok!(AjunaBoard::queue(RuntimeOrigin::signed(ERIN)));
+		assert_noop!(
+			AjunaBoard::play(RuntimeOrigin::signed(ALICE), Turn::DropBomb(TEST_COORD)),
+			Error::<Test>::NotPlaying
+		);
+
+		// Bomb phase
+		let drop_bomb = |coord: Coordinates| {
+			let _ = AjunaBoard::play(RuntimeOrigin::signed(BOB), Turn::DropBomb(coord));
+			let _ = AjunaBoard::play(RuntimeOrigin::signed(ERIN), Turn::DropBomb(coord));
+		};
+		drop_bomb(Coordinates::new(9, 9));
+		drop_bomb(Coordinates::new(8, 8));
+		drop_bomb(Coordinates::new(7, 7));
+
+		// Play phase
+		let drop_stone = || {
+			let win = (Side::North, 0);
+			let loss = (Side::North, 9);
+			let _ = AjunaBoard::play(RuntimeOrigin::signed(BOB), Turn::DropStone(win));
+			let _ = AjunaBoard::play(RuntimeOrigin::signed(ERIN), Turn::DropStone(loss));
+		};
+		drop_stone();
+		drop_stone();
+		drop_stone();
+		drop_stone();
+
+		// check if game has finished
+		System::assert_last_event(RuntimeEvent::AjunaBoard(crate::Event::GameFinished {
+			board_id: BOARD_ID,
+			winner: BOB,
+		}));
+		assert_ne!(Seed::<Test>::get(), Some(TEST_SEED));
+		assert!(PlayerBoards::<Test>::get(ALICE).is_none());
+		assert!(PlayerBoards::<Test>::get(BOB).is_none());
+		assert!(BoardGames::<Test>::get(BOARD_ID).is_some());
+
+		// We clear the board
+		assert_ok!(AjunaBoard::clear_board(RuntimeOrigin::root(), BOARD_ID));
+
+		assert!(BoardGames::<Test>::get(BOARD_ID).is_none());
+	})
+}

--- a/pallets/ajuna-board/src/types.rs
+++ b/pallets/ajuna-board/src/types.rs
@@ -1,0 +1,77 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+
+pub(crate) type PlayerOf<T> = <<T as Config>::Game as TurnBasedGame>::Player;
+pub(crate) type BoundedPlayersOf<T> =
+	BoundedVec<<T as frame_system::Config>::AccountId, <T as Config>::Players>;
+pub(crate) type BoardGameOf<T> = BoardGame<
+	<T as Config>::BoardId,
+	<T as Config>::GameState,
+	BoundedPlayersOf<T>,
+	BlockNumberFor<T>,
+>;
+
+/// The state of the board game
+#[derive(Clone, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct BoardGame<BoardId, State, Players, Start> {
+	board_id: BoardId,
+	/// Players in the game
+	pub(crate) players: Players,
+	/// The current state of the game
+	pub state: State,
+	/// When the game started
+	pub started: Start,
+}
+
+impl<BoardId, State, Players, Start> BoardGame<BoardId, State, Players, Start> {
+	/// Create a BoardGame
+	pub(crate) fn new(board_id: BoardId, players: Players, state: State, started: Start) -> Self {
+		Self { board_id, players, state, started }
+	}
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Finished<Player> {
+	No,
+	Winner(Player),
+}
+
+pub trait TurnBasedGame {
+	/// Represents a turn in the game
+	type Turn;
+	/// Represents a player in the game
+	type Player: Clone;
+	/// The state of the game
+	type State: Codec;
+	/// Initialise turn based game with players returning the initial state
+	fn init(players: &[Self::Player], seed: Option<u32>) -> Option<Self::State>;
+	/// Get the player that played its turn last
+	fn get_last_player(state: &Self::State) -> Self::Player;
+	/// Get the player that should play its turn next
+	fn get_next_player(state: &Self::State) -> Self::Player;
+	/// Play a turn with player on the current state returning the new state
+	fn play_turn(player: Self::Player, state: Self::State, turn: Self::Turn)
+		-> Option<Self::State>;
+	/// Forces the termination of a game with a designated winner, useful when games
+	/// get stalled for some reason.
+	fn abort(state: Self::State, winner: Self::Player) -> Self::State;
+	/// Check if the game has finished with winner
+	fn is_finished(state: &Self::State) -> Finished<Self::Player>;
+	/// Get seed if any
+	fn seed(state: &Self::State) -> Option<u32>;
+}

--- a/pallets/ajuna-matchmaker/Cargo.toml
+++ b/pallets/ajuna-matchmaker/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "pallet-ajuna-matchmaker"
+description = "Ajuna Network pallet matchmaker for creating matches between players."
+
+authors.workspace    = true
+edition.workspace    = true
+homepage.workspace   = true
+repository.workspace = true
+version.workspace    = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+# Substrate (wasm)
+frame-support      = { workspace = true }
+frame-system       = { workspace = true }
+parity-scale-codec = { workspace = true, features = [ "derive", "max-encoded-len" ] }
+scale-info         = { workspace = true, features = [ "derive" ] }
+sp-std             = { workspace = true }
+sp-runtime         = { workspace = true }
+
+[dev-dependencies]
+sp-core = { workspace = true }
+sp-io   = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "frame-support/std",
+    "frame-system/std",
+]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/ajuna-matchmaker/src/brackets.rs
+++ b/pallets/ajuna-matchmaker/src/brackets.rs
@@ -1,0 +1,224 @@
+//! # Matchmaker Brackets (based on Transient RingBuffer implementation)
+//!
+//! This pallet provides a trait and implementation for a brackets ranked system that
+//! abstracts over storage items and presents them as multiple brackets, with each
+//! having a FIFO queue. This allows an implementation of a matchmaker over different
+//! ranking brackets.
+//!
+//! Note: You might want to introduce a helper function that wraps the complex
+//! types and just returns the boxed trait object.
+use core::marker::PhantomData;
+use frame_support::storage::{StorageDoubleMap, StorageMap, StorageValue};
+use parity_scale_codec::{Codec, EncodeLike};
+use sp_std::vec::Vec;
+
+/// Trait object presenting the brackets interface.
+pub trait BracketsTrait<ItemKey, Item>
+where
+	ItemKey: Codec + EncodeLike,
+	Item: Codec + EncodeLike,
+{
+	/// Store all changes made in the underlying storage.
+	///
+	/// Data is not guaranteed to be consistent before this call.
+	///
+	/// Implementation note: Call in `drop` to increase ergonomics.
+	fn commit(&self);
+	/// Push an item onto the end of the queue.
+	fn push(&mut self, b: Bracket, j: ItemKey, i: Item) -> bool;
+	/// Pop an item from the start of the queue.
+	///
+	/// Returns `None` if the queue is empty.
+	fn pop(&mut self, b: Bracket) -> Option<Item>;
+	/// Return whether the queue is empty.
+	fn is_empty(&self, b: Bracket) -> bool;
+	/// Return the size of the brackets queue.
+	fn size(&self, b: Bracket) -> BufferIndex;
+	/// Return whether the item_key is queued or not.
+	fn is_queued(&self, j: ItemKey) -> bool;
+}
+
+// There is no equivalent trait in std so we create one.
+pub trait WrappingOps {
+	fn wrapping_add(self, rhs: Self) -> Self;
+	fn wrapping_sub(self, rhs: Self) -> Self;
+}
+
+macro_rules! impl_wrapping_ops {
+	($type:ty) => {
+		impl WrappingOps for $type {
+			fn wrapping_add(self, rhs: Self) -> Self {
+				self.wrapping_add(rhs)
+			}
+			fn wrapping_sub(self, rhs: Self) -> Self {
+				self.wrapping_sub(rhs)
+			}
+		}
+	};
+}
+
+impl_wrapping_ops!(u8);
+impl_wrapping_ops!(u16);
+impl_wrapping_ops!(u32);
+impl_wrapping_ops!(u64);
+
+pub type BufferIndex = u16;
+pub type BufferIndexVector = Vec<(BufferIndex, BufferIndex)>;
+pub type Bracket = u8;
+
+/// Transient backing data that is the backbone of the trait object.
+pub struct BracketsTransient<ItemKey, Item, C, B, M, N>
+where
+	ItemKey: Codec + EncodeLike,
+	Item: Codec + EncodeLike,
+	C: StorageValue<Bracket, Query = Bracket>,
+	B: StorageMap<Bracket, (BufferIndex, BufferIndex), Query = (BufferIndex, BufferIndex)>,
+	M: StorageDoubleMap<Bracket, BufferIndex, ItemKey, Query = Option<ItemKey>>,
+	N: StorageDoubleMap<Bracket, ItemKey, Item, Query = Option<Item>>,
+{
+	index_vector: BufferIndexVector,
+	_phantom: PhantomData<(ItemKey, Item, C, B, M, N)>,
+}
+
+impl<ItemKey, Item, C, B, M, N> BracketsTransient<ItemKey, Item, C, B, M, N>
+where
+	ItemKey: Codec + EncodeLike,
+	Item: Codec + EncodeLike,
+	C: StorageValue<Bracket, Query = Bracket>,
+	B: StorageMap<Bracket, (BufferIndex, BufferIndex), Query = (BufferIndex, BufferIndex)>,
+	M: StorageDoubleMap<Bracket, BufferIndex, ItemKey, Query = Option<ItemKey>>,
+	N: StorageDoubleMap<Bracket, ItemKey, Item, Query = Option<Item>>,
+{
+	/// Create a new `BracketsTransient` that backs the brackets implementation.
+	///
+	/// Initializes itself from the bounds storage `B`.
+	pub fn new() -> BracketsTransient<ItemKey, Item, C, B, M, N> {
+		// get brackets count
+		let brackets_count = C::get();
+
+		// initialize all brackets
+		let mut index_vector = Vec::new();
+		for i in 0..brackets_count {
+			let (start, end) = B::get(i);
+			index_vector.push((start, end));
+		}
+
+		BracketsTransient { index_vector, _phantom: PhantomData }
+	}
+}
+
+impl<ItemKey, Item, C, B, M, N> Drop for BracketsTransient<ItemKey, Item, C, B, M, N>
+where
+	ItemKey: Codec + EncodeLike,
+	Item: Codec + EncodeLike,
+	C: StorageValue<Bracket, Query = Bracket>,
+	B: StorageMap<Bracket, (BufferIndex, BufferIndex), Query = (BufferIndex, BufferIndex)>,
+	M: StorageDoubleMap<Bracket, BufferIndex, ItemKey, Query = Option<ItemKey>>,
+	N: StorageDoubleMap<Bracket, ItemKey, Item, Query = Option<Item>>,
+{
+	/// Commit on `drop`.
+	fn drop(&mut self) {
+		<Self as BracketsTrait<ItemKey, Item>>::commit(self);
+	}
+}
+
+/// Brackets implementation based on `BracketsTransient`
+impl<ItemKey, Item, C, B, M, N> BracketsTrait<ItemKey, Item>
+	for BracketsTransient<ItemKey, Item, C, B, M, N>
+where
+	ItemKey: Codec + EncodeLike,
+	Item: Codec + EncodeLike,
+	C: StorageValue<Bracket, Query = Bracket>,
+	B: StorageMap<Bracket, (BufferIndex, BufferIndex), Query = (BufferIndex, BufferIndex)>,
+	M: StorageDoubleMap<Bracket, BufferIndex, ItemKey, Query = Option<ItemKey>>,
+	N: StorageDoubleMap<Bracket, ItemKey, Item, Query = Option<Item>>,
+{
+	/// Commit the (potentially) changed bounds to storage.
+	fn commit(&self) {
+		// commit indicies on all brackets
+		for i in 0..self.index_vector.len() {
+			let (v_start, v_end) = self.index_vector[i];
+			B::insert(i as Bracket, (v_start, v_end));
+		}
+	}
+
+	/// Push an item onto the end of the queue.
+	///
+	/// Will insert the new item, but will not update the bounds in storage.
+	fn push(&mut self, bracket: Bracket, item_key: ItemKey, item: Item) -> bool {
+		let (mut v_start, mut v_end) = self.index_vector[bracket as usize];
+
+		// ensure that the key is not queued
+		for i in 0..self.index_vector.len() {
+			if N::contains_key(i as Bracket, &item_key) {
+				return false;
+			}
+		}
+
+		// insert the item key and the item
+		N::insert(bracket, &item_key, item);
+		M::insert(bracket, v_end, item_key);
+
+		// this will intentionally overflow and wrap around when bonds_end
+		// reaches `Index::max_value` because we want a brackets.
+		let next_index = v_end.wrapping_add(1 as u16);
+		if next_index == v_start {
+			// queue presents as empty but is not
+			// --> overwrite the oldest item in the FIFO brackets
+			v_start = v_start.wrapping_add(1 as u16);
+		}
+		v_end = next_index;
+
+		self.index_vector[bracket as usize] = (v_start, v_end);
+		true
+	}
+
+	/// Pop an item from the start of the queue.
+	///
+	/// Will remove the item, but will not update the bounds in storage.
+	fn pop(&mut self, bracket: Bracket) -> Option<Item> {
+		if self.is_empty(bracket) {
+			return None;
+		}
+
+		let (mut v_start, v_end) = self.index_vector[bracket as usize];
+
+		M::take(bracket, v_start)
+			.and_then(|item_key| N::take(bracket, item_key))
+			.map(|item| {
+				v_start = v_start.wrapping_add(1 as u16);
+				self.index_vector[bracket as usize] = (v_start, v_end);
+				item
+			})
+	}
+
+	/// Return whether to consider the queue empty.
+	fn is_empty(&self, bracket: Bracket) -> bool {
+		let (v_start, v_end) = self.index_vector[bracket as usize];
+
+		v_start == v_end
+	}
+
+	/// Return the current size of the ring buffer as a BufferIndex.
+	fn size(&self, bracket: Bracket) -> BufferIndex {
+		let (v_start, v_end) = self.index_vector[bracket as usize];
+
+		if v_start <= v_end {
+			v_end - v_start
+		} else {
+			(BufferIndex::MAX - v_start) + v_end
+		}
+	}
+
+	/// Return whether the item_key is queued or not.
+	fn is_queued(&self, item_key: ItemKey) -> bool {
+		// check all brackets if key is queued
+		for i in 0..self.index_vector.len() {
+			if N::contains_key(i as Bracket, &item_key) {
+				return true;
+			}
+		}
+
+		false
+	}
+}

--- a/pallets/ajuna-matchmaker/src/lib.rs
+++ b/pallets/ajuna-matchmaker/src/lib.rs
@@ -33,7 +33,7 @@ pub enum MatchingType {
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
 pub struct PlayerStruct<AccountId> {
-	account: AccountId,
+	pub account: AccountId,
 }
 
 #[frame_support::pallet]

--- a/pallets/ajuna-matchmaker/src/lib.rs
+++ b/pallets/ajuna-matchmaker/src/lib.rs
@@ -1,0 +1,292 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+/// Edit this file to define custom logic or remove it if it is not needed.
+/// Learn more about FRAME and the core library of Substrate FRAME pallets:
+/// <https://substrate.dev/docs/en/knowledgebase/runtime/frame>
+pub use pallet::*;
+
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_std::{boxed::Box, vec::Vec};
+
+use frame_support::traits::Get;
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+mod brackets;
+
+use brackets::{Bracket, BracketsTrait, BracketsTransient, BufferIndex};
+
+#[derive(Encode, Decode, Clone, PartialEq, TypeInfo)]
+pub enum MatchingType {
+	// ranked matches, if no one in bracket drop down
+	Simple,
+	// only allow same bracket matches
+	Same,
+	// take only one of one bracket
+	Mix,
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
+pub struct PlayerStruct<AccountId> {
+	account: AccountId,
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+
+	// important to use outside structs and consts
+	use super::*;
+
+	/// Configure the pallet by specifying the parameters and types on which it depends.
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// Because this pallet emits events, it depends on the runtime's definition of an event.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// Constant that indicates how many players are needed to create a new match.
+		#[pallet::constant]
+		type AmountPlayers: Get<u8>;
+
+		/// Constant that indicates how many ranking brackets exist for players.
+		#[pallet::constant]
+		type AmountBrackets: Get<u8>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::type_value]
+	pub fn BracketsCountDefault<T: Config>() -> u8 {
+		T::AmountBrackets::get()
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn brackets_count)]
+	pub type BracketsCount<T: Config> = StorageValue<_, u8, ValueQuery, BracketsCountDefault<T>>;
+
+	// Default value for Nonce
+	#[pallet::type_value]
+	pub fn BracketIndicesDefault<T: Config>() -> (BufferIndex, BufferIndex) {
+		(0, 0)
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn indices)]
+	pub type BracketIndices<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		Bracket,
+		(BufferIndex, BufferIndex),
+		ValueQuery,
+		BracketIndicesDefault<T>,
+	>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn index_key)]
+	pub type BracketIndexKeyMap<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		Bracket,
+		Blake2_128Concat,
+		BufferIndex,
+		T::AccountId,
+		OptionQuery,
+	>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn key_value)]
+	pub type BracketKeyValueMap<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		Bracket,
+		Blake2_128Concat,
+		T::AccountId,
+		PlayerStruct<T::AccountId>,
+		OptionQuery,
+	>;
+
+	// Pallets use events to inform users when important changes are made.
+	// https://substrate.dev/docs/en/knowledgebase/runtime/events
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Queued event
+		Queued(PlayerStruct<T::AccountId>),
+		/// Popped event
+		Popped(PlayerStruct<T::AccountId>),
+	}
+
+	// Errors inform users that something went wrong.
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Player has already queued, can not queue twice
+		AlreadyQueued,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+}
+
+impl<T: Config> Pallet<T> {
+	/// Constructor function so we don't have to specify the types every time.
+	///
+	/// Constructs a ringbuffer transient and returns it as a boxed trait object.
+	/// See [this part of the Rust book](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-objects-perform-dynamic-dispatch)
+	fn queue_transient() -> Box<dyn BracketsTrait<T::AccountId, PlayerStruct<T::AccountId>>> {
+		Box::new(BracketsTransient::<
+			T::AccountId,
+			PlayerStruct<T::AccountId>,
+			BracketsCount<T>,
+			BracketIndices<T>,
+			BracketIndexKeyMap<T>,
+			BracketKeyValueMap<T>,
+		>::new())
+	}
+
+	fn do_add_queue(account: T::AccountId, bracket: u8) -> Result<(), sp_runtime::DispatchError> {
+		let mut queue = Self::queue_transient();
+
+		let player = PlayerStruct { account };
+		// duplicate check if we can add key to the queue
+		if !queue.push(bracket, player.account.clone(), player.clone()) {
+			return Err(Error::<T>::AlreadyQueued.into());
+		}
+
+		Self::deposit_event(Event::Queued(player));
+
+		Ok(())
+	}
+
+	fn do_empty_queue(bracket: u8) {
+		let mut queue = Self::queue_transient();
+
+		while queue.size(bracket) > 0 {
+			queue.pop(bracket);
+		}
+	}
+
+	fn do_all_empty_queue() {
+		for i in 0..Self::brackets_count() {
+			Self::do_empty_queue(i);
+		}
+	}
+
+	fn do_try_match() -> Vec<T::AccountId> {
+		let mut queue = Self::queue_transient();
+		let max_players = T::AmountPlayers::get();
+
+		let mut result: Vec<T::AccountId> = Vec::new();
+		let mut brackets: Vec<Bracket> = Vec::new();
+		// pass trough all brackets
+		for i in 0..Self::brackets_count() {
+			// skip if bracket is empty
+			if queue.size(i) == 0 {
+				continue;
+			}
+			// iterate for each slot occupied and fill, till player match size reached
+			for _j in 0..queue.size(i) {
+				if brackets.len() == max_players as usize {
+					break;
+				}
+				brackets.push(i);
+			}
+			// leave if brackets is filled with brackets
+			if brackets.len() == max_players as usize {
+				break;
+			}
+		}
+		// vec not filled with enough brackets leave
+		if brackets.len() < max_players as usize {
+			return result;
+		}
+
+		// pop from the harvested brackets players
+		for bracket in brackets {
+			if let Some(p) = queue.pop(bracket) {
+				result.push(p.account.clone());
+				Self::deposit_event(Event::Popped(p));
+			}
+		}
+		// return result
+		result
+	}
+
+	fn do_is_queued(account: T::AccountId) -> bool {
+		Self::queue_transient().is_queued(account)
+	}
+
+	fn do_queue_size(bracket: u8) -> BufferIndex {
+		Self::queue_transient().size(bracket)
+	}
+
+	fn do_all_queue_size() -> BufferIndex {
+		let queue = Self::queue_transient();
+
+		let mut total_queued: BufferIndex = 0;
+		// count all existing brackets
+		for i in 0..Self::brackets_count() {
+			total_queued = total_queued.saturating_add(queue.size(i));
+		}
+		// return result
+		total_queued
+	}
+}
+
+impl<T: Config> MatchFunc<T::AccountId> for Pallet<T> {
+	fn empty_queue(bracket: u8) {
+		Self::do_empty_queue(bracket);
+	}
+
+	fn all_empty_queue() {
+		Self::do_all_empty_queue();
+	}
+
+	fn add_queue(account: T::AccountId, bracket: u8) -> Result<(), sp_runtime::DispatchError> {
+		Self::do_add_queue(account, bracket)
+	}
+
+	fn try_match() -> Vec<T::AccountId> {
+		Self::do_try_match()
+	}
+
+	fn is_queued(account: T::AccountId) -> bool {
+		Self::do_is_queued(account)
+	}
+
+	fn queue_size(bracket: u8) -> BufferIndex {
+		Self::do_queue_size(bracket)
+	}
+
+	fn all_queue_size() -> BufferIndex {
+		Self::do_all_queue_size()
+	}
+}
+
+pub trait MatchFunc<AccountId> {
+	/// empty specific bracket queue
+	fn empty_queue(bracket: u8);
+
+	/// empty all queues
+	fn all_empty_queue();
+
+	/// return true if adding account to bracket queue was successful
+	fn add_queue(account: AccountId, bracket: u8) -> Result<(), sp_runtime::DispatchError>;
+
+	/// try create a match
+	fn try_match() -> Vec<AccountId>;
+
+	// return true if an account is queued in any bracket
+	fn is_queued(account: AccountId) -> bool;
+
+	// return size of a specific bracket queue
+	fn queue_size(bracket: u8) -> BufferIndex;
+
+	// return total size of all queued accounts in all brackets
+	fn all_queue_size() -> BufferIndex;
+}

--- a/pallets/ajuna-matchmaker/src/mock.rs
+++ b/pallets/ajuna-matchmaker/src/mock.rs
@@ -1,0 +1,77 @@
+use crate as pallet_matchmaker;
+use frame_support::{
+	parameter_types,
+	traits::{ConstU16, ConstU64, Get},
+};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_core::H256;
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+
+type Block = frame_system::mocking::MockBlock<TestRuntime>;
+
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, MaxEncodedLen, TypeInfo)]
+pub struct ParameterGet<const N: u32>;
+
+impl<const N: u32> Get<u32> for ParameterGet<N> {
+	fn get() -> u32 {
+		N
+	}
+}
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+	pub enum TestRuntime
+	{
+		System: frame_system,
+		MatchMaker: pallet_matchmaker,
+	}
+);
+
+impl frame_system::Config for TestRuntime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Nonce = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Block = Block;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ConstU16<42>;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+parameter_types! {
+	pub const AmountPlayers: u8 = 2;
+	pub const AmountBrackets: u8 = 3;
+}
+
+impl pallet_matchmaker::Config for TestRuntime {
+	type RuntimeEvent = RuntimeEvent;
+	type AmountPlayers = AmountPlayers;
+	type AmountBrackets = AmountBrackets;
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	frame_system::GenesisConfig::<TestRuntime>::default()
+		.build_storage()
+		.unwrap()
+		.into()
+}

--- a/pallets/ajuna-matchmaker/src/tests.rs
+++ b/pallets/ajuna-matchmaker/src/tests.rs
@@ -1,0 +1,113 @@
+use crate::{mock::*, Error};
+
+#[test]
+fn test_is_queued() {
+	new_test_ext().execute_with(|| {
+		let player1 = 1;
+
+		assert_eq!(MatchMaker::do_queue_size(0), 0);
+		assert!(!MatchMaker::do_is_queued(player1));
+		assert_eq!(MatchMaker::do_add_queue(player1, 0), Ok(()));
+		assert!(MatchMaker::do_is_queued(player1));
+		MatchMaker::do_empty_queue(0);
+		assert!(!MatchMaker::do_is_queued(player1));
+	});
+}
+
+#[test]
+fn test_try_duplicate_queue() {
+	new_test_ext().execute_with(|| {
+		let player1 = 1;
+		let player2 = 2;
+
+		assert_eq!(MatchMaker::do_queue_size(0), 0);
+		assert_eq!(MatchMaker::do_add_queue(player1, 0), Ok(()));
+		// try same bracket
+		assert_eq!(
+			MatchMaker::do_add_queue(player1, 0),
+			Err(Error::<TestRuntime>::AlreadyQueued.into())
+		);
+		// try other bracket
+		assert_eq!(
+			MatchMaker::do_add_queue(player1, 1),
+			Err(Error::<TestRuntime>::AlreadyQueued.into())
+		);
+
+		assert_eq!(MatchMaker::do_add_queue(player2, 1), Ok(()));
+		// try same bracket
+		assert_eq!(
+			MatchMaker::do_add_queue(player2, 1),
+			Err(Error::<TestRuntime>::AlreadyQueued.into())
+		);
+		// try other bracket
+		assert_eq!(
+			MatchMaker::do_add_queue(player2, 0),
+			Err(Error::<TestRuntime>::AlreadyQueued.into())
+		);
+	});
+}
+
+#[test]
+fn test_add_queue() {
+	new_test_ext().execute_with(|| {
+		let player1 = 1;
+		let player2 = 2;
+
+		assert_eq!(MatchMaker::do_queue_size(0), 0);
+		assert!(MatchMaker::do_try_match().is_empty());
+		assert_eq!(MatchMaker::do_add_queue(player1, 0), Ok(()));
+		assert_eq!(MatchMaker::do_queue_size(0), 1);
+		assert!(MatchMaker::do_try_match().is_empty());
+		assert_eq!(MatchMaker::do_add_queue(player2, 0), Ok(()));
+		assert_eq!(MatchMaker::do_queue_size(0), 2);
+		assert_eq!(MatchMaker::do_try_match(), [1, 2]);
+		assert_eq!(MatchMaker::do_queue_size(0), 0);
+		assert!(MatchMaker::do_try_match().is_empty());
+
+		assert_eq!(MatchMaker::do_add_queue(player1, 0), Ok(()));
+		assert_eq!(MatchMaker::do_add_queue(player2, 0), Ok(()));
+		assert_eq!(MatchMaker::do_queue_size(0), 2);
+		MatchMaker::do_empty_queue(0);
+		assert!(MatchMaker::do_try_match().is_empty());
+		assert_eq!(MatchMaker::do_queue_size(0), 0);
+	});
+}
+
+#[test]
+fn test_brackets_count() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(MatchMaker::brackets_count(), 3);
+	});
+}
+
+#[test]
+fn test_brackets() {
+	new_test_ext().execute_with(|| {
+		let player1 = 1; // bracket: 0
+		let player2 = 2; // bracket: 0
+		let player3 = 3; // bracket: 0
+		let player4 = 4; // bracket: 1
+		let player5 = 5; // bracket: 1
+		let player6 = 6; // bracket: 2
+
+		assert_eq!(MatchMaker::do_queue_size(0), 0);
+		assert_eq!(MatchMaker::do_all_queue_size(), 0);
+		assert_eq!(MatchMaker::do_add_queue(player1, 0), Ok(()));
+		assert_eq!(MatchMaker::do_add_queue(player2, 0), Ok(()));
+		assert_eq!(MatchMaker::do_add_queue(player3, 0), Ok(()));
+		assert_eq!(MatchMaker::do_add_queue(player4, 1), Ok(()));
+		assert_eq!(MatchMaker::do_add_queue(player5, 1), Ok(()));
+		assert_eq!(MatchMaker::do_add_queue(player6, 2), Ok(()));
+		assert_eq!(MatchMaker::do_queue_size(0), 3);
+		assert_eq!(MatchMaker::do_queue_size(1), 2);
+		assert_eq!(MatchMaker::do_queue_size(2), 1);
+		assert_eq!(MatchMaker::do_all_queue_size(), 6);
+		assert_eq!(MatchMaker::do_try_match(), [1, 2]);
+		assert_eq!(MatchMaker::do_try_match(), [3, 4]);
+		assert_eq!(MatchMaker::do_add_queue(player1, 0), Ok(()));
+		assert_eq!(MatchMaker::do_try_match(), [1, 5]);
+		assert!(MatchMaker::do_try_match().is_empty());
+		assert_eq!(MatchMaker::do_add_queue(player5, 1), Ok(()));
+		assert_eq!(MatchMaker::do_try_match(), [5, 6]);
+	});
+}

--- a/pallets/ajuna-matchmaker/src/tests.rs
+++ b/pallets/ajuna-matchmaker/src/tests.rs
@@ -23,27 +23,15 @@ fn test_try_duplicate_queue() {
 		assert_eq!(MatchMaker::do_queue_size(0), 0);
 		assert_eq!(MatchMaker::do_add_queue(player1, 0), Ok(()));
 		// try same bracket
-		assert_eq!(
-			MatchMaker::do_add_queue(player1, 0),
-			Err(Error::<TestRuntime>::AlreadyQueued.into())
-		);
+		assert_eq!(MatchMaker::do_add_queue(player1, 0), Err(Error::<Test>::AlreadyQueued.into()));
 		// try other bracket
-		assert_eq!(
-			MatchMaker::do_add_queue(player1, 1),
-			Err(Error::<TestRuntime>::AlreadyQueued.into())
-		);
+		assert_eq!(MatchMaker::do_add_queue(player1, 1), Err(Error::<Test>::AlreadyQueued.into()));
 
 		assert_eq!(MatchMaker::do_add_queue(player2, 1), Ok(()));
 		// try same bracket
-		assert_eq!(
-			MatchMaker::do_add_queue(player2, 1),
-			Err(Error::<TestRuntime>::AlreadyQueued.into())
-		);
+		assert_eq!(MatchMaker::do_add_queue(player2, 1), Err(Error::<Test>::AlreadyQueued.into()));
 		// try other bracket
-		assert_eq!(
-			MatchMaker::do_add_queue(player2, 0),
-			Err(Error::<TestRuntime>::AlreadyQueued.into())
-		);
+		assert_eq!(MatchMaker::do_add_queue(player2, 0), Err(Error::<Test>::AlreadyQueued.into()));
 	});
 }
 


### PR DESCRIPTION
## Description

Adds the `ajuna-board` and `ajuna-matchmaking` pallets to the repo

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
