### PR TITLE
[AJUN-370] Adapat V2 matching logic to V3 code

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/avatar_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/avatar_utils.rs
@@ -1050,6 +1050,16 @@ where
 		out
 	}
 
+	pub fn read_progress_starting_at(avatar: &Avatar<BlockNumber>, index: usize) -> [u8; 11] {
+		let mut out = [0; 11];
+		let to_index = if avatar.dna.len() < 11 { avatar.dna.len() } else { 11 };
+
+		for (i, p) in (index..(index + to_index)).enumerate() {
+			out[i] = avatar.dna[p];
+		}
+		out
+	}
+
 	pub fn write_progress(avatar: &mut Avatar<BlockNumber>, value: [u8; 11]) {
 		(avatar.dna[21..32]).copy_from_slice(&value);
 	}
@@ -1104,7 +1114,7 @@ where
 		(mirrors, matches)
 	}
 
-	fn match_progress_byte(byte_1: u8, byte_2: u8) -> bool {
+	pub fn match_progress_byte(byte_1: u8, byte_2: u8) -> bool {
 		let diff = if byte_1 >= byte_2 { byte_1 - byte_2 } else { byte_2 - byte_1 };
 		diff == 1 || diff == (PROGRESS_VARIATIONS - 1)
 	}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v3.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v3.rs
@@ -236,7 +236,7 @@ impl<T: Config> ForgerV3<T> {
 						let rarity_2 = rhs >> 4;
 						let variation_2 = rhs & 0b0000_1111;
 
-						let have_same_rarity = rarity_1 == rarity_2 || rarity_2 == 0x0B;
+						let have_same_rarity = rarity_1 == rarity_2;
 						let is_maxed = rarity_1 > lowest_1;
 						let byte_match = DnaUtils::<BlockNumberFor<T>>::match_progress_byte(
 							variation_1,

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v3.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v3.rs
@@ -213,8 +213,8 @@ impl<T: Config> ForgerV3<T> {
 		indexes: &[usize],
 		max_tier: u8,
 	) -> (bool, BTreeSet<usize>) {
-		let array_1 = DnaUtils::<BlockNumberFor<T>>::read_progress_starting_at(&target, 0);
-		let array_2 = DnaUtils::<BlockNumberFor<T>>::read_progress_starting_at(&other, 0);
+		let array_1 = DnaUtils::<BlockNumberFor<T>>::read_progress_starting_at(target, 0);
+		let array_2 = DnaUtils::<BlockNumberFor<T>>::read_progress_starting_at(other, 0);
 
 		let lowest_1 =
 			DnaUtils::<BlockNumberFor<T>>::lowest_progress_byte(&array_1, ByteType::High);


### PR DESCRIPTION
## Description

Changes the way the `compare` method works in V3 forging, to work in the same way as the V2 `match_progress` method works.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
