### PR TITLE
[AJUN-400] Update do4gravity to hide bomb locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -283,9 +283,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
 dependencies = [
  "addr2line",
  "cc",
@@ -719,11 +719,12 @@ dependencies = [
 
 [[package]]
 name = "dot4gravity"
-version = "0.2.0"
-source = "git+https://github.com/ajuna-network/ajuna-games?branch=main#325e915c23a98c14bddd317b7f2b87ce76efab10"
+version = "0.4.0"
+source = "git+https://github.com/ajuna-network/ajuna-games?tag=v0.4.0#441e5976c9cab162205e56eaaa332da552f95f53"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
+ "sp-crypto-hashing",
 ]
 
 [[package]]
@@ -1190,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "group"
@@ -1719,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
 dependencies = [
  "memchr",
 ]
@@ -2288,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -3424,7 +3425,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.8",
+ "winnow 0.6.9",
 ]
 
 [[package]]
@@ -3595,9 +3596,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7335e4c132c28cc43caef6adb339789e599e39adbe78da0c4d547fad48cbc331"
+checksum = "9c5da5fa2c6afa2c9158eaa7cd9aee249765eb32b5fb0c63ad8b9e79336a47ec"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -3821,9 +3822,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
 dependencies = [
  "memchr",
 ]

--- a/pallets/ajuna-board/Cargo.toml
+++ b/pallets/ajuna-board/Cargo.toml
@@ -22,7 +22,7 @@ sp-std             = { workspace = true }
 sp-runtime         = { workspace = true }
 
 # Ajuna pallets
-dot4gravity             = { default-features = false, git = "https://github.com/ajuna-network/ajuna-games", branch = "main" }
+dot4gravity             = { default-features = false, git = "https://github.com/ajuna-network/ajuna-games", tag = "v0.4.0" }
 pallet-ajuna-matchmaker = { workspace = true }
 
 [dev-dependencies]

--- a/pallets/ajuna-board/src/benchmarking.rs
+++ b/pallets/ajuna-board/src/benchmarking.rs
@@ -59,7 +59,7 @@ fn create_and_play_until_win<T: Config>(players: Vec<T::AccountId>) {
 	let player_2: T::RuntimeOrigin = RawOrigin::Signed(players.next().unwrap()).into();
 
 	let each_player_drops_bomb = |coord: Coordinates| {
-		let drop_bomb: T::PlayersTurn = Turn::DropBomb(coord).into();
+		let drop_bomb: T::PlayersTurn = Turn::DropBomb(coord, 13).into();
 		let _ = AjunaBoard::<T>::play(player_1.clone(), drop_bomb.clone());
 		let _ = AjunaBoard::<T>::play(player_2.clone(), drop_bomb);
 	};
@@ -96,7 +96,7 @@ benchmarks! {
 		create_new_game::<T>(players.clone());
 
 		let player_1 = players.into_iter().next().unwrap();
-		let turn = Turn::DropBomb(Coordinates::new(1, 2));
+		let turn = Turn::DropBomb(Coordinates::new(1, 2), 35);
 	}: play(RawOrigin::Signed(player_1), turn.into())
 
 	play_turn_until_finished {

--- a/pallets/ajuna-board/src/dot4gravity.rs
+++ b/pallets/ajuna-board/src/dot4gravity.rs
@@ -22,8 +22,9 @@ use sp_std::borrow::ToOwned;
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebugNoBound, TypeInfo, MaxEncodedLen)]
 pub enum Turn {
-	DropBomb(Coordinates),
+	DropBomb(Coordinates, u64),
 	DropStone((Side, u8)),
+	DetonateBomb(Coordinates, u64),
 }
 
 pub struct Game<Account>(PhantomData<Account>);
@@ -61,8 +62,10 @@ where
 		turn: Self::Turn,
 	) -> Option<Self::State> {
 		match turn {
-			Turn::DropBomb(coords) => Dot4Gravity::drop_bomb(state, coords, player),
+			Turn::DropBomb(coords, secret) => Dot4Gravity::drop_bomb(state, coords, player, secret),
 			Turn::DropStone((side, pos)) => Dot4Gravity::drop_stone(state, player, side, pos),
+			Turn::DetonateBomb(coords, secret) =>
+				Dot4Gravity::detonate_bomb(state, player, coords, secret),
 		}
 		.ok()
 	}

--- a/pallets/ajuna-board/src/tests.rs
+++ b/pallets/ajuna-board/src/tests.rs
@@ -92,14 +92,14 @@ fn play_works() {
 		assert_ok!(AjunaBoard::queue(RuntimeOrigin::signed(BOB)));
 		assert_ok!(AjunaBoard::queue(RuntimeOrigin::signed(ERIN)));
 		assert_noop!(
-			AjunaBoard::play(RuntimeOrigin::signed(ALICE), Turn::DropBomb(TEST_COORD)),
+			AjunaBoard::play(RuntimeOrigin::signed(ALICE), Turn::DropBomb(TEST_COORD, 13)),
 			Error::<Test>::NotPlaying
 		);
 
 		// Bomb phase
 		let drop_bomb = |coord: Coordinates| {
-			let _ = AjunaBoard::play(RuntimeOrigin::signed(BOB), Turn::DropBomb(coord));
-			let _ = AjunaBoard::play(RuntimeOrigin::signed(ERIN), Turn::DropBomb(coord));
+			let _ = AjunaBoard::play(RuntimeOrigin::signed(BOB), Turn::DropBomb(coord, 13));
+			let _ = AjunaBoard::play(RuntimeOrigin::signed(ERIN), Turn::DropBomb(coord, 13));
 		};
 		drop_bomb(Coordinates::new(9, 9));
 		drop_bomb(Coordinates::new(8, 8));


### PR DESCRIPTION
## Description

Modifies the logic for dot4gravity so that bombs are triggered manually instead of working like mines.

Also hides the bomb placements for each player.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
