### PR TITLE
[Unlocking] Fixed bug in `evaluate_unlock_state`

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -2341,8 +2341,8 @@ pub mod pallet {
 			config[0] <= minted &&
 				config[1] <= free_minted &&
 				config[2] <= forged &&
-				config[3] <= bought as u8 &&
-				config[4] <= sold as u8
+				config[3] <= bought &&
+				config[4] <= sold
 		}
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -2332,11 +2332,17 @@ pub mod pallet {
 			config: &BoundedVec<u8, ConstU32<5>>,
 			account_stats: &SeasonInfo,
 		) -> bool {
-			config[0] <= account_stats.minted as u8 &&
-				config[1] <= account_stats.free_minted as u8 &&
-				config[2] <= account_stats.forged as u8 &&
-				config[3] <= account_stats.bought as u8 &&
-				config[4] <= account_stats.sold as u8
+			let minted = u8::try_from(account_stats.minted).unwrap_or(u8::MAX);
+			let free_minted = u8::try_from(account_stats.free_minted).unwrap_or(u8::MAX);
+			let forged = u8::try_from(account_stats.forged).unwrap_or(u8::MAX);
+			let bought = u8::try_from(account_stats.bought).unwrap_or(u8::MAX);
+			let sold = u8::try_from(account_stats.sold).unwrap_or(u8::MAX);
+
+			config[0] <= minted &&
+				config[1] <= free_minted &&
+				config[2] <= forged &&
+				config[3] <= bought as u8 &&
+				config[4] <= sold as u8
 		}
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -4313,10 +4313,27 @@ mod affiliates {
 	#[test]
 	fn enable_account_for_affiliation_free() {
 		let initial_balance = 1_000_000;
+		let season_1 = Season::default().mint_fee(MintFees { one: 12, three: 34, six: 56 });
 		ExtBuilder::default()
 			.balances(&[(ALICE, initial_balance)])
+			.seasons(&[(SEASON_ID, season_1)])
 			.build()
 			.execute_with(|| {
+				SeasonUnlocks::<Test>::insert(
+					SEASON_ID,
+					UnlockConfigs {
+						set_price_unlock: None,
+						avatar_transfer_unlock: None,
+						affiliate_unlock: Some(bounded_vec![0x00, 0x10, 0x10, 0x00, 0x00]),
+					},
+				);
+
+				SeasonStats::<Test>::insert(
+					SEASON_ID,
+					ALICE,
+					SeasonInfo { minted: 1_125, free_minted: 38, forged: 258, bought: 0, sold: 0 },
+				);
+
 				assert_ok!(AAvatars::enable_affiliator(
 					RuntimeOrigin::signed(ALICE),
 					UnlockTarget::OneselfFree,


### PR DESCRIPTION
## Description

* Fixes bug related to type conversions from `u32` to `u8`

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
