### PR TITLE
[Tournament] Bugfix adjust checks for tournament ranking during claim period

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -1758,7 +1758,8 @@ pub mod pallet {
 					info.minted.saturating_accrue(generated_avatar_ids.len() as Stat),
 			});
 
-			if is_tournament_in_active_period && T::TournamentHandler::is_golden_duck_enabled_for(&season_id)
+			if is_tournament_in_active_period &&
+				T::TournamentHandler::is_golden_duck_enabled_for(&season_id)
 			{
 				for avatar_id in generated_avatar_ids.iter() {
 					T::TournamentHandler::try_rank_entity_for_golden_duck(&season_id, avatar_id)?;

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -1685,7 +1685,7 @@ pub mod pallet {
 				LogicGeneration::Fourth => MinterV4::<T>::mint(player, &season_id, mint_option),
 			}?;
 
-			let is_tournament_active = matches!(
+			let is_tournament_in_active_period = matches!(
 				T::TournamentHandler::get_active_tournament_state_for(&season_id),
 				TournamentState::ActivePeriod(_)
 			);
@@ -1704,7 +1704,7 @@ pub mod pallet {
 									TournamentConfig {
 										take_fee_percentage: Some(fee_perc), ..
 									},
-								)) if is_tournament_active => Self::try_propagate_tournament_fee(
+								)) if is_tournament_in_active_period => Self::try_propagate_tournament_fee(
 									&season_id, player, fee_perc, base_fee,
 								)?,
 								_ => base_fee,
@@ -1758,7 +1758,7 @@ pub mod pallet {
 					info.minted.saturating_accrue(generated_avatar_ids.len() as Stat),
 			});
 
-			if is_tournament_active && T::TournamentHandler::is_golden_duck_enabled_for(&season_id)
+			if is_tournament_in_active_period && T::TournamentHandler::is_golden_duck_enabled_for(&season_id)
 			{
 				for avatar_id in generated_avatar_ids.iter() {
 					T::TournamentHandler::try_rank_entity_for_golden_duck(&season_id, avatar_id)?;
@@ -2033,27 +2033,35 @@ pub mod pallet {
 							}
 						});
 
-						// If the leader avatar has turned into a Legendary avatar then we try to
-						// rank it for the active tournament
-						if let Some((tournament_id, config)) =
-							T::TournamentHandler::get_active_tournament_config_for(season_id)
-						{
-							let sacrifices_are_in_bounds =
-								input_sacrifices.into_iter().all(|(_, sacrifice)| {
-									sacrifice.minted_at >= config.start &&
-										sacrifice.minted_at <= config.active_end
-								});
+						let is_tournament_in_active_period = matches!(
+							T::TournamentHandler::get_active_tournament_state_for(season_id),
+							TournamentState::ActivePeriod(_)
+						);
 
-							let leader_in_bounds = input_leader.1.minted_at >= config.start &&
-								input_leader.1.minted_at <= config.active_end;
+						// If the leader avatar has turned into a Legendary avatar and
+						// the tournament is in its active phase then we try to rank it
+						if is_tournament_in_active_period {
+							if let Some((tournament_id, config)) =
+								T::TournamentHandler::get_active_tournament_config_for(season_id)
+							{
+								let sacrifices_are_in_bounds =
+									input_sacrifices.into_iter().all(|(_, sacrifice)| {
+										sacrifice.minted_at >= config.start &&
+											sacrifice.minted_at <= config.active_end
+									});
 
-							if sacrifices_are_in_bounds && leader_in_bounds {
-								let ranker = TournamentRankers::<T>::get(season_id, tournament_id)
-									.ok_or(Error::<T>::TournamentRankerNotFound)?;
+								let leader_in_bounds = input_leader.1.minted_at >= config.start &&
+									input_leader.1.minted_at <= config.active_end;
 
-								T::TournamentHandler::try_rank_entity_in_tournament_for(
-									season_id, &leader_id, &leader, &ranker,
-								)?;
+								if sacrifices_are_in_bounds && leader_in_bounds {
+									let ranker =
+										TournamentRankers::<T>::get(season_id, tournament_id)
+											.ok_or(Error::<T>::TournamentRankerNotFound)?;
+
+									T::TournamentHandler::try_rank_entity_in_tournament_for(
+										season_id, &leader_id, &leader, &ranker,
+									)?;
+								}
 							}
 						}
 					}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -5036,7 +5036,14 @@ mod tournament {
 					0x17, 0xFC, 0x17, 0x2C, 0xDD, 0x68, 0xC6, 0xBD, 0xE6, 0x96, 0xCB, 0x41, 0x8B,
 					0xCC, 0x98, 0xE3, 0x5F, 0xCF, 0x40,
 				]);
-				let leader_1 = create_dummy_legendary_avatar_v3(SEASON_ID, 108, 30);
+				let leader_1 = {
+					let mut leader_1 = create_dummy_legendary_avatar_v3(SEASON_ID, 108, 30);
+					leader_1.dna = Dna::try_from(vec![
+						0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
+					])
+					.expect("Create dna");
+					leader_1
+				};
 				assert_eq!(leader_1.force(), ranker_force.as_byte());
 
 				Avatars::<Test>::insert(leader_id_1, (ALICE, leader_1.clone()));
@@ -5289,7 +5296,10 @@ mod tournament {
 				let leader_1 = {
 					let mut leader_1 = create_dummy_legendary_avatar_v3(SEASON_ID, 108, 30);
 					// Altering the last dna strand so that the force doesn't match the rank filter
-					leader_1.dna[2] = 0x53;
+					leader_1.dna = Dna::try_from(vec![
+						0x53, 0x53, 0x55, 0x53, 0x52, 0x54, 0x55, 0x53, 0x53, 0x53, 0x53,
+					])
+					.expect("Create avatar DNA");
 					leader_1
 				};
 				assert_ne!(leader_1.force(), ranker_force.as_byte());

--- a/pallets/ajuna-awesome-avatars/src/types/season.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/season.rs
@@ -358,6 +358,10 @@ mod test {
 			self.mint_logic = logic;
 			self
 		}
+		pub fn forge_logic(mut self, logic: LogicGeneration) -> Self {
+			self.forge_logic = logic;
+			self
+		}
 	}
 
 	impl Default for SeasonMeta {


### PR DESCRIPTION
## Description

Fixes a bug in which a legendary would be ranked while the tournament was in its claim period, producing an error.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
