### PR TITLE
[AJUN-703] Improper affiliate count decrease on affiliate clearing

### DIFF
--- a/pallets/ajuna-affiliates/src/lib.rs
+++ b/pallets/ajuna-affiliates/src/lib.rs
@@ -239,7 +239,13 @@ pub mod pallet {
 
 		fn try_clear_affiliation_for(account: &AccountIdFor<T>) -> DispatchResult {
 			Affiliatees::<T, I>::take(account)
-				.and_then(|mut affiliate_chain| affiliate_chain.pop())
+				.and_then(|mut affiliate_chain| {
+					if affiliate_chain.is_empty() {
+						None
+					} else {
+						Some(affiliate_chain.remove(0))
+					}
+				})
 				.map_or_else(
 					|| Ok(()),
 					|affiliator| {


### PR DESCRIPTION
## Description

* This PR fixes an issue in which an affiliate chains account may have their affiliate count improperly decrease when an account upstream clears its affiliation to an account affiliated to that base account.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
