### PR TITLE
[AJUN-874] SAGE pallet/api refinement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,7 @@ version = "0.15.0"
 dependencies = [
  "ajuna-primitives",
  "example-transition",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",

--- a/pallets/ajuna-affiliates/src/benchmarking.rs
+++ b/pallets/ajuna-affiliates/src/benchmarking.rs
@@ -25,7 +25,6 @@ use crate::{
 	},
 	Pallet as Affiliates, *,
 };
-use ajuna_primitives::account_manager::AccountManager;
 use frame_benchmarking::benchmarks_instance_pallet;
 use frame_system::RawOrigin;
 use sp_runtime::BuildStorage;
@@ -90,8 +89,6 @@ benchmarks_instance_pallet! {
 		let acc_2 = account::<T, I>(ACC_2);
 		let acc_3 = account::<T, I>(ACC_3);
 		mark_as_affiliatable::<T, I>(&acc_3);
-		let key = T::WhitelistKey::get();
-		T::AccountManager::try_set_whitelisted_for(&key, &acc_1).expect("Set whitelisted");
 	}: _(RawOrigin::Signed(acc_1.clone()), Some(acc_2.clone()), 0)
 	verify {
 		assert_last_event::<T, I>(Event::AccountAffiliated { account: acc_2, to: acc_3 })
@@ -152,6 +149,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext.execute_with(|| {
 		let acc_1 = account::<Test, ()>(ACC_1);
 		MockAccountManager::set_organizer(acc_1);
+		MockAccountManager::try_add_to_whitelist(&AffiliateWhitelistKey::get(), &acc_1)
+			.expect("Should add to whitelist");
 	});
 	ext
 }

--- a/pallets/ajuna-affiliates/src/mock.rs
+++ b/pallets/ajuna-affiliates/src/mock.rs
@@ -156,11 +156,6 @@ impl AccountManager for MockAccountManager {
 		})
 	}
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_organizer(owner: Self::AccountId) {
-		MockAccountManager::set_organizer(owner);
-	}
-
 	fn is_whitelisted_for(identifier: &WhitelistKey, account: &Self::AccountId) -> bool {
 		WHITELISTED_ACCOUNTS.with(|accounts| {
 			if let Some(entry) = accounts.borrow_mut().get_mut(identifier) {
@@ -169,14 +164,6 @@ impl AccountManager for MockAccountManager {
 				false
 			}
 		})
-	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn try_set_whitelisted_for(
-		identifier: &WhitelistKey,
-		account: &Self::AccountId,
-	) -> Result<(), DispatchError> {
-		Self::try_add_to_whitelist(identifier, account)
 	}
 }
 

--- a/pallets/ajuna-awesome-avatars/benchmarking/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/mock.rs
@@ -28,8 +28,9 @@ use frame_support::{
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_ajuna_affiliates::{traits::AffiliateUnlockRules, BenchmarkHelper};
 use pallet_ajuna_awesome_avatars::{
+	benchmark_helper,
 	types::{AffiliateMethods, Avatar, SeasonId},
-	AvatarRankerFor,
+	AvatarIdOf, AvatarOf, AvatarRankerFor, Avatars, CurrentSeasonStatus, Owners,
 };
 use pallet_ajuna_tournament::{GoldenDuckConfig, TournamentConfig};
 use sp_runtime::{
@@ -232,6 +233,9 @@ impl
 		MockBlockNumber,
 		MockBalance,
 		AvatarRankerFor<Runtime>,
+		MockAccountId,
+		AvatarIdOf<Runtime>,
+		AvatarOf<Runtime>,
 	> for TournamentBenchmarkHelper
 {
 	fn create_category_id(id: u32) -> SeasonId {
@@ -252,6 +256,24 @@ impl
 			max_players: 4,
 			ranker: AvatarRankerFor::<Runtime>::default(),
 		}
+	}
+
+	fn create_entities(
+		owner: MockAccountId,
+		count: u32,
+	) -> Vec<(AvatarIdOf<Runtime>, AvatarOf<Runtime>)> {
+		benchmark_helper::create_avatars::<Runtime>(owner.clone(), count).unwrap();
+
+		let season_id = CurrentSeasonStatus::<Runtime>::get().season_id;
+		let avatar_ids = Owners::<Runtime>::get(owner, season_id);
+		let mut avatars = Vec::with_capacity(avatar_ids.len());
+
+		for avatar_id in avatar_ids.iter() {
+			let (_, avatar) = Avatars::<Runtime>::get(avatar_id).unwrap();
+			avatars.push(avatar);
+		}
+
+		avatar_ids.into_iter().zip(avatars).collect()
 	}
 }
 

--- a/pallets/ajuna-awesome-avatars/src/impls/account_manager.rs
+++ b/pallets/ajuna-awesome-avatars/src/impls/account_manager.rs
@@ -25,26 +25,8 @@ impl<T: Config> AccountManager for Pallet<T> {
 		Ok(())
 	}
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_organizer(organizer: Self::AccountId) {
-		Organizer::<T>::put(organizer)
-	}
-
 	// TODO: For now we ignore the 'identifier' parameter in the AAA implementation
 	fn is_whitelisted_for(_identifier: &WhitelistKey, account: &Self::AccountId) -> bool {
 		WhitelistedAccounts::<T>::get().contains(account)
-	}
-
-	// TODO: For now we ignore the 'identifier' parameter in the AAA implementation
-	#[cfg(feature = "runtime-benchmarks")]
-	fn try_set_whitelisted_for(
-		_identifier: &WhitelistKey,
-		account: &Self::AccountId,
-	) -> Result<(), DispatchError> {
-		WhitelistedAccounts::<T>::try_mutate(|accounts| {
-			accounts
-				.try_push(account.clone())
-				.map_err(|_| Error::<T>::WhitelistedAccountsLimitReached.into())
-		})
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/impls/asset_manager.rs
+++ b/pallets/ajuna-awesome-avatars/src/impls/asset_manager.rs
@@ -88,20 +88,4 @@ impl<T: Config> AssetManager for Pallet<T> {
 		let Season { fee, .. } = Self::seasons(&asset.season_id)?;
 		T::Currency::transfer(player, fee_recipient, fee.prepare_avatar, AllowDeath)
 	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn create_assets(owner: Self::AccountId, count: u32) -> Vec<(Self::AssetId, Self::Asset)> {
-		benchmark_helper::create_avatars::<T>(owner.clone(), count).unwrap();
-
-		let season_id = CurrentSeasonStatus::<T>::get().season_id;
-		let avatar_ids = Owners::<T>::get(owner, season_id);
-		let mut avatars = Vec::with_capacity(avatar_ids.len());
-
-		for avatar_id in avatar_ids.iter() {
-			let (_, avatar) = Avatars::<T>::get(avatar_id).unwrap();
-			avatars.push(avatar);
-		}
-
-		avatar_ids.into_iter().zip(avatars).collect()
-	}
 }

--- a/pallets/ajuna-awesome-avatars/src/impls/treasury_manager.rs
+++ b/pallets/ajuna-awesome-avatars/src/impls/treasury_manager.rs
@@ -36,11 +36,6 @@ impl<T: Config> TreasuryManager for Pallet<T> {
 		Ok(Self::treasury_account_id())
 	}
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_treasurer_for(_key: Self::TreasuryPotKey, _owner: Self::AccountId) {
-		unimplemented!()
-	}
-
 	fn deposit_into(
 		depositor: &Self::AccountId,
 		key: &Self::TreasuryPotKey,

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -201,6 +201,9 @@ impl
 		MockBlockNumber,
 		MockBalance,
 		AvatarRankerFor<Test>,
+		MockAccountId,
+		AvatarIdOf<Test>,
+		AvatarOf<Test>,
 	> for TournamentBenchmarkHelper
 {
 	fn create_category_id(id: u32) -> SeasonId {
@@ -221,6 +224,24 @@ impl
 			max_players: 4,
 			ranker: AvatarRankerFor::<Test>::default(),
 		}
+	}
+
+	fn create_entities(
+		owner: MockAccountId,
+		count: u32,
+	) -> Vec<(AvatarIdOf<Test>, AvatarOf<Test>)> {
+		benchmark_helper::create_avatars::<Test>(owner, count).unwrap();
+
+		let season_id = CurrentSeasonStatus::<Test>::get().season_id;
+		let avatar_ids = Owners::<Test>::get(owner, season_id);
+		let mut avatars = Vec::with_capacity(avatar_ids.len());
+
+		for avatar_id in avatar_ids.iter() {
+			let (_, avatar) = Avatars::<Test>::get(avatar_id).unwrap();
+			avatars.push(avatar);
+		}
+
+		avatar_ids.into_iter().zip(avatars).collect()
 	}
 }
 

--- a/pallets/ajuna-nft-transfer/src/benchmarking.rs
+++ b/pallets/ajuna-nft-transfer/src/benchmarking.rs
@@ -17,8 +17,11 @@
 #![cfg(feature = "runtime-benchmarks")]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use crate::{mock::Test, traits::IpfsUrl, *};
-use ajuna_primitives::{account_manager::AccountManager, asset_manager::AssetManager};
+use crate::{
+	mock::{MockAccountManager, System, Test},
+	traits::IpfsUrl,
+	*,
+};
 use frame_benchmarking::benchmarks;
 use frame_support::{pallet_prelude::DispatchError, traits::Currency};
 use frame_system::RawOrigin;
@@ -41,13 +44,6 @@ fn account<T: Config>(name: &'static str) -> T::AccountId {
 	let index = 0;
 	let seed = 0;
 	frame_benchmarking::account(name, index, seed)
-}
-
-fn create_assets<T: Config>(owner: T::AccountId, count: u32) -> Vec<ItemIdOf<T>> {
-	T::AssetManager::create_assets(owner, count)
-		.into_iter()
-		.map(|(asset_id, _)| asset_id)
-		.collect()
 }
 
 fn create_service_account<T: Config>() -> T::AccountId {
@@ -79,7 +75,6 @@ fn assert_last_event<T: Config>(avatars_event: Event<T>) {
 benchmarks! {
 	set_collection_id {
 		let organizer = account::<T>("organizer");
-		T::AccountManager::set_organizer(organizer.clone());
 		let collection_id = CollectionIdOf::<T>::from(u32::MAX);
 	}: _(RawOrigin::Signed(organizer), collection_id)
 	verify {
@@ -96,7 +91,7 @@ benchmarks! {
 	prepare_asset {
 		let name = "player";
 		let player = account::<T>(name);
-		let asset_id = create_assets::<T>(player.clone(), 1)[0];
+		let asset_id = T::BenchmarkHelper::create_items(player.clone(), 1)[0];
 		let _ = create_service_account::<T>();
 		enable_fee_payment::<T>(&player);
 	}: _(RawOrigin::Signed(player), asset_id)
@@ -107,7 +102,7 @@ benchmarks! {
 	unprepare_asset {
 		let name = "player";
 		let player = account::<T>(name);
-		let asset_id = create_assets::<T>(player.clone(), 1)[0];
+		let asset_id = T::BenchmarkHelper::create_items(player.clone(), 1)[0];
 		let _ = create_service_account_and_prepare_avatar::<T>(player.clone(), asset_id)?;
 	}: _(RawOrigin::Signed(player), asset_id)
 	verify {
@@ -117,7 +112,7 @@ benchmarks! {
 	prepare_ipfs {
 		let name = "player";
 		let player = account::<T>(name);
-		let asset_id = create_assets::<T>(player.clone(), 1)[0];
+		let asset_id = T::BenchmarkHelper::create_items(player.clone(), 1)[0];
 		let service_account = create_service_account_and_prepare_avatar::<T>(player, asset_id)?;
 		let url = IpfsUrl::try_from(b"ipfs://".to_vec()).unwrap();
 	}: _(RawOrigin::Signed(service_account), asset_id, url.clone())
@@ -134,5 +129,12 @@ benchmarks! {
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	sp_io::TestExternalities::new(t)
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| System::set_block_number(1));
+	ext.execute_with(|| {
+		let organizer = account::<Test>("organizer");
+		MockAccountManager::set_organizer(organizer);
+	});
+
+	ext
 }

--- a/pallets/ajuna-nft-transfer/src/lib.rs
+++ b/pallets/ajuna-nft-transfer/src/lib.rs
@@ -62,13 +62,6 @@ pub mod pallet {
 		fn create_items(owner: AccountId, count: u32) -> sp_std::vec::Vec<ItemId>;
 	}
 
-	#[cfg(feature = "runtime-benchmarks")]
-	impl<AccountId, ItemId> BenchmarkHelper<AccountId, ItemId> for () {
-		fn create_items(_owner: AccountId, _count: u32) -> sp_std::vec::Vec<ItemId> {
-			sp_std::vec::Vec::with_capacity(0)
-		}
-	}
-
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 

--- a/pallets/ajuna-nft-transfer/src/lib.rs
+++ b/pallets/ajuna-nft-transfer/src/lib.rs
@@ -57,6 +57,18 @@ pub mod pallet {
 		Uploaded,
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
+	pub trait BenchmarkHelper<AccountId, ItemId> {
+		fn create_items(owner: AccountId, count: u32) -> sp_std::vec::Vec<ItemId>;
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	impl<AccountId, ItemId> BenchmarkHelper<AccountId, ItemId> for () {
+		fn create_items(_owner: AccountId, _count: u32) -> sp_std::vec::Vec<ItemId> {
+			sp_std::vec::Vec::with_capacity(0)
+		}
+	}
+
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
@@ -101,6 +113,9 @@ pub mod pallet {
 			+ Mutate<Self::AccountId, Self::ItemConfig>;
 
 		type WeightInfo: WeightInfo;
+
+		#[cfg(feature = "runtime-benchmarks")]
+		type BenchmarkHelper: BenchmarkHelper<AccountIdFor<Self>, Self::ItemId>;
 	}
 
 	#[pallet::storage]

--- a/pallets/ajuna-nft-transfer/src/mock.rs
+++ b/pallets/ajuna-nft-transfer/src/mock.rs
@@ -206,6 +206,16 @@ parameter_types! {
 	pub const NftTransferPalletId: PalletId = PalletId(*b"aj/nfttr");
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+pub struct NftTransferBenchmarkHelper;
+
+#[cfg(feature = "runtime-benchmarks")]
+impl crate::BenchmarkHelper<MockAccountId, ItemId> for NftTransferBenchmarkHelper {
+	fn create_items(owner: MockAccountId, count: u32) -> Vec<ItemId> {
+		MockAssetManager::create_items(owner, count)
+	}
+}
+
 impl pallet_ajuna_nft_transfer::Config for Test {
 	type PalletId = NftTransferPalletId;
 	type RuntimeEvent = RuntimeEvent;
@@ -219,6 +229,8 @@ impl pallet_ajuna_nft_transfer::Config for Test {
 	type ValueLimit = ValueLimit;
 	type NftHelper = Nft;
 	type WeightInfo = ();
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = NftTransferBenchmarkHelper;
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
@@ -275,18 +287,16 @@ thread_local! {
 pub struct MockAssetManager;
 
 impl MockAssetManager {
-	pub fn create_assets(owner: MockAccountId, count: u32) -> Vec<(ItemId, MockItem)> {
+	pub fn create_items(owner: MockAccountId, count: u32) -> Vec<ItemId> {
 		let mut ids = Vec::with_capacity(count as usize);
-		let mut items = Vec::with_capacity(count as usize);
 		for i in 0..count {
 			let id = ItemId::repeat_byte(i as u8);
 			let item = MockItem::new_with_field2(i);
 			ids.push(id);
-			items.push(item.clone());
 			Self::add_asset(owner, id, item)
 		}
 
-		ids.into_iter().zip(items).collect()
+		ids
 	}
 
 	pub fn add_asset(owner: MockAccountId, asset_id: ItemId, asset: MockItem) {
@@ -393,11 +403,6 @@ impl AssetManager for MockAssetManager {
 
 		Ok(())
 	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn create_assets(owner: Self::AccountId, count: u32) -> Vec<(Self::AssetId, Self::Asset)> {
-		Self::create_assets(owner, count)
-	}
 }
 
 /// In the future we might want to use the `pallet-awesome-ajuna-avatars`, but currently this
@@ -429,20 +434,7 @@ impl ajuna_primitives::account_manager::AccountManager for MockAccountManager {
 		})
 	}
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_organizer(organizer: Self::AccountId) {
-		Self::set_organizer(organizer)
-	}
-
 	fn is_whitelisted_for(_identifier: &WhitelistKey, _account: &Self::AccountId) -> bool {
-		unimplemented!()
-	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn try_set_whitelisted_for(
-		_identifier: &WhitelistKey,
-		_account: &Self::AccountId,
-	) -> Result<(), DispatchError> {
 		unimplemented!()
 	}
 }

--- a/pallets/ajuna-nft-transfer/src/tests.rs
+++ b/pallets/ajuna-nft-transfer/src/tests.rs
@@ -127,7 +127,7 @@ mod store_prepared_as_nft {
 			.execute_with(|| {
 				// setup
 				MockAccountManager::set_organizer(ALICE);
-				let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+				let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 				assert_ok!(NftTransfer::set_service_account(RuntimeOrigin::root(), ALICE));
 
 				let collection_id = create_collection(ALICE);
@@ -161,7 +161,7 @@ mod store_prepared_as_nft {
 	#[test]
 	fn store_prepared_as_nft_rejects_unowned_assets() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_noop!(
 				NftTransfer::store_prepared_as_nft(RuntimeOrigin::signed(BOB), asset_id),
 				DispatchError::Other(NOT_OWNER_ERR)
@@ -172,7 +172,7 @@ mod store_prepared_as_nft {
 	#[test]
 	fn store_prepared_as_nft_rejects_if_no_collection_id_set() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_noop!(
 				NftTransfer::store_prepared_as_nft(RuntimeOrigin::signed(ALICE), asset_id),
 				Error::<Test>::CollectionIdNotSet
@@ -184,7 +184,7 @@ mod store_prepared_as_nft {
 	fn store_prepared_as_nft_rejects_unprepared_asset() {
 		ExtBuilder::default().build().execute_with(|| {
 			let collection_id = 369;
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_ok!(NftTransfer::set_collection_id(RuntimeOrigin::signed(ALICE), collection_id));
 			assert_noop!(
 				NftTransfer::store_prepared_as_nft(RuntimeOrigin::signed(ALICE), asset_id),
@@ -210,7 +210,7 @@ mod recover_asset_from_nft {
 			.execute_with(|| {
 				// setup
 				MockAccountManager::set_organizer(ALICE);
-				let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+				let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 				assert_ok!(NftTransfer::set_service_account(RuntimeOrigin::root(), ALICE));
 
 				let collection_id = create_collection(ALICE);
@@ -257,7 +257,7 @@ mod recover_asset_from_nft {
 			.build()
 			.execute_with(|| {
 				// preparation
-				let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+				let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 
 				assert_noop!(
 					NftTransfer::recover_asset_from_nft(RuntimeOrigin::signed(ALICE), asset_id),
@@ -281,7 +281,7 @@ mod prepare_asset {
 			.balances(&[(ALICE, initial_balance)])
 			.build()
 			.execute_with(|| {
-				let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+				let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 				assert_ok!(NftTransfer::set_service_account(RuntimeOrigin::root(), BOB));
 				assert_eq!(Balances::free_balance(ALICE), initial_balance);
 				assert_ok!(NftTransfer::prepare_asset(RuntimeOrigin::signed(ALICE), asset_id));
@@ -296,7 +296,7 @@ mod prepare_asset {
 	#[test]
 	fn prepare_asset_rejects_unsigned_calls() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_noop!(
 				NftTransfer::prepare_asset(RuntimeOrigin::none(), asset_id),
 				DispatchError::BadOrigin
@@ -307,7 +307,7 @@ mod prepare_asset {
 	#[test]
 	fn prepare_asset_rejects_unowned_assets() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_noop!(
 				NftTransfer::prepare_asset(RuntimeOrigin::signed(BOB), asset_id),
 				DispatchError::Other(NOT_OWNER_ERR)
@@ -318,7 +318,7 @@ mod prepare_asset {
 	#[test]
 	fn prepare_asset_rejects_when_closed() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			MockAssetManager::set_nft_transfer_open(false);
 			assert_ok!(NftTransfer::set_service_account(RuntimeOrigin::root(), BOB));
 			assert_noop!(
@@ -331,7 +331,7 @@ mod prepare_asset {
 	#[test]
 	fn prepare_asset_rejects_locked_assets() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			MockAssetManager::lock_asset(<Test as Config>::PalletId::get().0, ALICE, asset_id)
 				.unwrap();
 			assert_noop!(
@@ -344,7 +344,7 @@ mod prepare_asset {
 	#[test]
 	fn prepare_asset_rejects_already_prepared_assets() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			let ipfs_url = IpfsUrl::try_from(Vec::new()).unwrap();
 			Preparation::<Test>::insert(asset_id, ipfs_url);
 			assert_noop!(
@@ -360,7 +360,7 @@ mod prepare_asset {
 			.balances(&[(ALICE, MockExistentialDeposit::get()), (BOB, 999_999)])
 			.build()
 			.execute_with(|| {
-				let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+				let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 				assert_ok!(NftTransfer::set_service_account(RuntimeOrigin::root(), BOB));
 				assert_noop!(
 					NftTransfer::prepare_asset(RuntimeOrigin::signed(ALICE), asset_id),
@@ -377,7 +377,7 @@ mod unprepare_asset {
 	#[test]
 	fn unprepare_asset_works() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_ok!(NftTransfer::set_service_account(RuntimeOrigin::root(), ALICE));
 			assert_ok!(NftTransfer::prepare_asset(RuntimeOrigin::signed(ALICE), asset_id));
 			assert_ok!(NftTransfer::unprepare_asset(RuntimeOrigin::signed(ALICE), asset_id));
@@ -401,7 +401,7 @@ mod unprepare_asset {
 	#[test]
 	fn unprepare_asset_rejects_unowned_assets() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_noop!(
 				NftTransfer::unprepare_asset(RuntimeOrigin::signed(BOB), asset_id),
 				DispatchError::Other(NOT_OWNER_ERR)
@@ -412,7 +412,7 @@ mod unprepare_asset {
 	#[test]
 	fn unprepare_asset_rejects_when_closed() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			MockAssetManager::set_nft_transfer_open(false);
 			assert_noop!(
 				NftTransfer::unprepare_asset(RuntimeOrigin::signed(ALICE), asset_id),
@@ -424,7 +424,7 @@ mod unprepare_asset {
 	#[test]
 	fn unprepare_asset_rejects_unprepared_assets() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_noop!(
 				NftTransfer::unprepare_asset(RuntimeOrigin::signed(ALICE), asset_id),
 				Error::<Test>::AssetUnprepared
@@ -440,7 +440,7 @@ mod prepare_ipfs {
 	#[test]
 	fn prepare_ipfs_works() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_ok!(NftTransfer::set_service_account(RuntimeOrigin::root(), ALICE));
 			assert_ok!(NftTransfer::prepare_asset(RuntimeOrigin::signed(ALICE), asset_id));
 			ServiceAccount::<Test>::put(BOB);
@@ -476,7 +476,7 @@ mod prepare_ipfs {
 	fn prepare_ipfs_rejects_when_closed() {
 		ExtBuilder::default().build().execute_with(|| {
 			MockAssetManager::set_nft_transfer_open(false);
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_ok!(NftTransfer::set_service_account(RuntimeOrigin::root(), ALICE));
 
 			assert_noop!(
@@ -493,7 +493,7 @@ mod prepare_ipfs {
 	#[test]
 	fn prepare_ipfs_rejects_unprepared_asset() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_ok!(NftTransfer::set_service_account(RuntimeOrigin::root(), ALICE));
 			assert_noop!(
 				NftTransfer::prepare_ipfs(RuntimeOrigin::signed(BOB), asset_id, IpfsUrl::default()),
@@ -505,7 +505,7 @@ mod prepare_ipfs {
 	#[test]
 	fn prepare_ipfs_rejects_empty_url() {
 		ExtBuilder::default().build().execute_with(|| {
-			let (asset_id, _) = MockAssetManager::create_assets(ALICE, 1)[0];
+			let asset_id = MockAssetManager::create_items(ALICE, 1)[0];
 			assert_ok!(NftTransfer::set_service_account(RuntimeOrigin::root(), ALICE));
 			assert_ok!(NftTransfer::prepare_asset(RuntimeOrigin::signed(ALICE), asset_id));
 

--- a/pallets/ajuna-seasons/src/mock.rs
+++ b/pallets/ajuna-seasons/src/mock.rs
@@ -132,20 +132,7 @@ impl AccountManager for MockAccountManager {
 		})
 	}
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_organizer(owner: Self::AccountId) {
-		MockAccountManager::set_organizer(owner);
-	}
-
 	fn is_whitelisted_for(_identifier: &WhitelistKey, _account: &Self::AccountId) -> bool {
-		unimplemented!()
-	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn try_set_whitelisted_for(
-		_identifier: &WhitelistKey,
-		_account: &Self::AccountId,
-	) -> Result<(), DispatchError> {
 		unimplemented!()
 	}
 }

--- a/pallets/ajuna-tournament/src/benchmarking.rs
+++ b/pallets/ajuna-tournament/src/benchmarking.rs
@@ -25,7 +25,6 @@ use crate::{
 	},
 	Pallet as Tournament, *,
 };
-use ajuna_primitives::asset_manager::AssetManager;
 use frame_benchmarking::benchmarks_instance_pallet;
 use frame_system::RawOrigin;
 use sp_runtime::BuildStorage;
@@ -50,7 +49,7 @@ const ACC_1: &str = "acc_1";
 fn create_owned_entity<T: Config<I>, I: 'static>(
 	account: T::AccountId,
 ) -> (T::EntityId, T::RankedEntity) {
-	let mut assets = T::AssetManager::create_assets(account, 1);
+	let mut assets = T::BenchmarkHelper::create_entities(account, 1);
 	assets.pop().unwrap()
 }
 

--- a/pallets/ajuna-tournament/src/lib.rs
+++ b/pallets/ajuna-tournament/src/lib.rs
@@ -84,41 +84,6 @@ pub mod pallet {
 		fn create_entities(owner: AccountId, count: u32) -> sp_std::vec::Vec<(EntityId, Entity)>;
 	}
 
-	#[cfg(feature = "runtime-benchmarks")]
-	impl<
-			CategoryId: From<u32>,
-			BlockNumber: From<u64>,
-			Balance: From<u64>,
-			Ranker: Default,
-			AccountId,
-			EntityId,
-			Entity,
-		> BenchmarkHelper<CategoryId, BlockNumber, Balance, Ranker, AccountId, EntityId, Entity> for ()
-	{
-		fn create_category_id(id: u32) -> CategoryId {
-			id.into()
-		}
-
-		fn create_default_tournament_config() -> TournamentConfig<BlockNumber, Balance, Ranker> {
-			TournamentConfig {
-				start: 20_u64.into(),
-				active_end: 40_u64.into(),
-				claim_end: 50_u64.into(),
-				initial_reward: None,
-				max_reward: None,
-				take_fee_percentage: None,
-				reward_distribution: Default::default(),
-				golden_duck_config: Default::default(),
-				max_players: 0,
-				ranker: Ranker::default(),
-			}
-		}
-
-		fn create_entities(_owner: AccountId, _count: u32) -> sp_std::vec::Vec<(EntityId, Entity)> {
-			sp_std::vec::Vec::with_capacity(0)
-		}
-	}
-
 	/// The current storage version.
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 

--- a/pallets/ajuna-tournament/src/lib.rs
+++ b/pallets/ajuna-tournament/src/lib.rs
@@ -75,15 +75,25 @@ pub mod pallet {
 	pub(crate) type GoldenDuckStateFor<T, I> = GoldenDuckState<<T as Config<I>>::EntityId>;
 
 	#[cfg(feature = "runtime-benchmarks")]
-	pub trait BenchmarkHelper<CategoryId, BlockNumber, Balance, Ranker> {
+	pub trait BenchmarkHelper<CategoryId, BlockNumber, Balance, Ranker, AccountId, EntityId, Entity>
+	{
 		fn create_category_id(id: u32) -> CategoryId;
 
 		fn create_default_tournament_config() -> TournamentConfig<BlockNumber, Balance, Ranker>;
+
+		fn create_entities(owner: AccountId, count: u32) -> sp_std::vec::Vec<(EntityId, Entity)>;
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	impl<CategoryId: From<u32>, BlockNumber: From<u64>, Balance: From<u64>, Ranker: Default>
-		BenchmarkHelper<CategoryId, BlockNumber, Balance, Ranker> for ()
+	impl<
+			CategoryId: From<u32>,
+			BlockNumber: From<u64>,
+			Balance: From<u64>,
+			Ranker: Default,
+			AccountId,
+			EntityId,
+			Entity,
+		> BenchmarkHelper<CategoryId, BlockNumber, Balance, Ranker, AccountId, EntityId, Entity> for ()
 	{
 		fn create_category_id(id: u32) -> CategoryId {
 			id.into()
@@ -102,6 +112,10 @@ pub mod pallet {
 				max_players: 0,
 				ranker: Ranker::default(),
 			}
+		}
+
+		fn create_entities(_owner: AccountId, _count: u32) -> sp_std::vec::Vec<(EntityId, Entity)> {
+			sp_std::vec::Vec::with_capacity(0)
 		}
 	}
 
@@ -157,6 +171,9 @@ pub mod pallet {
 			BlockNumberFor<Self>,
 			BalanceOf<Self, I>,
 			Self::EntityRanker,
+			AccountIdFor<Self>,
+			EntityIdFor<Self, I>,
+			Self::RankedEntity,
 		>;
 	}
 

--- a/pallets/ajuna-tournament/src/mock.rs
+++ b/pallets/ajuna-tournament/src/mock.rs
@@ -34,11 +34,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
 	MultiSignature,
 };
-use sp_std::{
-	cell::RefCell,
-	cmp::Ordering,
-	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-};
+use sp_std::{cell::RefCell, cmp::Ordering, collections::btree_map::BTreeMap};
 
 pub type MockSignature = MultiSignature;
 pub type MockAccountPublic = <MockSignature as Verify>::Signer;
@@ -140,7 +136,6 @@ impl EntityRank for MockRanker {
 }
 
 thread_local! {
-	pub static WHITELISTED_ACCOUNTS: RefCell<BTreeMap<WhitelistKey ,BTreeSet<MockAccountId>>> = RefCell::new(BTreeMap::new());
 	pub static ORGANIZER: RefCell<Option<MockAccountId>> = RefCell::new(None);
 	pub static ASSETS: RefCell<BTreeMap<MockEntityId, MockEntity>> = RefCell::new(BTreeMap::new());
 	pub static OWNERS: RefCell<BTreeMap<MockAccountId, MockEntityId>> = RefCell::new(BTreeMap::new());
@@ -152,20 +147,6 @@ pub const ACCOUNT_IS_NOT_ORGANIZER: &str = "ACCOUNT_IS_NOT_ORGANIZER";
 pub const NO_ORGANIZER_SET: &str = "NO_ORGANIZER_SET";
 
 impl MockAccountManager {
-	pub(crate) fn try_add_to_whitelist(
-		identifier: &WhitelistKey,
-		account: &MockAccountId,
-	) -> Result<(), DispatchError> {
-		WHITELISTED_ACCOUNTS.with(|accounts| {
-			if let Some(entry) = accounts.borrow_mut().get_mut(identifier) {
-				entry.insert(account.clone());
-				Ok(())
-			} else {
-				Err(DispatchError::Other("No account set for identifier"))
-			}
-		})
-	}
-
 	pub(crate) fn set_organizer(owner: MockAccountId) {
 		ORGANIZER.with(|maybe_account| {
 			*maybe_account.borrow_mut() = Some(owner);
@@ -187,27 +168,8 @@ impl AccountManager for MockAccountManager {
 		})
 	}
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_organizer(owner: Self::AccountId) {
-		MockAccountManager::set_organizer(owner);
-	}
-
-	fn is_whitelisted_for(identifier: &WhitelistKey, account: &Self::AccountId) -> bool {
-		WHITELISTED_ACCOUNTS.with(|accounts| {
-			if let Some(entry) = accounts.borrow_mut().get_mut(identifier) {
-				entry.contains(account)
-			} else {
-				false
-			}
-		})
-	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn try_set_whitelisted_for(
-		identifier: &WhitelistKey,
-		account: &Self::AccountId,
-	) -> Result<(), DispatchError> {
-		Self::try_add_to_whitelist(identifier, account)
+	fn is_whitelisted_for(_identifier: &WhitelistKey, _account: &Self::AccountId) -> bool {
+		unimplemented!()
 	}
 }
 
@@ -287,11 +249,6 @@ impl AssetManager for MockAssetManager {
 	) -> Result<(), DispatchError> {
 		unimplemented!()
 	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn create_assets(owner: Self::AccountId, count: u32) -> Vec<(Self::AssetId, Self::Asset)> {
-		Self::create_assets(owner, count)
-	}
 }
 
 parameter_types! {
@@ -304,8 +261,16 @@ parameter_types! {
 pub struct TournamentBenchmarkHelper;
 
 #[cfg(feature = "runtime-benchmarks")]
-impl BenchmarkHelper<MockCategoryId, MockBlockNumber, MockBalance, MockRanker>
-	for TournamentBenchmarkHelper
+impl
+	BenchmarkHelper<
+		MockCategoryId,
+		MockBlockNumber,
+		MockBalance,
+		MockRanker,
+		MockAccountId,
+		MockEntityId,
+		MockEntity,
+	> for TournamentBenchmarkHelper
 {
 	fn create_category_id(id: u32) -> MockCategoryId {
 		id
@@ -325,6 +290,10 @@ impl BenchmarkHelper<MockCategoryId, MockBlockNumber, MockBalance, MockRanker>
 			max_players: 4,
 			ranker: MockRanker,
 		}
+	}
+
+	fn create_entities(owner: MockAccountId, count: u32) -> Vec<(MockEntityId, MockEntity)> {
+		MockAssetManager::create_assets(owner, count)
 	}
 }
 

--- a/primitives/src/account_manager.rs
+++ b/primitives/src/account_manager.rs
@@ -26,14 +26,5 @@ pub trait AccountManager {
 
 	fn is_organizer(account: &Self::AccountId) -> Result<(), DispatchError>;
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_organizer(owner: Self::AccountId);
-
 	fn is_whitelisted_for(identifier: &WhitelistKey, account: &Self::AccountId) -> bool;
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn try_set_whitelisted_for(
-		identifier: &WhitelistKey,
-		account: &Self::AccountId,
-	) -> Result<(), DispatchError>;
 }

--- a/primitives/src/asset_manager.rs
+++ b/primitives/src/asset_manager.rs
@@ -78,9 +78,6 @@ pub trait AssetManager {
 		from: &Self::AccountId,
 		fees_recipient: &Self::AccountId,
 	) -> Result<(), DispatchError>;
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn create_assets(owner: Self::AccountId, count: u32) -> Vec<(Self::AssetId, Self::Asset)>;
 }
 
 pub trait AssetInspector {

--- a/primitives/src/trade_manager.rs
+++ b/primitives/src/trade_manager.rs
@@ -22,7 +22,7 @@ pub trait TradeManager {
 
 	type Asset: Member + Parameter + MaxEncodedLen;
 
-	fn is_tradeable_using(asset: &Self::Asset, filter: &Self::TradeFilter) -> bool;
+	fn can_be_traded_using(asset: &Self::Asset, filter: &Self::TradeFilter) -> bool;
 }
 
 pub trait TransferManager {
@@ -30,5 +30,5 @@ pub trait TransferManager {
 
 	type Asset: Member + Parameter + MaxEncodedLen;
 
-	fn is_transferable_using(asset: &Self::Asset, filter: &Self::TransferFilter) -> bool;
+	fn can_be_transferred_using(asset: &Self::Asset, filter: &Self::TransferFilter) -> bool;
 }

--- a/primitives/src/treasury_manager.rs
+++ b/primitives/src/treasury_manager.rs
@@ -38,9 +38,6 @@ pub trait TreasuryManager {
 	/// Get the assigned holder of the treasury pot for the given key
 	fn get_treasurer_for(key: Self::TreasuryPotKey) -> Result<Self::AccountId, DispatchError>;
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_treasurer_for(key: Self::TreasuryPotKey, owner: Self::AccountId);
-
 	/// Deposit the given amount to the treasury pot for the given key
 	fn deposit_into(
 		depository: &Self::AccountId,

--- a/sage/api/src/traits.rs
+++ b/sage/api/src/traits.rs
@@ -4,7 +4,7 @@ use scale_info::TypeInfo;
 use sp_runtime::traits::Member;
 use sp_std::vec::Vec;
 
-pub trait Identifiable<Id> {
+pub trait GetId<Id> {
 	fn get_id(&self) -> Id;
 }
 
@@ -21,7 +21,7 @@ pub trait SageGameTransition {
 	type TransitionConfig: Member + Parameter + MaxEncodedLen + TypeInfo + Default;
 	type AccountId: Member + Codec;
 	type AssetId: Member + Parameter + MaxEncodedLen + TypeInfo;
-	type Asset: Member + Parameter + MaxEncodedLen + TypeInfo + Identifiable<Self::AssetId>;
+	type Asset: Member + Parameter + MaxEncodedLen + TypeInfo + GetId<Self::AssetId>;
 	/// An optional extra, which is simply forwarded to the `verify_rule` and `do_transition`
 	/// method. If you don't need custom arguments, you can define that type as `()`.
 	type Extra: Member + Parameter + MaxEncodedLen + TypeInfo;

--- a/sage/api/src/traits.rs
+++ b/sage/api/src/traits.rs
@@ -24,7 +24,7 @@ pub trait SageGameTransition {
 	type Asset: Member + Parameter + MaxEncodedLen + TypeInfo + GetId<Self::AssetId>;
 	/// An optional extra, which is simply forwarded to the `verify_rule` and `do_transition`
 	/// method. If you don't need custom arguments, you can define that type as `()`.
-	type Extra: Member + Parameter + MaxEncodedLen + TypeInfo;
+	type Extra: Member + Parameter + MaxEncodedLen + TypeInfo + Default;
 
 	fn verify_rule(
 		transition_id: &Self::TransitionId,

--- a/sage/api/src/traits.rs
+++ b/sage/api/src/traits.rs
@@ -4,6 +4,10 @@ use scale_info::TypeInfo;
 use sp_runtime::traits::Member;
 use sp_std::vec::Vec;
 
+pub trait Identifiable<Id> {
+	fn get_id(&self) -> Id;
+}
+
 pub enum TransitionOutput<AssetId, Asset> {
 	Minted(Asset),
 	Mutated(AssetId, Asset),
@@ -13,9 +17,11 @@ pub enum TransitionOutput<AssetId, Asset> {
 pub trait SageGameTransition {
 	/// Transition identifier type.
 	type TransitionId: Member + Parameter + MaxEncodedLen + TypeInfo;
+	/// THe type of the specific configuration options for the transition
+	type TransitionConfig: Member + Parameter + MaxEncodedLen + TypeInfo + Default;
 	type AccountId: Member + Codec;
 	type AssetId: Member + Parameter + MaxEncodedLen + TypeInfo;
-	type Asset: Member + Parameter + MaxEncodedLen + TypeInfo;
+	type Asset: Member + Parameter + MaxEncodedLen + TypeInfo + Identifiable<Self::AssetId>;
 	/// An optional extra, which is simply forwarded to the `verify_rule` and `do_transition`
 	/// method. If you don't need custom arguments, you can define that type as `()`.
 	type Extra: Member + Parameter + MaxEncodedLen + TypeInfo;

--- a/sage/example-transition/src/concrete.rs
+++ b/sage/example-transition/src/concrete.rs
@@ -41,6 +41,7 @@ where
 					.map_err(|_| sage_api::Error::InvalidTransitionId)?;
 				Ok(())
 			},
+			BenchTransition => Ok(()),
 		}
 	}
 
@@ -62,6 +63,7 @@ where
 			ConsumeAsset => {
 				consume_asset(&mut asset)?;
 			},
+			BenchTransition => {},
 		}
 
 		Ok(vec![TransitionOutput::Mutated(asset_ids[0], asset)])

--- a/sage/example-transition/src/concrete.rs
+++ b/sage/example-transition/src/concrete.rs
@@ -74,6 +74,7 @@ where
 		+ AssetInspector<AssetId = AssetId, Asset = Asset>,
 {
 	type TransitionId = ExampleTransitionId;
+	type TransitionConfig = ();
 	type AccountId = AccountId;
 
 	type AssetId = AssetId;

--- a/sage/example-transition/src/generic.rs
+++ b/sage/example-transition/src/generic.rs
@@ -3,12 +3,13 @@
 //! The pattern here follows the generic style of frame, and therefore is the easiest to integrate
 //! within frame. However, it is a bit harder to understand for downstream implementors.
 
-use crate::types::{consume_asset, Asset, AssetId, ExampleTransitionId};
+use crate::types::{consume_asset, Asset, AssetId, ExampleTransitionId, Level};
 use ajuna_primitives::asset_manager::{AssetInspector, AssetManager};
 use core::marker::PhantomData;
 use frame_support::pallet_prelude::Member;
 use parity_scale_codec::Codec;
 use sage_api::{rules::ensure_asset_length, traits::TransitionOutput, SageGameTransition};
+use sp_core::H256;
 
 pub struct ExampleTransitionGeneric<AccountId, AssetHandler> {
 	phantom_data: PhantomData<(AccountId, AssetHandler)>,
@@ -40,6 +41,14 @@ where
 					.map_err(|_| sage_api::Error::InvalidTransitionId)?;
 				Ok(())
 			},
+			BenchTransition => {
+				ensure_asset_length(assets, 5)?;
+				for asset in assets.iter() {
+					let _ = AssetHandler::ensure_ownership(account, asset)
+						.map_err(|_| sage_api::Error::InvalidTransitionId)?;
+				}
+				Ok(())
+			},
 		}
 	}
 
@@ -50,19 +59,40 @@ where
 		asset_ids: &[AssetId],
 	) -> Result<Vec<TransitionOutput<AssetId, Asset>>, sage_api::Error> {
 		use ExampleTransitionId::*;
-		let mut asset = AssetHandler::get_asset(&asset_ids[0])
-			.map_err(|_| sage_api::Error::Transition { error: 0 })?;
-
 		match transition_id {
 			UpgradeAsset => {
+				let mut asset = AssetHandler::get_asset(&asset_ids[0])
+					.map_err(|_| sage_api::Error::Transition { error: 0 })?;
 				asset.level = asset.level.upgrade()?;
+				Ok(vec![TransitionOutput::Mutated(asset_ids[0], asset)])
 			},
 			ConsumeAsset => {
+				let mut asset = AssetHandler::get_asset(&asset_ids[0])
+					.map_err(|_| sage_api::Error::Transition { error: 0 })?;
 				consume_asset(&mut asset)?;
+				Ok(vec![TransitionOutput::Consumed(asset_ids[0])])
+			},
+			BenchTransition => {
+				let mut output_vec = Vec::with_capacity(15);
+
+				for asset_id in asset_ids {
+					output_vec.push(TransitionOutput::Consumed(*asset_id));
+				}
+
+				for i in 0..10 {
+					let asset_id = {
+						let mut base = H256::repeat_byte(i as u8);
+						base.0[i] = asset_ids[0].0[i] % (i as u8 + 1) * 13;
+						base
+					};
+					let asset =
+						Asset::create(asset_id, i as u32, 0, 0, [i as u8; 32], 10, Level::Two);
+					output_vec.push(TransitionOutput::Minted(asset))
+				}
+
+				Ok(output_vec)
 			},
 		}
-
-		Ok(vec![TransitionOutput::Mutated(asset_ids[0], asset)])
 	}
 }
 

--- a/sage/example-transition/src/generic.rs
+++ b/sage/example-transition/src/generic.rs
@@ -74,6 +74,7 @@ where
 		+ AssetInspector<AssetId = AssetId, Asset = Asset>,
 {
 	type TransitionId = ExampleTransitionId;
+	type TransitionConfig = ();
 	type AccountId = AccountId;
 
 	type AssetId = AssetId;

--- a/sage/example-transition/src/types.rs
+++ b/sage/example-transition/src/types.rs
@@ -3,7 +3,7 @@
 //! These should be expanded to really showcase the power of the SageApi design.
 
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use sage_api::traits::Identifiable;
+use sage_api::traits::GetId;
 use scale_info::TypeInfo;
 use sp_core::H256;
 
@@ -54,7 +54,7 @@ impl Asset {
 	}
 }
 
-impl Identifiable<AssetId> for Asset {
+impl GetId<AssetId> for Asset {
 	fn get_id(&self) -> AssetId {
 		self.asset_id
 	}

--- a/sage/example-transition/src/types.rs
+++ b/sage/example-transition/src/types.rs
@@ -3,6 +3,7 @@
 //! These should be expanded to really showcase the power of the SageApi design.
 
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use sage_api::traits::Identifiable;
 use scale_info::TypeInfo;
 use sp_core::H256;
 
@@ -11,6 +12,8 @@ pub type AssetId = H256;
 /// Placeholder type, this was just a quick brain dump to get things going.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Encode, Decode, MaxEncodedLen, TypeInfo)]
 pub struct Asset {
+	asset_id: H256,
+
 	pub collection_id: u32,
 
 	pub asset_type: u32,
@@ -26,6 +29,35 @@ pub struct Asset {
 
 	// Example of a game's custom field.
 	pub consumed: bool,
+}
+
+impl Asset {
+	pub fn create(
+		asset_id: H256,
+		collection_id: u32,
+		asset_type: u32,
+		asset_sub_type: u32,
+		dna: [u8; 32],
+		minted_at: u32,
+		level: Level,
+	) -> Self {
+		Self {
+			asset_id,
+			collection_id,
+			asset_type,
+			asset_sub_type,
+			dna,
+			minted_at,
+			level,
+			consumed: false,
+		}
+	}
+}
+
+impl Identifiable<AssetId> for Asset {
+	fn get_id(&self) -> AssetId {
+		self.asset_id
+	}
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Encode, Decode, MaxEncodedLen, TypeInfo)]

--- a/sage/example-transition/src/types.rs
+++ b/sage/example-transition/src/types.rs
@@ -89,6 +89,7 @@ impl Level {
 pub enum ExampleTransitionId {
 	UpgradeAsset,
 	ConsumeAsset,
+	BenchTransition,
 }
 
 /// One specific transition that a game wants to execute.

--- a/sage/pallet/Cargo.toml
+++ b/sage/pallet/Cargo.toml
@@ -22,6 +22,11 @@ sp-std             = { workspace = true }
 ajuna-primitives   = { workspace = true }
 sage-api           = { workspace = true }
 
+# Benchmarking
+frame-benchmarking = { workspace = true, optional = true }
+example-transition = { workspace = true, optional = true }
+pallet-balances    = { workspace = true, optional = true }
+
 [dev-dependencies]
 example-transition = { workspace = true, features = ["std"] }
 pallet-balances = { workspace = true, features = ["std"] }
@@ -29,6 +34,7 @@ pallet-balances = { workspace = true, features = ["std"] }
 [features]
 default = [ "std" ]
 std = [
+    "frame-benchmarking/std",
     "frame-support/std",
     "frame-system/std",
     "parity-scale-codec/std",
@@ -45,6 +51,7 @@ std = [
     "example-transition/std",
 ]
 runtime-benchmarks = [
+    "frame-benchmarking/runtime-benchmarks",
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
     "sp-runtime/runtime-benchmarks",

--- a/sage/pallet/src/benchmarking.rs
+++ b/sage/pallet/src/benchmarking.rs
@@ -19,13 +19,13 @@
 
 use crate::{
 	config::{InventoryTier, Locks},
-	mock::{Balances, RuntimeOrigin, SageBenchmarkHelper, System, Test, SEASON_ID_0},
-	pallet::AssetFilterOf,
-	AssetTradePrices, BalanceOf, BenchmarkHelper, Call, Config, Event, GeneralConfigOf,
+	mock::{Balances, RuntimeOrigin, System, Test, SEASON_ID_0},
+	pallet::{AssetFilterOf, TradeFilterOf, TransferFilterOf},
+	AssetTradePrices, BalanceOf, BenchmarkHelper, Call, Config, Event, ExtraOf, GeneralConfigOf,
 	GeneralConfigStore, LockableFeature, Organizer, Pallet, PlayerSeasonConfigs, SeasonUnlocks,
 	UnlockRule, UnlockTarget, SAGE_LOCK_ID,
 };
-use ajuna_primitives::asset_manager::Lock;
+use ajuna_primitives::{asset_manager::Lock, season_manager::SeasonManager};
 use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
 use sp_runtime::BuildStorage;
@@ -54,11 +54,7 @@ benchmarks! {
 
 	update_general_config {
 		let acc_1 = account::<T, ()>(ACC_1);
-		let general_config = GeneralConfigOf::<T, ()> {
-			transition: T::BenchmarkHelper::create_transition_config(0),
-			transfer: Default::default(),
-			trade: Default::default()
-		};
+		let general_config = GeneralConfigOf::<T, ()>::default();
 	}: _(RawOrigin::Signed(acc_1), general_config.clone())
 	verify {
 		assert_last_event::<T, ()>(Event::UpdatedGeneralConfig { updated_config: general_config })
@@ -66,10 +62,10 @@ benchmarks! {
 
 	update_unlock_rule {
 		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
 		let feature = LockableFeature::TradeAsset;
 		let unlock_rule: UnlockRule = [10, 10, 10, 10, 10];
-		// Benchmark helper season_id
 	}: _(RawOrigin::Signed(acc_1), season_id.clone(), feature, unlock_rule)
 	verify {
 		assert_last_event::<T, ()>(Event::UpdatedUnlockRule {
@@ -82,9 +78,9 @@ benchmarks! {
 	upgrade_asset_inventory {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let acc_2 = account::<T, ()>(ACC_2);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
 		let in_season = Some(season_id.clone());
-		// Benchmark helper season_id
 	}: _(RawOrigin::Signed(acc_1), Some(acc_2.clone()), in_season)
 	verify {
 		assert_last_event::<T, ()>(Event::InventoryTierUpgraded {
@@ -96,8 +92,9 @@ benchmarks! {
 
 	update_asset_trade_filter {
 		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let filter = T::BenchmarkHelper::create_asset_trade_filter(0);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
+		let filter = TradeFilterOf::<T, ()>::default();
 		let trade_filter = AssetFilterOf::<T, ()>::Trade(filter.clone());
 	}: update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), trade_filter)
 	verify {
@@ -109,8 +106,9 @@ benchmarks! {
 
 	update_asset_transfer_filter {
 		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let filter = T::BenchmarkHelper::create_asset_transfer_filter(0);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
+		let filter = TransferFilterOf::<T, ()>::default();
 		let transfer_filter = AssetFilterOf::<T, ()>::Transfer(filter.clone());
 	}: update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), transfer_filter)
 	verify {
@@ -123,8 +121,9 @@ benchmarks! {
 	transfer_asset {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let acc_2 = account::<T, ()>(ACC_2);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 2);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
+		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 2);
 	}: _(RawOrigin::Signed(acc_1.clone()), acc_2.clone(), asset_id.clone())
 	verify {
 		assert_last_event::<T, ()>(Event::AssetTransferred {
@@ -136,8 +135,9 @@ benchmarks! {
 
 	set_asset_price {
 		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
+		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let price = 45_242_u32;
 	}: _(RawOrigin::Signed(acc_1), asset_id.clone(), price.into())
 	verify {
@@ -149,8 +149,9 @@ benchmarks! {
 
 	remove_asset_price {
 		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
+		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let price = BalanceOf::<T, ()>::from(45_242_u32);
 		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, price);
 	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
@@ -163,8 +164,9 @@ benchmarks! {
 	buy_asset {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let acc_2 = account::<T, ()>(ACC_2);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
+		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let price = BalanceOf::<T, ()>::from(45_242_u32);
 		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, price);
 	}: _(RawOrigin::Signed(acc_2.clone()), asset_id.clone())
@@ -179,8 +181,9 @@ benchmarks! {
 
 	lock_asset {
 		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
+		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let expected_lock = Lock::new(*SAGE_LOCK_ID, acc_1.clone());
 	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
 	verify {
@@ -192,8 +195,9 @@ benchmarks! {
 
 	unlock_asset {
 		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
+		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let expected_lock = Lock::new(*SAGE_LOCK_ID, acc_1.clone());
 		Pallet::<T, ()>::lock_asset(
 			RawOrigin::Signed(acc_1.clone()).into(),
@@ -211,7 +215,8 @@ benchmarks! {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let target = UnlockTarget::OneselfFree;
 		let feature = LockableFeature::TradeAsset;
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
 	}: unlock_feature(RawOrigin::Signed(acc_1.clone()), target, feature, season_id.clone())
 	verify {
 		assert_last_event::<T, ()>(Event::FeatureUnlocked {
@@ -225,7 +230,8 @@ benchmarks! {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let target = UnlockTarget::OneselfFree;
 		let feature = LockableFeature::TransferAsset;
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
 	}: unlock_feature(RawOrigin::Signed(acc_1.clone()), target, feature, season_id.clone())
 	verify {
 		assert_last_event::<T, ()>(Event::FeatureUnlocked {
@@ -237,9 +243,10 @@ benchmarks! {
 
 	state_transition {
 		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+			.expect("Should get current season");
 		let (transition_id, asset_ids) = T::BenchmarkHelper::create_bench_transition_for(&acc_1, &season_id, 99);
-		let extra = T::BenchmarkHelper::create_extra(0);
+		let extra = ExtraOf::<T, ()>::default();
 	}: _(RawOrigin::Signed(acc_1.clone()), transition_id.clone(), asset_ids, extra)
 	verify {
 		assert_last_event::<T, ()>(Event::TransitionExecuted {

--- a/sage/pallet/src/benchmarking.rs
+++ b/sage/pallet/src/benchmarking.rs
@@ -18,101 +18,17 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use crate::{
-	mock::{
-		Balances, MockAccountId, MockAffiliatesFeeProvider, MockFilterHandler, MockSeasonManager,
-		MockTournamentFeeProvider, MockTransitionFeeProvider, MockTreasuryManager, RuntimeEvent,
-		RuntimeOrigin, SageBenchmarkHelper, System, Test, SEASON_ID_0,
-	},
-	Pallet as Sage, *,
+	config::{InventoryTier, Locks},
+	mock::{Balances, RuntimeOrigin, SageBenchmarkHelper, System, Test, SEASON_ID_0},
+	pallet::AssetFilterOf,
+	AssetTradePrices, BalanceOf, BenchmarkHelper, Call, Config, Event, GeneralConfigOf,
+	GeneralConfigStore, LockableFeature, Organizer, Pallet, PlayerSeasonConfigs, SeasonUnlocks,
+	UnlockRule, UnlockTarget, SAGE_LOCK_ID,
 };
-use ajuna_primitives::{asset_manager::AssetInspector, fee_handler::GameFeeHandler};
-use example_transition::{
-	generic::ExampleTransitionGeneric,
-	types::{Asset, AssetId},
-};
-use frame_benchmarking::benchmarks_instance_pallet;
-use frame_support::parameter_types;
+use ajuna_primitives::asset_manager::Lock;
+use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
 use sp_runtime::BuildStorage;
-
-parameter_types! {
-	pub const BenchPalletId: PalletId = PalletId(*b"sage/bch");
-}
-
-pub struct MockAssetMediatorBench;
-
-impl AssetManager for MockAssetMediatorBench {
-	type AccountId = MockAccountId;
-	type AssetId = AssetId;
-	type Asset = Asset;
-
-	fn ensure_ownership(
-		owner: &Self::AccountId,
-		asset_id: &Self::AssetId,
-	) -> Result<Self::Asset, DispatchError> {
-		<Sage<Test, ()> as AssetManager>::ensure_ownership(owner, asset_id)
-	}
-
-	fn lock_asset(
-		lock_id: LockIdentifier,
-		owner: Self::AccountId,
-		asset_id: Self::AssetId,
-	) -> Result<Self::Asset, DispatchError> {
-		<Sage<Test, ()> as AssetManager>::lock_asset(lock_id, owner, asset_id)
-	}
-
-	fn unlock_asset(
-		lock_id: LockIdentifier,
-		owner: Self::AccountId,
-		asset_id: Self::AssetId,
-	) -> Result<Self::Asset, DispatchError> {
-		<Sage<Test, ()> as AssetManager>::unlock_asset(lock_id, owner, asset_id)
-	}
-
-	fn is_locked(asset: &Self::AssetId) -> Option<Lock<Self::AccountId>> {
-		<Sage<Test, ()> as AssetManager>::is_locked(asset)
-	}
-
-	fn nft_transfer_open() -> bool {
-		<Sage<Test, ()> as AssetManager>::nft_transfer_open()
-	}
-
-	fn handle_asset_prepare_fee(
-		asset: &Self::Asset,
-		from: &Self::AccountId,
-		fees_recipient: &Self::AccountId,
-	) -> Result<(), DispatchError> {
-		<Sage<Test, ()> as AssetManager>::handle_asset_prepare_fee(asset, from, fees_recipient)
-	}
-}
-
-impl AssetInspector for MockAssetMediatorBench {
-	type AssetId = AssetId;
-	type Asset = Asset;
-
-	fn get_asset(asset_id: &Self::AssetId) -> Result<Self::Asset, DispatchError> {
-		<Sage<Test, ()> as AssetInspector>::get_asset(asset_id)
-	}
-}
-
-impl Config for Test {
-	type PalletId = BenchPalletId;
-	type SageGameTransition = ExampleTransitionGeneric<MockAccountId, MockAssetMediatorBench>;
-	type SeasonHandler = MockSeasonManager;
-	type FeeHandler = GameFeeHandler<
-		MockAccountId,
-		Balances,
-		MockAffiliatesFeeProvider,
-		MockTournamentFeeProvider,
-		MockTransitionFeeProvider,
-		MockTreasuryManager,
-	>;
-	type FilterHandler = MockFilterHandler;
-	type Currency = Balances;
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-	type BenchmarkHelper = SageBenchmarkHelper;
-}
 
 const ACC_1: &str = "acc_1";
 const ACC_2: &str = "acc_2";
@@ -128,49 +44,35 @@ fn assert_last_event<T: Config<I>, I: 'static>(avatars_event: Event<T, I>) {
 	frame_system::Pallet::<T>::assert_last_event(event.into());
 }
 
-fn create_asset_for<T: Config<I>, I: 'static>(
-	account: &T::AccountId,
-	season_id: &SeasonIdOf<T, I>,
-	seed: u32,
-) -> AssetIdOf<T, I> {
-	let (asset_id, asset) = T::BenchmarkHelper::create_asset(seed);
-
-	T::SeasonHandler::register_asset_in(&asset_id, season_id).expect("Asset should be registered");
-	Assets::<T, I>::insert(&asset_id, (account, asset));
-	AssetOwners::<T, I>::insert((account, season_id, &asset_id), ());
-
-	asset_id
-}
-
-benchmarks_instance_pallet! {
+benchmarks! {
 	set_organizer {
-		let acc_2 = account::<T, I>(ACC_2);
+		let acc_2 = account::<T, ()>(ACC_2);
 	}: _(RawOrigin::Root, acc_2.clone())
 	verify {
-		assert_last_event::<T, I>(Event::OrganizerSet { organizer: acc_2 })
+		assert_last_event::<T, ()>(Event::OrganizerSet { organizer: acc_2 })
 	}
 
 	update_general_config {
-		let acc_1 = account::<T, I>(ACC_1);
-		let general_config = GeneralConfigOf::<T, I> {
+		let acc_1 = account::<T, ()>(ACC_1);
+		let general_config = GeneralConfigOf::<T, ()> {
 			transition: T::BenchmarkHelper::create_transition_config(0),
 			transfer: Default::default(),
 			trade: Default::default()
 		};
 	}: _(RawOrigin::Signed(acc_1), general_config.clone())
 	verify {
-		assert_last_event::<T, I>(Event::UpdatedGeneralConfig { updated_config: general_config })
+		assert_last_event::<T, ()>(Event::UpdatedGeneralConfig { updated_config: general_config })
 	}
 
 	update_unlock_rule {
-		let acc_1 = account::<T, I>(ACC_1);
+		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
 		let feature = LockableFeature::TradeAsset;
 		let unlock_rule: UnlockRule = [10, 10, 10, 10, 10];
 		// Benchmark helper season_id
 	}: _(RawOrigin::Signed(acc_1), season_id.clone(), feature, unlock_rule)
 	verify {
-		assert_last_event::<T, I>(Event::UpdatedUnlockRule {
+		assert_last_event::<T, ()>(Event::UpdatedUnlockRule {
 			season_id,
 			feature,
 			updated_rule: unlock_rule,
@@ -178,14 +80,14 @@ benchmarks_instance_pallet! {
 	}
 
 	upgrade_asset_inventory {
-		let acc_1 = account::<T, I>(ACC_1);
-		let acc_2 = account::<T, I>(ACC_2);
+		let acc_1 = account::<T, ()>(ACC_1);
+		let acc_2 = account::<T, ()>(ACC_2);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
 		let in_season = Some(season_id.clone());
 		// Benchmark helper season_id
 	}: _(RawOrigin::Signed(acc_1), Some(acc_2.clone()), in_season)
 	verify {
-		assert_last_event::<T, I>(Event::InventoryTierUpgraded {
+		assert_last_event::<T, ()>(Event::InventoryTierUpgraded {
 			account: acc_2,
 			season_id,
 			new_tier: InventoryTier::Two,
@@ -193,39 +95,39 @@ benchmarks_instance_pallet! {
 	}
 
 	update_asset_trade_filter {
-		let acc_1 = account::<T, I>(ACC_1);
+		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
 		let filter = T::BenchmarkHelper::create_asset_trade_filter(0);
-		let trade_filter = AssetFilterOf::<T,I>::Trade(filter.clone());
+		let trade_filter = AssetFilterOf::<T, ()>::Trade(filter.clone());
 	}: update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), trade_filter)
 	verify {
-		assert_last_event::<T, I>(Event::UpdatedTradeFilter {
+		assert_last_event::<T, ()>(Event::UpdatedTradeFilter {
 			season_id,
 			filter,
 		})
 	}
 
 	update_asset_transfer_filter {
-		let acc_1 = account::<T, I>(ACC_1);
+		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
 		let filter = T::BenchmarkHelper::create_asset_transfer_filter(0);
-		let transfer_filter = AssetFilterOf::<T,I>::Transfer(filter.clone());
+		let transfer_filter = AssetFilterOf::<T, ()>::Transfer(filter.clone());
 	}: update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), transfer_filter)
 	verify {
-		assert_last_event::<T, I>(Event::UpdatedTransferFilter {
+		assert_last_event::<T, ()>(Event::UpdatedTransferFilter {
 			season_id,
 			filter,
 		})
 	}
 
 	transfer_asset {
-		let acc_1 = account::<T, I>(ACC_1);
-		let acc_2 = account::<T, I>(ACC_2);
+		let acc_1 = account::<T, ()>(ACC_1);
+		let acc_2 = account::<T, ()>(ACC_2);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 2);
+		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 2);
 	}: _(RawOrigin::Signed(acc_1.clone()), acc_2.clone(), asset_id.clone())
 	verify {
-		assert_last_event::<T, I>(Event::AssetTransferred {
+		assert_last_event::<T, ()>(Event::AssetTransferred {
 			from: acc_1,
 			to: acc_2,
 			asset_id,
@@ -233,49 +135,41 @@ benchmarks_instance_pallet! {
 	}
 
 	set_asset_price {
-		let acc_1 = account::<T, I>(ACC_1);
+		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 31);
+		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
 		let price = 45_242_u32;
 	}: _(RawOrigin::Signed(acc_1), asset_id.clone(), price.into())
 	verify {
-		assert_last_event::<T, I>(Event::AssetPriceSet {
+		assert_last_event::<T, ()>(Event::AssetPriceSet {
 			asset_id,
 			price: price.into(),
 		})
 	}
 
 	remove_asset_price {
-		let acc_1 = account::<T, I>(ACC_1);
+		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 31);
-		let price = 45_242_u32;
-		Sage::<T, I>::set_asset_price(
-			RawOrigin::Signed(acc_1.clone()).into(),
-			asset_id.clone(),
-			price.into())
-		.expect("Should set price");
+		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
+		let price = BalanceOf::<T, ()>::from(45_242_u32);
+		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, &price);
 	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
 	verify {
-		assert_last_event::<T, I>(Event::AssetPriceUnset {
+		assert_last_event::<T, ()>(Event::AssetPriceUnset {
 			asset_id,
 		})
 	}
 
 	buy_asset {
-		let acc_1 = account::<T, I>(ACC_1);
-		let acc_2 = account::<T, I>(ACC_2);
+		let acc_1 = account::<T, ()>(ACC_1);
+		let acc_2 = account::<T, ()>(ACC_2);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 31);
-		let price = 45_242_u32;
-		Sage::<T, I>::set_asset_price(
-			RawOrigin::Signed(acc_1.clone()).into(),
-			asset_id.clone(),
-			price.into())
-		.expect("Should set price");
+		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
+		let price = BalanceOf::<T, ()>::from(45_242_u32);
+		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, &price);
 	}: _(RawOrigin::Signed(acc_2.clone()), asset_id.clone())
 	verify {
-		assert_last_event::<T, I>(Event::AssetTraded {
+		assert_last_event::<T, ()>(Event::AssetTraded {
 			asset_id,
 			from: acc_1,
 			to: acc_2,
@@ -284,43 +178,43 @@ benchmarks_instance_pallet! {
 	}
 
 	lock_asset {
-		let acc_1 = account::<T, I>(ACC_1);
+		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 31);
+		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
 		let expected_lock = Lock::new(*SAGE_LOCK_ID, acc_1.clone());
 	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
 	verify {
-		assert_last_event::<T, I>(Event::AssetLocked {
+		assert_last_event::<T, ()>(Event::AssetLocked {
 			asset_id,
 			lock: expected_lock,
 		})
 	}
 
 	unlock_asset {
-		let acc_1 = account::<T, I>(ACC_1);
+		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 31);
+		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
 		let expected_lock = Lock::new(*SAGE_LOCK_ID, acc_1.clone());
-		Sage::<T, I>::lock_asset(
+		Pallet::<T, ()>::lock_asset(
 			RawOrigin::Signed(acc_1.clone()).into(),
 			asset_id.clone())
 		.expect("Should lock asset");
 	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
 	verify {
-		assert_last_event::<T, I>(Event::AssetUnlocked {
+		assert_last_event::<T, ()>(Event::AssetUnlocked {
 			asset_id,
 			lock: expected_lock,
 		})
 	}
 
 	unlock_trade_asset_feature {
-		let acc_1 = account::<T, I>(ACC_1);
+		let acc_1 = account::<T, ()>(ACC_1);
 		let target = UnlockTarget::OneselfFree;
 		let feature = LockableFeature::TradeAsset;
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
 	}: unlock_feature(RawOrigin::Signed(acc_1.clone()), target, feature, season_id.clone())
 	verify {
-		assert_last_event::<T, I>(Event::FeatureUnlocked {
+		assert_last_event::<T, ()>(Event::FeatureUnlocked {
 			feature,
 			season_id,
 			account: acc_1,
@@ -328,13 +222,13 @@ benchmarks_instance_pallet! {
 	}
 
 	unlock_transfer_asset_feature {
-		let acc_1 = account::<T, I>(ACC_1);
+		let acc_1 = account::<T, ()>(ACC_1);
 		let target = UnlockTarget::OneselfFree;
 		let feature = LockableFeature::TransferAsset;
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
 	}: unlock_feature(RawOrigin::Signed(acc_1.clone()), target, feature, season_id.clone())
 	verify {
-		assert_last_event::<T, I>(Event::FeatureUnlocked {
+		assert_last_event::<T, ()>(Event::FeatureUnlocked {
 			feature,
 			season_id,
 			account: acc_1,
@@ -342,26 +236,20 @@ benchmarks_instance_pallet! {
 	}
 
 	state_transition {
-		let acc_1 = account::<T, I>(ACC_1);
+		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
-		let asset_id_1 = create_asset_for::<T, I>(&acc_1, &season_id, 31);
-		let asset_id_2 = create_asset_for::<T, I>(&acc_1, &season_id, 124);
-		let asset_id_3 = create_asset_for::<T, I>(&acc_1, &season_id, 482);
-		let asset_id_4 = create_asset_for::<T, I>(&acc_1, &season_id, 1);
-		let asset_id_5 = create_asset_for::<T, I>(&acc_1, &season_id, 73);
+		let (transition_id, asset_ids) = T::BenchmarkHelper::create_bench_transition_for(&acc_1, &season_id, 99);
 		let extra = T::BenchmarkHelper::create_extra(0);
-		let transition_id = T::BenchmarkHelper::create_transition_id(99);
-		let asset_ids = vec![asset_id_1, asset_id_2, asset_id_3, asset_id_4, asset_id_5];
 	}: _(RawOrigin::Signed(acc_1.clone()), transition_id.clone(), asset_ids, extra)
 	verify {
-		assert_last_event::<T, I>(Event::TransitionExecuted {
+		assert_last_event::<T, ()>(Event::TransitionExecuted {
 			account: acc_1,
 			id: transition_id,
 		})
 	}
 
 	impl_benchmark_test_suite!(
-		Sage,
+		Pallet,
 		new_test_ext(),
 		Test
 	);

--- a/sage/pallet/src/benchmarking.rs
+++ b/sage/pallet/src/benchmarking.rs
@@ -1,0 +1,406 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(feature = "runtime-benchmarks")]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use crate::{
+	mock::{
+		Balances, MockAccountId, MockAffiliatesFeeProvider, MockFilterHandler, MockSeasonManager,
+		MockTournamentFeeProvider, MockTransitionFeeProvider, MockTreasuryManager, RuntimeEvent,
+		RuntimeOrigin, SageBenchmarkHelper, System, Test, SEASON_ID_0,
+	},
+	Pallet as Sage, *,
+};
+use ajuna_primitives::{asset_manager::AssetInspector, fee_handler::GameFeeHandler};
+use example_transition::{
+	generic::ExampleTransitionGeneric,
+	types::{Asset, AssetId},
+};
+use frame_benchmarking::benchmarks_instance_pallet;
+use frame_support::parameter_types;
+use frame_system::RawOrigin;
+use sp_runtime::BuildStorage;
+
+parameter_types! {
+	pub const BenchPalletId: PalletId = PalletId(*b"sage/bch");
+}
+
+pub struct MockAssetMediatorBench;
+
+impl AssetManager for MockAssetMediatorBench {
+	type AccountId = MockAccountId;
+	type AssetId = AssetId;
+	type Asset = Asset;
+
+	fn ensure_ownership(
+		owner: &Self::AccountId,
+		asset_id: &Self::AssetId,
+	) -> Result<Self::Asset, DispatchError> {
+		<Sage<Test, ()> as AssetManager>::ensure_ownership(owner, asset_id)
+	}
+
+	fn lock_asset(
+		lock_id: LockIdentifier,
+		owner: Self::AccountId,
+		asset_id: Self::AssetId,
+	) -> Result<Self::Asset, DispatchError> {
+		<Sage<Test, ()> as AssetManager>::lock_asset(lock_id, owner, asset_id)
+	}
+
+	fn unlock_asset(
+		lock_id: LockIdentifier,
+		owner: Self::AccountId,
+		asset_id: Self::AssetId,
+	) -> Result<Self::Asset, DispatchError> {
+		<Sage<Test, ()> as AssetManager>::unlock_asset(lock_id, owner, asset_id)
+	}
+
+	fn is_locked(asset: &Self::AssetId) -> Option<Lock<Self::AccountId>> {
+		<Sage<Test, ()> as AssetManager>::is_locked(asset)
+	}
+
+	fn nft_transfer_open() -> bool {
+		<Sage<Test, ()> as AssetManager>::nft_transfer_open()
+	}
+
+	fn handle_asset_prepare_fee(
+		asset: &Self::Asset,
+		from: &Self::AccountId,
+		fees_recipient: &Self::AccountId,
+	) -> Result<(), DispatchError> {
+		<Sage<Test, ()> as AssetManager>::handle_asset_prepare_fee(asset, from, fees_recipient)
+	}
+
+	fn create_assets(owner: Self::AccountId, count: u32) -> Vec<(Self::AssetId, Self::Asset)> {
+		<Sage<Test, ()> as AssetManager>::create_assets(owner, count)
+	}
+}
+
+impl AssetInspector for MockAssetMediatorBench {
+	type AssetId = AssetId;
+	type Asset = Asset;
+
+	fn get_asset(asset_id: &Self::AssetId) -> Result<Self::Asset, DispatchError> {
+		<Sage<Test, ()> as AssetInspector>::get_asset(asset_id)
+	}
+}
+
+impl Config for Test {
+	type PalletId = BenchPalletId;
+	type SageGameTransition = ExampleTransitionGeneric<MockAccountId, MockAssetMediatorBench>;
+	type SeasonHandler = MockSeasonManager;
+	type FeeHandler = GameFeeHandler<
+		MockAccountId,
+		Balances,
+		MockAffiliatesFeeProvider,
+		MockTournamentFeeProvider,
+		MockTransitionFeeProvider,
+		MockTreasuryManager,
+	>;
+	type FilterHandler = MockFilterHandler;
+	type Currency = Balances;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type BenchmarkHelper = SageBenchmarkHelper;
+}
+
+const ACC_1: &str = "acc_1";
+const ACC_2: &str = "acc_2";
+
+fn account<T: Config<I>, I: 'static>(name: &'static str) -> T::AccountId {
+	let index = 0;
+	let seed = 0;
+	frame_benchmarking::account(name, index, seed)
+}
+
+fn assert_last_event<T: Config<I>, I: 'static>(avatars_event: Event<T, I>) {
+	let event = <T as Config<I>>::RuntimeEvent::from(avatars_event);
+	frame_system::Pallet::<T>::assert_last_event(event.into());
+}
+
+fn create_asset_for<T: Config<I>, I: 'static>(
+	account: &T::AccountId,
+	season_id: &SeasonIdOf<T, I>,
+	seed: u32,
+) -> AssetIdOf<T, I> {
+	let (asset_id, asset) = T::BenchmarkHelper::create_asset(seed);
+
+	T::SeasonHandler::register_asset_in(&asset_id, season_id).expect("Asset should be registered");
+	Assets::<T, I>::insert(&asset_id, (account, asset));
+	AssetOwners::<T, I>::insert((account, season_id, &asset_id), ());
+
+	asset_id
+}
+
+benchmarks_instance_pallet! {
+	set_organizer {
+		let acc_2 = account::<T, I>(ACC_2);
+	}: _(RawOrigin::Root, acc_2.clone())
+	verify {
+		assert_last_event::<T, I>(Event::OrganizerSet { organizer: acc_2 })
+	}
+
+	update_general_config {
+		let acc_1 = account::<T, I>(ACC_1);
+		let general_config = GeneralConfigOf::<T, I> {
+			transition: T::BenchmarkHelper::create_transition_config(0),
+			transfer: Default::default(),
+			trade: Default::default()
+		};
+	}: _(RawOrigin::Signed(acc_1), general_config.clone())
+	verify {
+		assert_last_event::<T, I>(Event::UpdatedGeneralConfig { updated_config: general_config })
+	}
+
+	update_unlock_rule {
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let feature = LockableFeature::TradeAsset;
+		let unlock_rule: UnlockRule = [10, 10, 10, 10, 10];
+		// Benchmark helper season_id
+	}: _(RawOrigin::Signed(acc_1), season_id.clone(), feature, unlock_rule)
+	verify {
+		assert_last_event::<T, I>(Event::UpdatedUnlockRule {
+			season_id,
+			feature,
+			updated_rule: unlock_rule,
+		})
+	}
+
+	upgrade_asset_inventory {
+		let acc_1 = account::<T, I>(ACC_1);
+		let acc_2 = account::<T, I>(ACC_2);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let in_season = Some(season_id.clone());
+		// Benchmark helper season_id
+	}: _(RawOrigin::Signed(acc_1), Some(acc_2.clone()), in_season)
+	verify {
+		assert_last_event::<T, I>(Event::InventoryTierUpgraded {
+			account: acc_2,
+			season_id,
+			new_tier: InventoryTier::Two,
+		})
+	}
+
+	update_asset_trade_filter {
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let filter = T::BenchmarkHelper::create_asset_trade_filter(0);
+		let trade_filter = AssetFilterOf::<T,I>::Trade(filter.clone());
+	}: update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), trade_filter)
+	verify {
+		assert_last_event::<T, I>(Event::UpdatedTradeFilter {
+			season_id,
+			filter,
+		})
+	}
+
+	update_asset_transfer_filter {
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let filter = T::BenchmarkHelper::create_asset_transfer_filter(0);
+		let transfer_filter = AssetFilterOf::<T,I>::Transfer(filter.clone());
+	}: update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), transfer_filter)
+	verify {
+		assert_last_event::<T, I>(Event::UpdatedTransferFilter {
+			season_id,
+			filter,
+		})
+	}
+
+	transfer_asset {
+		let acc_1 = account::<T, I>(ACC_1);
+		let acc_2 = account::<T, I>(ACC_2);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 2);
+	}: _(RawOrigin::Signed(acc_1.clone()), acc_2.clone(), asset_id.clone())
+	verify {
+		assert_last_event::<T, I>(Event::AssetTransferred {
+			from: acc_1,
+			to: acc_2,
+			asset_id,
+		})
+	}
+
+	set_asset_price {
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 31);
+		let price = 45_242_u32;
+	}: _(RawOrigin::Signed(acc_1), asset_id.clone(), price.into())
+	verify {
+		assert_last_event::<T, I>(Event::AssetPriceSet {
+			asset_id,
+			price: price.into(),
+		})
+	}
+
+	remove_asset_price {
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 31);
+		let price = 45_242_u32;
+		Sage::<T, I>::set_asset_price(
+			RawOrigin::Signed(acc_1.clone()).into(),
+			asset_id.clone(),
+			price.into())
+		.expect("Should set price");
+	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
+	verify {
+		assert_last_event::<T, I>(Event::AssetPriceUnset {
+			asset_id,
+		})
+	}
+
+	buy_asset {
+		let acc_1 = account::<T, I>(ACC_1);
+		let acc_2 = account::<T, I>(ACC_2);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 31);
+		let price = 45_242_u32;
+		Sage::<T, I>::set_asset_price(
+			RawOrigin::Signed(acc_1.clone()).into(),
+			asset_id.clone(),
+			price.into())
+		.expect("Should set price");
+	}: _(RawOrigin::Signed(acc_2.clone()), asset_id.clone())
+	verify {
+		assert_last_event::<T, I>(Event::AssetTraded {
+			asset_id,
+			from: acc_1,
+			to: acc_2,
+			price: price.into(),
+		})
+	}
+
+	lock_asset {
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 31);
+		let expected_lock = Lock::new(*SAGE_LOCK_ID, acc_1.clone());
+	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
+	verify {
+		assert_last_event::<T, I>(Event::AssetLocked {
+			asset_id,
+			lock: expected_lock,
+		})
+	}
+
+	unlock_asset {
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let asset_id = create_asset_for::<T, I>(&acc_1, &season_id, 31);
+		let expected_lock = Lock::new(*SAGE_LOCK_ID, acc_1.clone());
+		Sage::<T, I>::lock_asset(
+			RawOrigin::Signed(acc_1.clone()).into(),
+			asset_id.clone())
+		.expect("Should lock asset");
+	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
+	verify {
+		assert_last_event::<T, I>(Event::AssetUnlocked {
+			asset_id,
+			lock: expected_lock,
+		})
+	}
+
+	unlock_trade_asset_feature {
+		let acc_1 = account::<T, I>(ACC_1);
+		let target = UnlockTarget::OneselfFree;
+		let feature = LockableFeature::TradeAsset;
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+	}: unlock_feature(RawOrigin::Signed(acc_1.clone()), target, feature, season_id.clone())
+	verify {
+		assert_last_event::<T, I>(Event::FeatureUnlocked {
+			feature,
+			season_id,
+			account: acc_1,
+		})
+	}
+
+	unlock_transfer_asset_feature {
+		let acc_1 = account::<T, I>(ACC_1);
+		let target = UnlockTarget::OneselfFree;
+		let feature = LockableFeature::TransferAsset;
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+	}: unlock_feature(RawOrigin::Signed(acc_1.clone()), target, feature, season_id.clone())
+	verify {
+		assert_last_event::<T, I>(Event::FeatureUnlocked {
+			feature,
+			season_id,
+			account: acc_1,
+		})
+	}
+
+	state_transition {
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
+		let asset_id_1 = create_asset_for::<T, I>(&acc_1, &season_id, 31);
+		let asset_id_2 = create_asset_for::<T, I>(&acc_1, &season_id, 124);
+		let asset_id_3 = create_asset_for::<T, I>(&acc_1, &season_id, 482);
+		let asset_id_4 = create_asset_for::<T, I>(&acc_1, &season_id, 1);
+		let asset_id_5 = create_asset_for::<T, I>(&acc_1, &season_id, 73);
+		let extra = T::BenchmarkHelper::create_extra(0);
+		let transition_id = T::BenchmarkHelper::create_transition_id(99);
+		let asset_ids = vec![asset_id_1, asset_id_2, asset_id_3, asset_id_4, asset_id_5];
+	}: _(RawOrigin::Signed(acc_1.clone()), transition_id.clone(), asset_ids, extra)
+	verify {
+		assert_last_event::<T, I>(Event::TransitionExecuted {
+			account: acc_1,
+			id: transition_id,
+		})
+	}
+
+	impl_benchmark_test_suite!(
+		Sage,
+		new_test_ext(),
+		Test
+	);
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| System::set_block_number(1));
+	ext.execute_with(|| {
+		GeneralConfigStore::<Test, ()>::mutate(|config| {
+			config.trade.open = true;
+			config.transfer.open = true;
+		});
+		SeasonUnlocks::<Test, ()>::mutate(SEASON_ID_0, LockableFeature::TradeAsset, |rule| {
+			*rule = Some(UnlockRule::from([0, 0, 0, 0, 0]));
+		});
+		SeasonUnlocks::<Test, ()>::mutate(SEASON_ID_0, LockableFeature::TransferAsset, |rule| {
+			*rule = Some(UnlockRule::from([0, 0, 0, 0, 0]));
+		});
+
+		let acc_1 = account::<Test, ()>(ACC_1);
+		Organizer::<Test, ()>::put(acc_1);
+		PlayerSeasonConfigs::<Test, ()>::mutate(acc_1, SEASON_ID_0, |config| {
+			config.locks = Locks::all_unlocked();
+		});
+		Balances::force_set_balance(RuntimeOrigin::root(), acc_1, 100_000)
+			.expect("Should set balance");
+
+		let acc_2 = account::<Test, ()>(ACC_2);
+		PlayerSeasonConfigs::<Test, ()>::mutate(acc_2, SEASON_ID_0, |config| {
+			config.locks = Locks::all_unlocked();
+		});
+		Balances::force_set_balance(RuntimeOrigin::root(), acc_2, 100_000)
+			.expect("Should set balance");
+	});
+	ext
+}

--- a/sage/pallet/src/benchmarking.rs
+++ b/sage/pallet/src/benchmarking.rs
@@ -152,7 +152,7 @@ benchmarks! {
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
 		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
 		let price = BalanceOf::<T, ()>::from(45_242_u32);
-		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, &price);
+		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, price);
 	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
 	verify {
 		assert_last_event::<T, ()>(Event::AssetPriceUnset {
@@ -166,14 +166,14 @@ benchmarks! {
 		let season_id = T::BenchmarkHelper::create_season_id(SEASON_ID_0 as u32);
 		let asset_id = SageBenchmarkHelper::create_asset_for::<T, ()>(&acc_1, &season_id, 31);
 		let price = BalanceOf::<T, ()>::from(45_242_u32);
-		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, &price);
+		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, price);
 	}: _(RawOrigin::Signed(acc_2.clone()), asset_id.clone())
 	verify {
 		assert_last_event::<T, ()>(Event::AssetTraded {
 			asset_id,
 			from: acc_1,
 			to: acc_2,
-			price: price.into(),
+			price,
 		})
 	}
 

--- a/sage/pallet/src/benchmarking.rs
+++ b/sage/pallet/src/benchmarking.rs
@@ -84,10 +84,6 @@ impl AssetManager for MockAssetMediatorBench {
 	) -> Result<(), DispatchError> {
 		<Sage<Test, ()> as AssetManager>::handle_asset_prepare_fee(asset, from, fees_recipient)
 	}
-
-	fn create_assets(owner: Self::AccountId, count: u32) -> Vec<(Self::AssetId, Self::Asset)> {
-		<Sage<Test, ()> as AssetManager>::create_assets(owner, count)
-	}
 }
 
 impl AssetInspector for MockAssetMediatorBench {

--- a/sage/pallet/src/lib.rs
+++ b/sage/pallet/src/lib.rs
@@ -26,7 +26,9 @@ pub mod config;
 mod pallet_impls;
 mod trait_impls;
 
-#[cfg(test)]
+#[cfg(feature = "runtime-benchmarks")]
+pub mod benchmarking;
+#[cfg(any(test, feature = "runtime-benchmarks"))]
 pub mod mock;
 #[cfg(test)]
 mod tests;
@@ -64,7 +66,10 @@ pub const MAX_ASSETS_IN_TRANSITION: usize = 10;
 pub mod pallet {
 	use super::*;
 
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 
 	pub type AssetIdOf<T, I> =
@@ -92,6 +97,92 @@ pub mod pallet {
 		<<T as Config<I>>::FilterHandler as TransferManager>::TransferFilter;
 	pub(crate) type AssetFilterOf<T, I> = AssetFilter<TradeFilterOf<T, I>, TransferFilterOf<T, I>>;
 	pub(crate) type AffiliateMethodsOf<T, I> = AffiliateMethods<TransitionIdOf<T, I>>;
+
+	#[cfg(feature = "runtime-benchmarks")]
+	pub trait BenchmarkHelper<
+		AssetId,
+		Asset,
+		TradeFilter,
+		TransferFilter,
+		SeasonId,
+		TransitionId,
+		TransitionConfig,
+		Extra,
+	>
+	{
+		fn create_asset(seed: u32) -> (AssetId, Asset);
+
+		fn create_asset_trade_filter(id: u32) -> TradeFilter;
+
+		fn create_asset_transfer_filter(id: u32) -> TransferFilter;
+
+		fn create_transition_id(id: u32) -> TransitionId;
+
+		fn create_season_id(id: u32) -> SeasonId;
+
+		fn create_transition_config(id: u32) -> TransitionConfig;
+
+		fn create_extra(id: u32) -> Extra;
+	}
+	#[cfg(feature = "runtime-benchmarks")]
+	impl<
+			AssetId,
+			Asset,
+			TradeFilter,
+			TransferFilter,
+			SeasonId,
+			TransitionId,
+			TransitionConfig,
+			Extra,
+		>
+		BenchmarkHelper<
+			AssetId,
+			Asset,
+			TradeFilter,
+			TransferFilter,
+			SeasonId,
+			TransitionId,
+			TransitionConfig,
+			Extra,
+		> for ()
+	where
+		AssetId: From<u32>,
+		Asset: From<u32>,
+		TradeFilter: From<u32>,
+		TransferFilter: From<u32>,
+		SeasonId: From<u32>,
+		TransitionId: From<u32>,
+		TransitionConfig: From<u32>,
+		Extra: From<u32>,
+	{
+		fn create_asset(seed: u32) -> (AssetId, Asset) {
+			(AssetId::from(seed), Asset::from(seed))
+		}
+
+		fn create_asset_trade_filter(id: u32) -> TradeFilter {
+			TradeFilter::from(id)
+		}
+
+		fn create_asset_transfer_filter(id: u32) -> TransferFilter {
+			TransferFilter::from(id)
+		}
+
+		fn create_transition_id(id: u32) -> TransitionId {
+			TransitionId::from(id)
+		}
+
+		fn create_season_id(id: u32) -> SeasonId {
+			SeasonId::from(id)
+		}
+
+		fn create_transition_config(id: u32) -> TransitionConfig {
+			TransitionConfig::from(id)
+		}
+
+		fn create_extra(id: u32) -> Extra {
+			Extra::from(id)
+		}
+	}
 
 	#[pallet::config]
 	pub trait Config<I: 'static = ()>: frame_system::Config {
@@ -139,6 +230,18 @@ pub mod pallet {
 
 		/// The weight calculations
 		type WeightInfo: WeightInfo;
+
+		#[cfg(feature = "runtime-benchmarks")]
+		type BenchmarkHelper: BenchmarkHelper<
+			AssetIdOf<Self, I>,
+			AssetOf<Self, I>,
+			TradeFilterOf<Self, I>,
+			TransferFilterOf<Self, I>,
+			SeasonIdOf<Self, I>,
+			TransitionIdOf<Self, I>,
+			TransitionConfigOf<Self, I>,
+			ExtraOf<Self, I>,
+		>;
 	}
 
 	/// Organizer of the game. Essentially the administrator with certain privileges.
@@ -391,7 +494,7 @@ pub mod pallet {
 
 		/// Updates an unlock rule for the given season.
 		///
-		/// It doesn't affect ulready unlocked features.
+		/// It doesn't affect already unlocked features.
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::update_unlock_rule())]
 		pub fn update_unlock_rule(
@@ -462,7 +565,8 @@ pub mod pallet {
 
 		/// Updates the filter that assets need to pass for certain actions.
 		#[pallet::call_index(4)]
-		#[pallet::weight(T::WeightInfo::update_asset_filter())]
+		#[pallet::weight({T::WeightInfo::update_asset_trade_filter()
+			.max(T::WeightInfo::update_asset_transfer_filter())})]
 		pub fn update_asset_filter(
 			origin: OriginFor<T>,
 			season_id: SeasonIdOf<T, I>,
@@ -649,7 +753,8 @@ pub mod pallet {
 
 		/// Attempts to unlock the selected feature for the `target`.
 		#[pallet::call_index(11)]
-		#[pallet::weight(T::WeightInfo::unlock_feature())]
+		#[pallet::weight(T::WeightInfo::unlock_trade_asset_feature()
+			.max(T::WeightInfo::unlock_transfer_asset_feature()))]
 		pub fn unlock_feature(
 			origin: OriginFor<T>,
 			target: UnlockTarget<AccountIdOf<T>>,
@@ -804,7 +909,7 @@ pub mod pallet {
 						let asset_id = asset.get_id();
 
 						T::SeasonHandler::register_asset_in(&asset_id, season_id)?;
-						Assets::<T, I>::insert(&asset_id, asset);
+						Assets::<T, I>::insert(&asset_id, (player, asset));
 						AssetOwners::<T, I>::insert((player, season_id, &asset_id), ());
 					},
 					TransitionOutput::Mutated(asset_id, asset) => {

--- a/sage/pallet/src/lib.rs
+++ b/sage/pallet/src/lib.rs
@@ -565,8 +565,10 @@ pub mod pallet {
 
 		/// Updates the filter that assets need to pass for certain actions.
 		#[pallet::call_index(4)]
-		#[pallet::weight({T::WeightInfo::update_asset_trade_filter()
-			.max(T::WeightInfo::update_asset_transfer_filter())})]
+		#[pallet::weight(
+			T::WeightInfo::update_asset_trade_filter()
+				.max(T::WeightInfo::update_asset_transfer_filter())
+		)]
 		pub fn update_asset_filter(
 			origin: OriginFor<T>,
 			season_id: SeasonIdOf<T, I>,
@@ -624,7 +626,7 @@ pub mod pallet {
 
 			let transfer_filter = SeasonTransferFilters::<T, I>::get(&asset_season_id);
 			ensure!(
-				T::FilterHandler::is_transferable_using(&asset, &transfer_filter),
+				T::FilterHandler::can_be_transferred_using(&asset, &transfer_filter),
 				Error::<T, I>::AssetCannotBeTransfered
 			);
 
@@ -658,7 +660,7 @@ pub mod pallet {
 
 			let trade_filter = SeasonTradeFilters::<T, I>::get(&asset_season_id);
 			ensure!(
-				T::FilterHandler::is_tradeable_using(&asset, &trade_filter),
+				T::FilterHandler::can_be_traded_using(&asset, &trade_filter),
 				Error::<T, I>::AssetCannotBeTraded
 			);
 
@@ -753,8 +755,10 @@ pub mod pallet {
 
 		/// Attempts to unlock the selected feature for the `target`.
 		#[pallet::call_index(11)]
-		#[pallet::weight(T::WeightInfo::unlock_trade_asset_feature()
-			.max(T::WeightInfo::unlock_transfer_asset_feature()))]
+		#[pallet::weight(
+			T::WeightInfo::unlock_trade_asset_feature()
+				.max(T::WeightInfo::unlock_transfer_asset_feature())
+		)]
 		pub fn unlock_feature(
 			origin: OriginFor<T>,
 			target: UnlockTarget<AccountIdOf<T>>,

--- a/sage/pallet/src/lib.rs
+++ b/sage/pallet/src/lib.rs
@@ -41,7 +41,7 @@ use ajuna_primitives::{
 	trade_manager::{TradeManager, TransferManager},
 };
 use sage_api::{
-	traits::{Identifiable, TransitionOutput},
+	traits::{GetId, TransitionOutput},
 	AsErrorCode, SageGameTransition,
 };
 
@@ -104,6 +104,7 @@ pub mod pallet {
 		Asset,
 		TradeFilter,
 		TransferFilter,
+		AccountId,
 		SeasonId,
 		TransitionId,
 		TransitionConfig,
@@ -116,72 +117,17 @@ pub mod pallet {
 
 		fn create_asset_transfer_filter(id: u32) -> TransferFilter;
 
-		fn create_transition_id(id: u32) -> TransitionId;
+		fn create_bench_transition_for(
+			account: &AccountId,
+			season: &SeasonId,
+			seed: u32,
+		) -> (TransitionId, Vec<AssetId>);
 
 		fn create_season_id(id: u32) -> SeasonId;
 
 		fn create_transition_config(id: u32) -> TransitionConfig;
 
 		fn create_extra(id: u32) -> Extra;
-	}
-	#[cfg(feature = "runtime-benchmarks")]
-	impl<
-			AssetId,
-			Asset,
-			TradeFilter,
-			TransferFilter,
-			SeasonId,
-			TransitionId,
-			TransitionConfig,
-			Extra,
-		>
-		BenchmarkHelper<
-			AssetId,
-			Asset,
-			TradeFilter,
-			TransferFilter,
-			SeasonId,
-			TransitionId,
-			TransitionConfig,
-			Extra,
-		> for ()
-	where
-		AssetId: From<u32>,
-		Asset: From<u32>,
-		TradeFilter: From<u32>,
-		TransferFilter: From<u32>,
-		SeasonId: From<u32>,
-		TransitionId: From<u32>,
-		TransitionConfig: From<u32>,
-		Extra: From<u32>,
-	{
-		fn create_asset(seed: u32) -> (AssetId, Asset) {
-			(AssetId::from(seed), Asset::from(seed))
-		}
-
-		fn create_asset_trade_filter(id: u32) -> TradeFilter {
-			TradeFilter::from(id)
-		}
-
-		fn create_asset_transfer_filter(id: u32) -> TransferFilter {
-			TransferFilter::from(id)
-		}
-
-		fn create_transition_id(id: u32) -> TransitionId {
-			TransitionId::from(id)
-		}
-
-		fn create_season_id(id: u32) -> SeasonId {
-			SeasonId::from(id)
-		}
-
-		fn create_transition_config(id: u32) -> TransitionConfig {
-			TransitionConfig::from(id)
-		}
-
-		fn create_extra(id: u32) -> Extra {
-			Extra::from(id)
-		}
 	}
 
 	#[pallet::config]
@@ -237,6 +183,7 @@ pub mod pallet {
 			AssetOf<Self, I>,
 			TradeFilterOf<Self, I>,
 			TransferFilterOf<Self, I>,
+			AccountIdOf<Self>,
 			SeasonIdOf<Self, I>,
 			TransitionIdOf<Self, I>,
 			TransitionConfigOf<Self, I>,

--- a/sage/pallet/src/lib.rs
+++ b/sage/pallet/src/lib.rs
@@ -99,35 +99,14 @@ pub mod pallet {
 	pub(crate) type AffiliateMethodsOf<T, I> = AffiliateMethods<TransitionIdOf<T, I>>;
 
 	#[cfg(feature = "runtime-benchmarks")]
-	pub trait BenchmarkHelper<
-		AssetId,
-		Asset,
-		TradeFilter,
-		TransferFilter,
-		AccountId,
-		SeasonId,
-		TransitionId,
-		TransitionConfig,
-		Extra,
-	>
-	{
-		fn create_asset(seed: u32) -> (AssetId, Asset);
-
-		fn create_asset_trade_filter(id: u32) -> TradeFilter;
-
-		fn create_asset_transfer_filter(id: u32) -> TransferFilter;
+	pub trait BenchmarkHelper<AccountId, SeasonId, AssetId, Asset, TransitionId> {
+		fn create_asset_for(account: &AccountId, season: &SeasonId, seed: u32) -> AssetId;
 
 		fn create_bench_transition_for(
 			account: &AccountId,
 			season: &SeasonId,
 			seed: u32,
 		) -> (TransitionId, Vec<AssetId>);
-
-		fn create_season_id(id: u32) -> SeasonId;
-
-		fn create_transition_config(id: u32) -> TransitionConfig;
-
-		fn create_extra(id: u32) -> Extra;
 	}
 
 	#[pallet::config]
@@ -179,15 +158,11 @@ pub mod pallet {
 
 		#[cfg(feature = "runtime-benchmarks")]
 		type BenchmarkHelper: BenchmarkHelper<
-			AssetIdOf<Self, I>,
-			AssetOf<Self, I>,
-			TradeFilterOf<Self, I>,
-			TransferFilterOf<Self, I>,
 			AccountIdOf<Self>,
 			SeasonIdOf<Self, I>,
+			AssetIdOf<Self, I>,
+			AssetOf<Self, I>,
 			TransitionIdOf<Self, I>,
-			TransitionConfigOf<Self, I>,
-			ExtraOf<Self, I>,
 		>;
 	}
 

--- a/sage/pallet/src/lib.rs
+++ b/sage/pallet/src/lib.rs
@@ -38,7 +38,10 @@ use ajuna_primitives::{
 	season_manager::{SeasonConfig, SeasonManager},
 	trade_manager::{TradeManager, TransferManager},
 };
-use sage_api::{traits::TransitionOutput, AsErrorCode, SageGameTransition};
+use sage_api::{
+	traits::{Identifiable, TransitionOutput},
+	AsErrorCode, SageGameTransition,
+};
 
 use frame_support::{pallet_prelude::*, traits::Currency, PalletId};
 use frame_system::pallet_prelude::*;
@@ -74,7 +77,8 @@ pub mod pallet {
 		<<T as Config<I>>::SageGameTransition as SageGameTransition>::TransitionId;
 	pub type ExtraOf<T, I> = <<T as Config<I>>::SageGameTransition as SageGameTransition>::Extra;
 	pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
-	pub type TransitionConfigOf<T, I> = <T as Config<I>>::SageTransitionConfig;
+	pub type TransitionConfigOf<T, I> =
+		<<T as Config<I>>::SageGameTransition as SageGameTransition>::TransitionConfig;
 	pub(crate) type TransitionOutputOf<T, I> = TransitionOutput<AssetIdOf<T, I>, AssetOf<T, I>>;
 	pub type GeneralConfigOf<T, I> = GeneralConfig<TransitionConfigOf<T, I>>;
 
@@ -100,11 +104,6 @@ pub mod pallet {
 		/// The `SageGameTransition` that this pallet hosts, and whose state transition
 		/// are executed as part of the `state_transition` extrinsic.
 		type SageGameTransition: SageGameTransition<AccountId = AccountIdOf<Self>>;
-
-		/// Custom transition config.
-		///
-		/// Todo: Shouldn't this just be part of the `SageGameTranstion` trait?
-		type SageTransitionConfig: Member + Parameter + MaxEncodedLen + TypeInfo + Default;
 
 		/// Retrieves information about past and ongoing seasons.
 		type SeasonHandler: SeasonManager<
@@ -698,7 +697,6 @@ pub mod pallet {
 			let current_season_id = T::SeasonHandler::get_current_season_id()?;
 			Self::process_transition_results(&sender, &current_season_id, transition_results)?;
 
-			// TODO: Review the logic in this section
 			let transition_fee = {
 				let SeasonConfigOf::<T, I> { fee, .. } =
 					T::SeasonHandler::get_season_config_for(&current_season_id)?;
@@ -796,19 +794,18 @@ pub mod pallet {
 
 			for output in transition_results {
 				match output {
-					TransitionOutput::Minted(_asset) => {
+					TransitionOutput::Minted(asset) => {
 						minted_amount.saturating_inc();
 						player_asset_count.saturating_inc();
 						ensure!(
 							player_asset_count <= player_inventory_slots,
 							Error::<T, I>::MaxOwnershipReached
 						);
+						let asset_id = asset.get_id();
 
-						// TODO: Need a way to create new asset_id generically
-						// T::SeasonHandler::register_asset_in(asset_id, season_id)?;
-						// Assets::<T, I>::insert(asset_id, asset);
-						// AssetOwners::<T, I>::insert((player, season_id, asset_id);
-						// AssetsOwnedCount update
+						T::SeasonHandler::register_asset_in(&asset_id, season_id)?;
+						Assets::<T, I>::insert(&asset_id, asset);
+						AssetOwners::<T, I>::insert((player, season_id, &asset_id), ());
 					},
 					TransitionOutput::Mutated(asset_id, asset) => {
 						mutated_amount.saturating_inc();

--- a/sage/pallet/src/mock.rs
+++ b/sage/pallet/src/mock.rs
@@ -264,11 +264,6 @@ impl TreasuryManager for MockTreasuryManager {
 		Ok(TREASURER)
 	}
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_treasurer_for(_key: Self::TreasuryPotKey, _owner: Self::AccountId) {
-		todo!()
-	}
-
 	fn deposit_into(
 		depository: &Self::AccountId,
 		_key: &Self::TreasuryPotKey,
@@ -286,7 +281,7 @@ impl TradeManager for MockFilterHandler {
 	type TradeFilter = MockFilter;
 	type Asset = Asset;
 
-	fn is_tradeable_using(asset: &Self::Asset, filter: &Self::TradeFilter) -> bool {
+	fn can_be_traded_using(asset: &Self::Asset, filter: &Self::TradeFilter) -> bool {
 		asset.asset_type == *filter
 	}
 }
@@ -295,7 +290,7 @@ impl TransferManager for MockFilterHandler {
 	type TransferFilter = MockFilter;
 	type Asset = Asset;
 
-	fn is_transferable_using(asset: &Self::Asset, filter: &Self::TransferFilter) -> bool {
+	fn can_be_transferred_using(asset: &Self::Asset, filter: &Self::TransferFilter) -> bool {
 		asset.asset_type == *filter
 	}
 }
@@ -344,11 +339,6 @@ impl AssetManager for MockAssetMediator {
 		fees_recipient: &Self::AccountId,
 	) -> Result<(), DispatchError> {
 		<Sage as AssetManager>::handle_asset_prepare_fee(asset, from, fees_recipient)
-	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn create_assets(owner: Self::AccountId, count: u32) -> Vec<(Self::AssetId, Self::Asset)> {
-		<Sage as AssetManager>::create_assets(owner, count)
 	}
 }
 

--- a/sage/pallet/src/mock.rs
+++ b/sage/pallet/src/mock.rs
@@ -57,9 +57,7 @@ frame_support::construct_runtime!(
 	pub struct Test {
 		System: frame_system = 0,
 		Balances: pallet_balances = 1,
-		Sage: pallet_sage::<Instance1> = 2,
-		#[cfg(feature = "runtime-benchmarks")]
-		SageBench: pallet_sage = 3,
+		Sage: pallet_sage = 2,
 	}
 );
 
@@ -194,7 +192,7 @@ pub struct MockAffiliatesFeeProvider;
 
 impl FeeProvider for MockAffiliatesFeeProvider {
 	type AccountId = MockAccountId;
-	type FeeIdentifier = AffiliateMethodsOf<Test, Instance1>;
+	type FeeIdentifier = AffiliateMethodsOf<Test, ()>;
 	type FeeCurrency = MockBalance;
 	type FeeOutput = Vec<(MockBalance, MockAccountId)>;
 
@@ -355,12 +353,31 @@ impl AssetInspector for MockAssetMediator {
 pub struct SageBenchmarkHelper;
 
 #[cfg(feature = "runtime-benchmarks")]
+impl SageBenchmarkHelper {
+	pub(crate) fn create_asset_for<T: Config<I>, I: 'static>(
+		account: &T::AccountId,
+		season_id: &SeasonIdOf<T, I>,
+		seed: u32,
+	) -> AssetIdOf<T, I> {
+		let (asset_id, asset) = T::BenchmarkHelper::create_asset(seed);
+
+		T::SeasonHandler::register_asset_in(&asset_id, season_id)
+			.expect("Asset should be registered");
+		Assets::<T, I>::insert(&asset_id, (account, asset));
+		AssetOwners::<T, I>::insert((account, season_id, &asset_id), ());
+
+		asset_id
+	}
+}
+
+#[cfg(feature = "runtime-benchmarks")]
 impl
 	BenchmarkHelper<
 		AssetId,
 		Asset,
 		MockFilter,
 		MockFilter,
+		MockAccountId,
 		MockSeasonId,
 		ExampleTransitionId,
 		(),
@@ -382,12 +399,20 @@ impl
 		MockFilter::from(id)
 	}
 
-	fn create_transition_id(id: u32) -> ExampleTransitionId {
-		if id == 99 {
-			ExampleTransitionId::BenchTransition
-		} else {
-			ExampleTransitionId::UpgradeAsset
-		}
+	fn create_bench_transition_for(
+		account: &MockAccountId,
+		season: &MockSeasonId,
+		seed: u32,
+	) -> (ExampleTransitionId, Vec<AssetId>) {
+		let asset_id_1 = Self::create_asset_for::<Test, ()>(account, season, seed);
+		let asset_id_2 = Self::create_asset_for::<Test, ()>(account, season, seed * 2);
+		let asset_id_3 = Self::create_asset_for::<Test, ()>(account, season, seed * 3);
+		let asset_id_4 = Self::create_asset_for::<Test, ()>(account, season, seed * 4);
+		let asset_id_5 = Self::create_asset_for::<Test, ()>(account, season, seed * 5);
+
+		let asset_vec = vec![asset_id_1, asset_id_2, asset_id_3, asset_id_4, asset_id_5];
+
+		(ExampleTransitionId::BenchTransition, asset_vec)
 	}
 
 	fn create_season_id(id: u32) -> MockSeasonId {
@@ -399,8 +424,7 @@ impl
 	fn create_extra(_id: u32) {}
 }
 
-pub type SageInstance1 = pallet_sage::Instance1;
-impl crate::Config<SageInstance1> for Test {
+impl crate::Config for Test {
 	type PalletId = ExamplePalletId;
 	type SageGameTransition = ExampleTransitionGeneric<MockAccountId, MockAssetMediator>;
 	type SeasonHandler = MockSeasonManager;
@@ -455,13 +479,13 @@ impl ExtBuilder {
 			let _ = Balances::deposit_creating(&TREASURER, MockExistentialDeposit::get());
 
 			if let Some(organizer) = self.organizer {
-				Organizer::<Test, Instance1>::put(organizer);
+				Organizer::<Test, ()>::put(organizer);
 			}
 
 			if !self.locks.is_empty() {
 				for (account, season_id, lock) in self.locks {
 					let config = PlayerConfig { inventory_tier: InventoryTier::One, locks: lock };
-					PlayerSeasonConfigs::<Test, Instance1>::insert(account, season_id, config);
+					PlayerSeasonConfigs::<Test, ()>::insert(account, season_id, config);
 				}
 			}
 
@@ -471,7 +495,7 @@ impl ExtBuilder {
 				transfer: TransferConfig { open: true },
 				trade: TradeConfig { open: true },
 			};
-			GeneralConfigStore::<Test, Instance1>::put(config);
+			GeneralConfigStore::<Test, ()>::put(config);
 		});
 		ext
 	}

--- a/sage/pallet/src/mock.rs
+++ b/sage/pallet/src/mock.rs
@@ -58,22 +58,27 @@ frame_support::construct_runtime!(
 		System: frame_system = 0,
 		Balances: pallet_balances = 1,
 		Sage: pallet_sage::<Instance1> = 2,
+		#[cfg(feature = "runtime-benchmarks")]
+		SageBench: pallet_sage = 3,
 	}
 );
 
 impl frame_system::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
 	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
-	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
+	type RuntimeTask = RuntimeTask;
+	type Nonce = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = MockAccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type RuntimeEvent = RuntimeEvent;
+	type Block = MockBlock;
 	type BlockHashCount = ConstU64<250>;
+	type DbWeight = ();
 	type Version = ();
 	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<MockBalance>;
@@ -83,9 +88,6 @@ impl frame_system::Config for Test {
 	type SS58Prefix = ConstU16<42>;
 	type OnSetCode = ();
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	type Nonce = u32;
-	type Block = MockBlock;
-	type RuntimeTask = RuntimeTask;
 	type SingleBlockMigrations = ();
 	type MultiBlockMigrator = ();
 	type PreInherents = ();
@@ -98,24 +100,24 @@ parameter_types! {
 }
 
 impl pallet_balances::Config for Test {
-	type Balance = MockBalance;
-	type DustRemoval = ();
 	type RuntimeEvent = RuntimeEvent;
-	type ExistentialDeposit = MockExistentialDeposit;
-	type AccountStore = System;
-	type WeightInfo = ();
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type ReserveIdentifier = [u8; 8];
-	type FreezeIdentifier = ();
-	type MaxFreezes = ();
 	type RuntimeHoldReason = ();
 	type RuntimeFreezeReason = ();
+	type WeightInfo = ();
+	type Balance = MockBalance;
+	type DustRemoval = ();
+	type ExistentialDeposit = MockExistentialDeposit;
+	type AccountStore = System;
+	type ReserveIdentifier = [u8; 8];
+	type FreezeIdentifier = ();
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type MaxFreezes = ();
 }
 
 use example_transition::{
 	generic::ExampleTransitionGeneric,
-	types::{Asset, AssetId, ExampleTransitionId},
+	types::{Asset, AssetId, ExampleTransitionId, Level},
 };
 
 parameter_types! {
@@ -238,6 +240,7 @@ impl FeeProvider for MockTransitionFeeProvider {
 		match identifier {
 			ExampleTransitionId::UpgradeAsset => base_fee.saturating_mul(2),
 			ExampleTransitionId::ConsumeAsset => base_fee.saturating_mul(3),
+			ExampleTransitionId::BenchTransition => base_fee.saturating_mul(10),
 		}
 	}
 }
@@ -358,6 +361,54 @@ impl AssetInspector for MockAssetMediator {
 	}
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+pub struct SageBenchmarkHelper;
+
+#[cfg(feature = "runtime-benchmarks")]
+impl
+	BenchmarkHelper<
+		AssetId,
+		Asset,
+		MockFilter,
+		MockFilter,
+		MockSeasonId,
+		ExampleTransitionId,
+		(),
+		(),
+	> for SageBenchmarkHelper
+{
+	fn create_asset(seed: u32) -> (AssetId, Asset) {
+		let asset_id = AssetId::from_low_u64_le(seed as u64);
+		let asset = Asset::create(asset_id, 0, 0, 0, [seed as u8; 32], 1, Level::One);
+
+		(asset_id, asset)
+	}
+
+	fn create_asset_trade_filter(id: u32) -> MockFilter {
+		MockFilter::from(id)
+	}
+
+	fn create_asset_transfer_filter(id: u32) -> MockFilter {
+		MockFilter::from(id)
+	}
+
+	fn create_transition_id(id: u32) -> ExampleTransitionId {
+		if id == 99 {
+			ExampleTransitionId::BenchTransition
+		} else {
+			ExampleTransitionId::UpgradeAsset
+		}
+	}
+
+	fn create_season_id(id: u32) -> MockSeasonId {
+		MockSeasonId::from(id as u8)
+	}
+
+	fn create_transition_config(_id: u32) {}
+
+	fn create_extra(_id: u32) {}
+}
+
 pub type SageInstance1 = pallet_sage::Instance1;
 impl crate::Config<SageInstance1> for Test {
 	type PalletId = ExamplePalletId;
@@ -375,6 +426,8 @@ impl crate::Config<SageInstance1> for Test {
 	type Currency = Balances;
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = SageBenchmarkHelper;
 }
 
 #[derive(Default)]

--- a/sage/pallet/src/mock.rs
+++ b/sage/pallet/src/mock.rs
@@ -353,50 +353,19 @@ impl AssetInspector for MockAssetMediator {
 pub struct SageBenchmarkHelper;
 
 #[cfg(feature = "runtime-benchmarks")]
-impl SageBenchmarkHelper {
-	pub(crate) fn create_asset_for<T: Config<I>, I: 'static>(
-		account: &T::AccountId,
-		season_id: &SeasonIdOf<T, I>,
-		seed: u32,
-	) -> AssetIdOf<T, I> {
-		let (asset_id, asset) = T::BenchmarkHelper::create_asset(seed);
-
-		T::SeasonHandler::register_asset_in(&asset_id, season_id)
-			.expect("Asset should be registered");
-		Assets::<T, I>::insert(&asset_id, (account, asset));
-		AssetOwners::<T, I>::insert((account, season_id, &asset_id), ());
-
-		asset_id
-	}
-}
-
-#[cfg(feature = "runtime-benchmarks")]
-impl
-	BenchmarkHelper<
-		AssetId,
-		Asset,
-		MockFilter,
-		MockFilter,
-		MockAccountId,
-		MockSeasonId,
-		ExampleTransitionId,
-		(),
-		(),
-	> for SageBenchmarkHelper
+impl BenchmarkHelper<MockAccountId, MockSeasonId, AssetId, Asset, ExampleTransitionId>
+	for SageBenchmarkHelper
 {
-	fn create_asset(seed: u32) -> (AssetId, Asset) {
+	fn create_asset_for(account: &MockAccountId, season_id: &MockSeasonId, seed: u32) -> AssetId {
 		let asset_id = AssetId::from_low_u64_le(seed as u64);
 		let asset = Asset::create(asset_id, 0, 0, 0, [seed as u8; 32], 1, Level::One);
 
-		(asset_id, asset)
-	}
+		MockSeasonManager::register_asset_in(&asset_id, season_id)
+			.expect("Asset should be registered");
+		Assets::<Test, ()>::insert(asset_id, (account, asset));
+		AssetOwners::<Test, ()>::insert((account, season_id, &asset_id), ());
 
-	fn create_asset_trade_filter(id: u32) -> MockFilter {
-		MockFilter::from(id)
-	}
-
-	fn create_asset_transfer_filter(id: u32) -> MockFilter {
-		MockFilter::from(id)
+		asset_id
 	}
 
 	fn create_bench_transition_for(
@@ -404,24 +373,16 @@ impl
 		season: &MockSeasonId,
 		seed: u32,
 	) -> (ExampleTransitionId, Vec<AssetId>) {
-		let asset_id_1 = Self::create_asset_for::<Test, ()>(account, season, seed);
-		let asset_id_2 = Self::create_asset_for::<Test, ()>(account, season, seed * 2);
-		let asset_id_3 = Self::create_asset_for::<Test, ()>(account, season, seed * 3);
-		let asset_id_4 = Self::create_asset_for::<Test, ()>(account, season, seed * 4);
-		let asset_id_5 = Self::create_asset_for::<Test, ()>(account, season, seed * 5);
+		let asset_id_1 = Self::create_asset_for(account, season, seed);
+		let asset_id_2 = Self::create_asset_for(account, season, seed * 2);
+		let asset_id_3 = Self::create_asset_for(account, season, seed * 3);
+		let asset_id_4 = Self::create_asset_for(account, season, seed * 4);
+		let asset_id_5 = Self::create_asset_for(account, season, seed * 5);
 
 		let asset_vec = vec![asset_id_1, asset_id_2, asset_id_3, asset_id_4, asset_id_5];
 
 		(ExampleTransitionId::BenchTransition, asset_vec)
 	}
-
-	fn create_season_id(id: u32) -> MockSeasonId {
-		MockSeasonId::from(id as u8)
-	}
-
-	fn create_transition_config(_id: u32) {}
-
-	fn create_extra(_id: u32) {}
 }
 
 impl crate::Config for Test {

--- a/sage/pallet/src/mock.rs
+++ b/sage/pallet/src/mock.rs
@@ -123,6 +123,7 @@ parameter_types! {
 }
 
 thread_local! {
+	pub static ASSET_SEEDS: RefCell<u64> = RefCell::new(0);
 	pub static ASSET_SEASONS: RefCell<BTreeMap<AssetId, MockSeasonId>> = RefCell::new(BTreeMap::new());
 	pub static CURRENT_SEASON: RefCell<MockSeasonId> = RefCell::new(SEASON_ID_0)
 }
@@ -361,7 +362,6 @@ pub type SageInstance1 = pallet_sage::Instance1;
 impl crate::Config<SageInstance1> for Test {
 	type PalletId = ExamplePalletId;
 	type SageGameTransition = ExampleTransitionGeneric<MockAccountId, MockAssetMediator>;
-	type SageTransitionConfig = ();
 	type SeasonHandler = MockSeasonManager;
 	type FeeHandler = GameFeeHandler<
 		MockAccountId,

--- a/sage/pallet/src/tests/extrinsics/buy_asset.rs
+++ b/sage/pallet/src/tests/extrinsics/buy_asset.rs
@@ -36,16 +36,16 @@ fn buy_should_work() {
 		.build()
 		.execute_with(|| {
 			let season_config_0 =
-				<Test as Config<Instance1>>::SeasonHandler::get_season_config_for(&SEASON_ID_0)
+				<Test as Config<()>>::SeasonHandler::get_season_config_for(&SEASON_ID_0)
 					.expect("Should get season config");
 			let season_fees_0 = season_config_0.fee;
 
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 3);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 3);
 
-			let owned_by_alice = AssetOwners::<Test, Instance1>::iter_prefix((ALICE, SEASON_ID_0))
+			let owned_by_alice = AssetOwners::<Test, ()>::iter_prefix((ALICE, SEASON_ID_0))
 				.map(|(asset_id, _)| asset_id)
 				.collect::<Vec<_>>();
-			let owned_by_bob = AssetOwners::<Test, Instance1>::iter_prefix((BOB, SEASON_ID_0))
+			let owned_by_bob = AssetOwners::<Test, ()>::iter_prefix((BOB, SEASON_ID_0))
 				.map(|(asset_id, _)| asset_id)
 				.collect::<Vec<_>>();
 
@@ -67,34 +67,23 @@ fn buy_should_work() {
 
 			// check for ownership transfer
 			assert_eq!(
-				AssetOwners::<Test, Instance1>::iter_prefix((ALICE, SEASON_ID_0)).count(),
+				AssetOwners::<Test, ()>::iter_prefix((ALICE, SEASON_ID_0)).count(),
 				owned_by_alice.len() + 1
 			);
 			assert_eq!(
-				AssetOwners::<Test, Instance1>::iter_prefix((BOB, SEASON_ID_0)).count(),
+				AssetOwners::<Test, ()>::iter_prefix((BOB, SEASON_ID_0)).count(),
 				owned_by_bob.len() - 1
 			);
-			assert!(AssetOwners::<Test, Instance1>::contains_key((
-				ALICE,
-				SEASON_ID_0,
-				asset_for_sale
-			)));
-			assert!(!AssetOwners::<Test, Instance1>::contains_key((
-				BOB,
-				SEASON_ID_0,
-				asset_for_sale
-			)));
-			assert_eq!(Assets::<Test, Instance1>::get(asset_for_sale).unwrap().0, ALICE);
+			assert!(AssetOwners::<Test, ()>::contains_key((ALICE, SEASON_ID_0, asset_for_sale)));
+			assert!(!AssetOwners::<Test, ()>::contains_key((BOB, SEASON_ID_0, asset_for_sale)));
+			assert_eq!(Assets::<Test, ()>::get(asset_for_sale).unwrap().0, ALICE);
 
 			// check for removal from trade storage
-			assert_eq!(AssetTradePrices::<Test, Instance1>::get(SEASON_ID_0, asset_for_sale), None);
+			assert_eq!(AssetTradePrices::<Test, ()>::get(SEASON_ID_0, asset_for_sale), None);
 
 			// check for account stats
-			assert_eq!(
-				PlayerSeasonStats::<Test, Instance1>::get(ALICE, SEASON_ID_0).bought_amount,
-				1
-			);
-			assert_eq!(PlayerSeasonStats::<Test, Instance1>::get(BOB, SEASON_ID_0).sold_amount, 1);
+			assert_eq!(PlayerSeasonStats::<Test, ()>::get(ALICE, SEASON_ID_0).bought_amount, 1);
+			assert_eq!(PlayerSeasonStats::<Test, ()>::get(BOB, SEASON_ID_0).sold_amount, 1);
 
 			// check events
 			System::assert_last_event(RuntimeEvent::Sage(Event::AssetTraded {
@@ -113,14 +102,11 @@ fn buy_should_work() {
 				asset_price
 			));
 			assert_ok!(Sage::buy_asset(RuntimeOrigin::signed(CHARLIE), asset_for_sale));
-			assert_eq!(
-				PlayerSeasonStats::<Test, Instance1>::get(CHARLIE, SEASON_ID_0).bought_amount,
-				1
-			);
-			assert_eq!(PlayerSeasonStats::<Test, Instance1>::get(BOB, SEASON_ID_0).sold_amount, 2);
+			assert_eq!(PlayerSeasonStats::<Test, ()>::get(CHARLIE, SEASON_ID_0).bought_amount, 1);
+			assert_eq!(PlayerSeasonStats::<Test, ()>::get(BOB, SEASON_ID_0).sold_amount, 2);
 
 			// check season id
-			let asset_on_sale = create_assets::<Instance1>(SEASON_ID_1, ALICE, 1)[0];
+			let asset_on_sale = create_assets::<()>(SEASON_ID_1, ALICE, 1)[0];
 			let asset_price = 369;
 			assert_ok!(Sage::set_asset_price(
 				RuntimeOrigin::signed(ALICE),
@@ -130,28 +116,15 @@ fn buy_should_work() {
 			assert_ok!(Sage::buy_asset(RuntimeOrigin::signed(DAVE), asset_on_sale));
 			// Since the current season is SEASON_ID_0 the stat changes are applied to that season
 			// not SEASON_ID_1
-			let current_season_id =
-				<Test as Config<Instance1>>::SeasonHandler::get_current_season_id()
-					.expect("Should get season id");
+			let current_season_id = <Test as Config<()>>::SeasonHandler::get_current_season_id()
+				.expect("Should get season id");
 			assert_eq!(current_season_id, SEASON_ID_0);
 			// changes in SEASON_ID_0
-			assert_eq!(
-				PlayerSeasonStats::<Test, Instance1>::get(ALICE, SEASON_ID_0).sold_amount,
-				1
-			);
-			assert_eq!(
-				PlayerSeasonStats::<Test, Instance1>::get(DAVE, SEASON_ID_0).bought_amount,
-				1
-			);
+			assert_eq!(PlayerSeasonStats::<Test, ()>::get(ALICE, SEASON_ID_0).sold_amount, 1);
+			assert_eq!(PlayerSeasonStats::<Test, ()>::get(DAVE, SEASON_ID_0).bought_amount, 1);
 			// no changes were applied to SEASON_ID_1 stats
-			assert_eq!(
-				PlayerSeasonStats::<Test, Instance1>::get(ALICE, SEASON_ID_1).sold_amount,
-				0
-			);
-			assert_eq!(
-				PlayerSeasonStats::<Test, Instance1>::get(DAVE, SEASON_ID_1).bought_amount,
-				0
-			);
+			assert_eq!(PlayerSeasonStats::<Test, ()>::get(ALICE, SEASON_ID_1).sold_amount, 0);
+			assert_eq!(PlayerSeasonStats::<Test, ()>::get(DAVE, SEASON_ID_1).bought_amount, 0);
 		});
 }
 
@@ -164,11 +137,11 @@ fn buy_fee_should_be_calculated_correctly() {
 		.build()
 		.execute_with(|| {
 			let season_config_0 =
-				<Test as Config<Instance1>>::SeasonHandler::get_season_config_for(&SEASON_ID_0)
+				<Test as Config<()>>::SeasonHandler::get_season_config_for(&SEASON_ID_0)
 					.expect("Should get season config");
 			let season_fees_0 = season_config_0.fee;
 
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 2);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 2);
 
 			let asset_price = 9_999;
 			assert_ok!(Sage::set_asset_price(
@@ -216,10 +189,10 @@ fn buy_fee_should_be_calculated_correctly() {
 #[test]
 fn buy_should_reject_when_trading_is_closed() {
 	ExtBuilder::default().build().execute_with(|| {
-		GeneralConfigStore::<Test, Instance1>::mutate(|config| config.trade.open = false);
+		GeneralConfigStore::<Test, ()>::mutate(|config| config.trade.open = false);
 		assert_noop!(
 			Sage::buy_asset(RuntimeOrigin::signed(ALICE), AssetId::random()),
-			Error::<Test, Instance1>::TradeClosed,
+			Error::<Test, ()>::TradeClosed,
 		);
 	});
 }
@@ -237,10 +210,10 @@ fn buy_should_reject_unsigned_calls() {
 #[test]
 fn buy_should_reject_unlisted_asset() {
 	ExtBuilder::default().build().execute_with(|| {
-		let asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 1);
+		let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 1);
 		assert_noop!(
 			Sage::buy_asset(RuntimeOrigin::signed(BOB), asset_ids[0]),
-			Error::<Test, Instance1>::AssetNotInTrade,
+			Error::<Test, ()>::AssetNotInTrade,
 		);
 	});
 }
@@ -253,7 +226,7 @@ fn buy_should_reject_insufficient_balance() {
 		.locks(&[(BOB, SEASON_ID_0, Locks::all_unlocked())])
 		.build()
 		.execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 3);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 3);
 			let asset_for_sale = asset_ids[0];
 			let asset_price = alice_initial_balance + 1;
 
@@ -275,7 +248,7 @@ fn buy_should_reject_when_buyer_tries_to_buy_own_asset() {
 		.locks(&[(BOB, SEASON_ID_0, Locks::all_unlocked())])
 		.build()
 		.execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 3);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 3);
 			let asset_for_sale = asset_ids[0];
 			let asset_price = 749;
 
@@ -286,7 +259,7 @@ fn buy_should_reject_when_buyer_tries_to_buy_own_asset() {
 			));
 			assert_noop!(
 				Sage::buy_asset(RuntimeOrigin::signed(BOB), asset_for_sale),
-				Error::<Test, Instance1>::AlreadyOwned
+				Error::<Test, ()>::AlreadyOwned
 			);
 		});
 }

--- a/sage/pallet/src/tests/extrinsics/lock_asset.rs
+++ b/sage/pallet/src/tests/extrinsics/lock_asset.rs
@@ -28,12 +28,12 @@ fn can_lock_asset_successfully_with_sage_lock_id() {
 		])
 		.build()
 		.execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 1);
 			let asset_id = asset_ids[0];
 			let expected_lock = Lock { id: *SAGE_LOCK_ID, locker: ALICE };
 
 			assert_ok!(Sage::lock_asset(RuntimeOrigin::signed(ALICE), asset_id));
-			assert!(LockedAssets::<Test, Instance1>::contains_key(asset_id));
+			assert!(LockedAssets::<Test, ()>::contains_key(asset_id));
 			System::assert_has_event(RuntimeEvent::Sage(Event::AssetLocked {
 				asset_id,
 				lock: expected_lock,
@@ -42,13 +42,13 @@ fn can_lock_asset_successfully_with_sage_lock_id() {
 			// Ensure ownership transferred to technical account
 			let technical_account = Sage::technical_account_id();
 
-			assert!(!AssetOwners::<Test, Instance1>::contains_key((ALICE, SEASON_ID_0, asset_id)));
-			assert!(!AssetOwners::<Test, Instance1>::contains_key((
+			assert!(!AssetOwners::<Test, ()>::contains_key((ALICE, SEASON_ID_0, asset_id)));
+			assert!(!AssetOwners::<Test, ()>::contains_key((
 				technical_account,
 				SEASON_ID_0,
 				asset_id
 			)));
-			assert_eq!(Assets::<Test, Instance1>::get(asset_id).unwrap().0, technical_account);
+			assert_eq!(Assets::<Test, ()>::get(asset_id).unwrap().0, technical_account);
 
 			// Ensure locked assets cannot be used in trading, transferring and forging
 			for extrinsic in [
@@ -61,7 +61,7 @@ fn can_lock_asset_successfully_with_sage_lock_id() {
 					(),
 				),
 			] {
-				assert_noop!(extrinsic, Error::<Test, Instance1>::AssetLocked);
+				assert_noop!(extrinsic, Error::<Test, ()>::AssetLocked);
 			}
 		});
 }

--- a/sage/pallet/src/tests/extrinsics/remove_asset_price.rs
+++ b/sage/pallet/src/tests/extrinsics/remove_asset_price.rs
@@ -22,18 +22,15 @@ fn remove_price_should_work() {
 		.locks(&[(BOB, SEASON_ID_0, Locks::all_unlocked())])
 		.build()
 		.execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 2);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 2);
 			let asset_for_sale = asset_ids[0];
 			let price = 101;
 
 			assert_ok!(Sage::set_asset_price(RuntimeOrigin::signed(BOB), asset_for_sale, price));
 
-			assert_eq!(
-				AssetTradePrices::<Test, Instance1>::get(SEASON_ID_0, asset_for_sale),
-				Some(101)
-			);
+			assert_eq!(AssetTradePrices::<Test, ()>::get(SEASON_ID_0, asset_for_sale), Some(101));
 			assert_ok!(Sage::remove_asset_price(RuntimeOrigin::signed(BOB), asset_for_sale));
-			assert_eq!(AssetTradePrices::<Test, Instance1>::get(SEASON_ID_0, asset_for_sale), None);
+			assert_eq!(AssetTradePrices::<Test, ()>::get(SEASON_ID_0, asset_for_sale), None);
 			System::assert_last_event(RuntimeEvent::Sage(Event::AssetPriceUnset {
 				asset_id: asset_for_sale,
 			}));
@@ -43,10 +40,10 @@ fn remove_price_should_work() {
 #[test]
 fn remove_price_should_reject_when_trading_is_closed() {
 	ExtBuilder::default().build().execute_with(|| {
-		GeneralConfigStore::<Test, Instance1>::mutate(|config| config.trade.open = false);
+		GeneralConfigStore::<Test, ()>::mutate(|config| config.trade.open = false);
 		assert_noop!(
 			Sage::remove_asset_price(RuntimeOrigin::signed(ALICE), AssetId::random()),
-			Error::<Test, Instance1>::TradeClosed,
+			Error::<Test, ()>::TradeClosed,
 		);
 	});
 }
@@ -67,13 +64,13 @@ fn remove_price_should_reject_incorrect_ownership() {
 		.locks(&[(BOB, SEASON_ID_0, Locks::all_unlocked())])
 		.build()
 		.execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 3);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 3);
 			let asset_for_sale = asset_ids[0];
 
 			assert_ok!(Sage::set_asset_price(RuntimeOrigin::signed(BOB), asset_for_sale, 123));
 			assert_noop!(
 				Sage::remove_asset_price(RuntimeOrigin::signed(CHARLIE), asset_for_sale),
-				Error::<Test, Instance1>::AssetNotOwned
+				Error::<Test, ()>::AssetNotOwned
 			);
 		});
 }
@@ -81,10 +78,10 @@ fn remove_price_should_reject_incorrect_ownership() {
 #[test]
 fn remove_price_should_reject_unlisted_asset() {
 	ExtBuilder::default().build().execute_with(|| {
-		let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 1);
+		let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 1);
 		assert_noop!(
 			Sage::remove_asset_price(RuntimeOrigin::signed(CHARLIE), asset_ids[0]),
-			Error::<Test, Instance1>::AssetNotInTrade,
+			Error::<Test, ()>::AssetNotInTrade,
 		);
 	});
 }

--- a/sage/pallet/src/tests/extrinsics/set_asset_price.rs
+++ b/sage/pallet/src/tests/extrinsics/set_asset_price.rs
@@ -22,15 +22,12 @@ fn set_price_should_work() {
 		.locks(&[(BOB, SEASON_ID_0, Locks::all_unlocked())])
 		.build()
 		.execute_with(|| {
-			let asset_for_sale = create_assets::<Instance1>(SEASON_ID_0, BOB, 1)[0];
+			let asset_for_sale = create_assets::<()>(SEASON_ID_0, BOB, 1)[0];
 			let price = 7357;
 
-			assert_eq!(AssetTradePrices::<Test, Instance1>::get(SEASON_ID_0, asset_for_sale), None);
+			assert_eq!(AssetTradePrices::<Test, ()>::get(SEASON_ID_0, asset_for_sale), None);
 			assert_ok!(Sage::set_asset_price(RuntimeOrigin::signed(BOB), asset_for_sale, price));
-			assert_eq!(
-				AssetTradePrices::<Test, Instance1>::get(SEASON_ID_0, asset_for_sale),
-				Some(price)
-			);
+			assert_eq!(AssetTradePrices::<Test, ()>::get(SEASON_ID_0, asset_for_sale), Some(price));
 			System::assert_last_event(RuntimeEvent::Sage(Event::AssetPriceSet {
 				asset_id: asset_for_sale,
 				price,
@@ -41,11 +38,11 @@ fn set_price_should_work() {
 #[test]
 fn set_price_should_reject_when_trading_is_closed() {
 	ExtBuilder::default().build().execute_with(|| {
-		GeneralConfigStore::<Test, Instance1>::mutate(|config| config.trade.open = false);
+		GeneralConfigStore::<Test, ()>::mutate(|config| config.trade.open = false);
 		let asset_id = AssetId::random();
 		assert_noop!(
 			Sage::set_asset_price(RuntimeOrigin::signed(ALICE), asset_id, 1),
-			Error::<Test, Instance1>::TradeClosed,
+			Error::<Test, ()>::TradeClosed,
 		);
 	});
 }
@@ -64,12 +61,12 @@ fn set_price_should_reject_unsigned_calls() {
 #[test]
 fn set_price_should_reject_setting_price_to_a_non_owned_asset() {
 	ExtBuilder::default().build().execute_with(|| {
-		let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 2);
+		let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 2);
 		let asset_id = asset_ids[0];
 
 		assert_noop!(
 			Sage::set_asset_price(RuntimeOrigin::signed(CHARLIE), asset_id, 101),
-			Error::<Test, Instance1>::AssetNotOwned
+			Error::<Test, ()>::AssetNotOwned
 		);
 	});
 }
@@ -89,22 +86,21 @@ fn set_price_should_reject_asset_not_matching_trade_filters() {
 				AssetFilter::Trade(trade_filter)
 			));
 
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 2);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 2);
 			let asset_id_1 = asset_ids[0];
 			let asset_id_2 = asset_ids[1];
 
 			// Since asset_id_1 doest have its type match the filter we cannot set price for it
-			let (_, asset_1) =
-				Assets::<Test, Instance1>::get(asset_id_1).expect("Should get asset");
+			let (_, asset_1) = Assets::<Test, ()>::get(asset_id_1).expect("Should get asset");
 			assert_eq!(asset_1.asset_type, 0);
 			assert_noop!(
 				Sage::set_asset_price(RuntimeOrigin::signed(BOB), asset_id_1, 101),
-				Error::<Test, Instance1>::AssetCannotBeTraded
+				Error::<Test, ()>::AssetCannotBeTraded
 			);
 
 			// We change asset_id_2 type so that it matches the filter, allowing us to put it on
 			// sale
-			Assets::<Test, Instance1>::mutate(asset_id_2, |maybe_asset| {
+			Assets::<Test, ()>::mutate(asset_id_2, |maybe_asset| {
 				if let Some((_, ref mut asset)) = maybe_asset {
 					asset.asset_type = trade_filter;
 				}

--- a/sage/pallet/src/tests/extrinsics/set_organizer.rs
+++ b/sage/pallet/src/tests/extrinsics/set_organizer.rs
@@ -19,9 +19,9 @@ use super::*;
 #[test]
 fn set_organizer_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(Organizer::<Test, Instance1>::get(), None);
+		assert_eq!(Organizer::<Test, ()>::get(), None);
 		assert_ok!(Sage::set_organizer(RuntimeOrigin::root(), ALICE));
-		assert_eq!(Organizer::<Test, Instance1>::get(), Some(ALICE));
+		assert_eq!(Organizer::<Test, ()>::get(), Some(ALICE));
 		System::assert_last_event(RuntimeEvent::Sage(Event::OrganizerSet { organizer: ALICE }));
 	});
 }
@@ -39,13 +39,13 @@ fn set_organizer_should_reject_non_root_calls() {
 #[test]
 fn set_organizer_should_replace_existing_organizer() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(Organizer::<Test, Instance1>::get(), None);
+		assert_eq!(Organizer::<Test, ()>::get(), None);
 		assert_ok!(Sage::set_organizer(RuntimeOrigin::root(), DAVE));
-		assert_eq!(Organizer::<Test, Instance1>::get(), Some(DAVE));
+		assert_eq!(Organizer::<Test, ()>::get(), Some(DAVE));
 		System::assert_last_event(RuntimeEvent::Sage(Event::OrganizerSet { organizer: DAVE }));
 
 		assert_ok!(Sage::set_organizer(RuntimeOrigin::root(), CHARLIE));
-		assert_eq!(Organizer::<Test, Instance1>::get(), Some(CHARLIE));
+		assert_eq!(Organizer::<Test, ()>::get(), Some(CHARLIE));
 		System::assert_last_event(RuntimeEvent::Sage(Event::OrganizerSet { organizer: CHARLIE }));
 	});
 }

--- a/sage/pallet/src/tests/extrinsics/state_transition.rs
+++ b/sage/pallet/src/tests/extrinsics/state_transition.rs
@@ -24,12 +24,12 @@ fn state_transition_works() {
 		.balances(&[(ALICE, initial_balance)])
 		.build()
 		.execute_with(|| {
-			let season_id = <Test as Config<Instance1>>::SeasonHandler::get_current_season_id()
+			let season_id = <Test as Config<()>>::SeasonHandler::get_current_season_id()
 				.expect("Should get season_id");
 			let season_config =
-				<Test as Config<Instance1>>::SeasonHandler::get_season_config_for(&season_id)
+				<Test as Config<()>>::SeasonHandler::get_season_config_for(&season_id)
 					.expect("Should get season config");
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 1);
 			let transition_id = ExampleTransitionId::UpgradeAsset;
 
 			assert_eq!(Balances::free_balance(ALICE), initial_balance);
@@ -57,12 +57,12 @@ fn state_transition_should_reject_non_owned_assets() {
 		.balances(&[(ALICE, initial_balance)])
 		.build()
 		.execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 1);
 			let transition_id = ExampleTransitionId::UpgradeAsset;
 
 			assert_noop!(
 				Sage::state_transition(RuntimeOrigin::signed(ALICE), transition_id, asset_ids, ()),
-				Error::<Test, Instance1>::AssetNotOwned
+				Error::<Test, ()>::AssetNotOwned
 			);
 		})
 }
@@ -74,7 +74,7 @@ fn state_transition_should_reject_locked_assets() {
 		.balances(&[(ALICE, initial_balance)])
 		.build()
 		.execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 1);
 			let asset_id = asset_ids[0];
 			let transition_id = ExampleTransitionId::UpgradeAsset;
 
@@ -88,7 +88,7 @@ fn state_transition_should_reject_locked_assets() {
 					asset_ids,
 					()
 				),
-				Error::<Test, Instance1>::AssetLocked
+				Error::<Test, ()>::AssetLocked
 			);
 		})
 }
@@ -103,12 +103,12 @@ fn state_transition_should_reject_rule_verification_failure() {
 			// This test assumes that the rule for 'UpgradeAsset' in
 			// sage/example-transition/src/generic.rs
 			// requires the input assets to be of length 1
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 2);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 2);
 			let transition_id = ExampleTransitionId::UpgradeAsset;
 
 			assert_noop!(
 				Sage::state_transition(RuntimeOrigin::signed(ALICE), transition_id, asset_ids, ()),
-				Error::<Test, Instance1>::RuleNotSatisfied {
+				Error::<Test, ()>::RuleNotSatisfied {
 					code: sage_api::Error::InvalidAssetLength.as_error_code()
 				}
 			);
@@ -122,16 +122,13 @@ fn state_transition_should_reject_too_many_input_assets() {
 		.balances(&[(ALICE, initial_balance)])
 		.build()
 		.execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(
-				SEASON_ID_0,
-				ALICE,
-				(MAX_ASSETS_IN_TRANSITION + 1) as u8,
-			);
+			let asset_ids =
+				create_assets::<()>(SEASON_ID_0, ALICE, (MAX_ASSETS_IN_TRANSITION + 1) as u8);
 			let transition_id = ExampleTransitionId::UpgradeAsset;
 
 			assert_noop!(
 				Sage::state_transition(RuntimeOrigin::signed(ALICE), transition_id, asset_ids, ()),
-				Error::<Test, Instance1>::TooManyAssetsInTransition
+				Error::<Test, ()>::TooManyAssetsInTransition
 			);
 		})
 }

--- a/sage/pallet/src/tests/extrinsics/transfer_asset.rs
+++ b/sage/pallet/src/tests/extrinsics/transfer_asset.rs
@@ -30,12 +30,12 @@ fn transfer_asset_works() {
 		.build()
 		.execute_with(|| {
 			let season_config =
-				<Test as Config<Instance1>>::SeasonHandler::get_season_config_for(&SEASON_ID_0)
+				<Test as Config<()>>::SeasonHandler::get_season_config_for(&SEASON_ID_0)
 					.expect("Should get season config");
 			let transfer_fee = season_config.fee.transfer_asset;
 
-			let alice_asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 3);
-			let bob_asset_ids = create_assets::<Instance1>(SEASON_ID_1, BOB, 6);
+			let alice_asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 3);
+			let bob_asset_ids = create_assets::<()>(SEASON_ID_1, BOB, 6);
 			let asset_id = alice_asset_ids[0];
 
 			assert_ok!(Sage::transfer_asset(RuntimeOrigin::signed(ALICE), BOB, asset_id));
@@ -47,11 +47,11 @@ fn transfer_asset_works() {
 
 			// Asset transferred from Alice.
 			assert_eq!(
-				AssetOwners::<Test, Instance1>::iter_prefix((ALICE, SEASON_ID_0)).count(),
+				AssetOwners::<Test, ()>::iter_prefix((ALICE, SEASON_ID_0)).count(),
 				alice_asset_ids.len() - 1
 			);
 			let alice_current_assets = {
-				let mut assets = AssetOwners::<Test, Instance1>::iter_prefix((ALICE, SEASON_ID_0))
+				let mut assets = AssetOwners::<Test, ()>::iter_prefix((ALICE, SEASON_ID_0))
 					.map(|(asset_id, _)| asset_id)
 					.collect::<Vec<_>>();
 
@@ -66,11 +66,11 @@ fn transfer_asset_works() {
 			assert_eq!(alice_current_assets, alice_expected_assets);
 
 			// Asset transferred to Bob.
-			assert_eq!(AssetOwners::<Test, Instance1>::iter_prefix((BOB, SEASON_ID_0)).count(), 1);
-			assert_eq!(Assets::<Test, Instance1>::get(asset_id).unwrap().0, BOB);
+			assert_eq!(AssetOwners::<Test, ()>::iter_prefix((BOB, SEASON_ID_0)).count(), 1);
+			assert_eq!(Assets::<Test, ()>::get(asset_id).unwrap().0, BOB);
 
 			let bob_current_assets_season_0 = {
-				let mut assets = AssetOwners::<Test, Instance1>::iter_prefix((BOB, SEASON_ID_0))
+				let mut assets = AssetOwners::<Test, ()>::iter_prefix((BOB, SEASON_ID_0))
 					.map(|(asset_id, _)| asset_id)
 					.collect::<Vec<_>>();
 				assets.sort();
@@ -79,9 +79,9 @@ fn transfer_asset_works() {
 			assert_eq!(bob_current_assets_season_0, vec![asset_id]);
 
 			// Bob's original assets are safe.
-			assert_eq!(AssetOwners::<Test, Instance1>::iter_prefix((BOB, SEASON_ID_1)).count(), 6);
+			assert_eq!(AssetOwners::<Test, ()>::iter_prefix((BOB, SEASON_ID_1)).count(), 6);
 			let bob_current_assets_season_1 = {
-				let mut assets = AssetOwners::<Test, Instance1>::iter_prefix((BOB, SEASON_ID_1))
+				let mut assets = AssetOwners::<Test, ()>::iter_prefix((BOB, SEASON_ID_1))
 					.map(|(asset_id, _)| asset_id)
 					.collect::<Vec<_>>();
 				assets.sort();
@@ -98,29 +98,26 @@ fn transfer_asset_works() {
 			assert_eq!(Balances::free_balance(ALICE), alice_initial_balance - transfer_fee);
 
 			// Organizer can transfer even when trade is closed.
-			GeneralConfigStore::<Test, Instance1>::mutate(|config| config.transfer.open = false);
+			GeneralConfigStore::<Test, ()>::mutate(|config| config.transfer.open = false);
 			Balances::make_free_balance_be(&BOB, transfer_fee + MockExistentialDeposit::get());
 			assert_ok!(Sage::set_organizer(RuntimeOrigin::root(), BOB));
 			assert_ok!(Sage::transfer_asset(RuntimeOrigin::signed(BOB), CHARLIE, bob_asset_ids[0]));
 			assert_eq!(Balances::free_balance(BOB), MockExistentialDeposit::get());
 			assert_eq!(
-				AssetOwners::<Test, Instance1>::iter_prefix((BOB, SEASON_ID_1)).count(),
+				AssetOwners::<Test, ()>::iter_prefix((BOB, SEASON_ID_1)).count(),
 				bob_asset_ids.len() - 1
 			);
-			assert_eq!(
-				AssetOwners::<Test, Instance1>::iter_prefix((CHARLIE, SEASON_ID_1)).count(),
-				1
-			);
+			assert_eq!(AssetOwners::<Test, ()>::iter_prefix((CHARLIE, SEASON_ID_1)).count(), 1);
 		});
 }
 
 #[test]
 fn transfer_asset_rejects_on_transfer_closed() {
 	ExtBuilder::default().build().execute_with(|| {
-		GeneralConfigStore::<Test, Instance1>::mutate(|config| config.transfer.open = false);
+		GeneralConfigStore::<Test, ()>::mutate(|config| config.transfer.open = false);
 		assert_noop!(
 			Sage::transfer_asset(RuntimeOrigin::signed(BOB), CHARLIE, AssetId::random()),
-			Error::<Test, Instance1>::TransferClosed
+			Error::<Test, ()>::TransferClosed
 		);
 	});
 }
@@ -133,8 +130,8 @@ fn transfer_asset_works_on_transfer_closed_with_organizer() {
 		.locks(&[(BOB, SEASON_ID_0, Locks::all_unlocked())])
 		.build()
 		.execute_with(|| {
-			GeneralConfigStore::<Test, Instance1>::mutate(|config| config.transfer.open = false);
-			let bob_asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 1);
+			GeneralConfigStore::<Test, ()>::mutate(|config| config.transfer.open = false);
+			let bob_asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 1);
 			let asset_id = bob_asset_ids[0];
 			assert_ok!(Sage::transfer_asset(RuntimeOrigin::signed(BOB), DAVE, asset_id));
 		});
@@ -144,11 +141,11 @@ fn transfer_asset_works_on_transfer_closed_with_organizer() {
 fn transfer_asset_rejects_transferring_to_self() {
 	ExtBuilder::default().build().execute_with(|| {
 		for who in [ALICE, BOB, CHARLIE, DAVE] {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, who, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, who, 1);
 			let asset_id = asset_ids[0];
 			assert_noop!(
 				Sage::transfer_asset(RuntimeOrigin::signed(who), who, asset_id),
-				Error::<Test, Instance1>::CannotTransferToSelf
+				Error::<Test, ()>::CannotTransferToSelf
 			);
 		}
 	});
@@ -160,12 +157,12 @@ fn transfer_asset_rejects_asset_in_trade() {
 		.locks(&[(CHARLIE, SEASON_ID_0, Locks::all_unlocked())])
 		.build()
 		.execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, CHARLIE, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, CHARLIE, 1);
 			let asset_id = asset_ids[0];
 			assert_ok!(Sage::set_asset_price(RuntimeOrigin::signed(CHARLIE), asset_id, 999));
 			assert_noop!(
 				Sage::transfer_asset(RuntimeOrigin::signed(CHARLIE), DAVE, asset_id),
-				Error::<Test, Instance1>::CannotTransferAssetInTrade
+				Error::<Test, ()>::CannotTransferAssetInTrade
 			);
 		});
 }
@@ -173,10 +170,10 @@ fn transfer_asset_rejects_asset_in_trade() {
 #[test]
 fn transfer_asset_rejects_unowned_assets() {
 	ExtBuilder::default().build().execute_with(|| {
-		let asset_id = create_assets::<Instance1>(SEASON_ID_0, CHARLIE, 1)[0];
+		let asset_id = create_assets::<()>(SEASON_ID_0, CHARLIE, 1)[0];
 		assert_noop!(
 			Sage::transfer_asset(RuntimeOrigin::signed(ALICE), BOB, asset_id),
-			Error::<Test, Instance1>::AssetNotOwned
+			Error::<Test, ()>::AssetNotOwned
 		);
 	});
 }
@@ -186,7 +183,7 @@ fn transfer_asset_rejects_unknown_assets() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_noop!(
 			Sage::transfer_asset(RuntimeOrigin::signed(ALICE), BOB, AssetId::random()),
-			Error::<Test, Instance1>::UnknownAsset
+			Error::<Test, ()>::UnknownAsset
 		);
 	});
 }
@@ -198,22 +195,18 @@ fn transfer_asset_rejects_on_full_asset_inventory_of_recipient() {
 		.locks(&[(ALICE, SEASON_ID_0, Locks::all_unlocked())])
 		.build()
 		.execute_with(|| {
-			PlayerSeasonConfigs::<Test, Instance1>::mutate(BOB, SEASON_ID_0, |config| {
+			PlayerSeasonConfigs::<Test, ()>::mutate(BOB, SEASON_ID_0, |config| {
 				config.inventory_tier = InventoryTier::Three
 			});
 
-			let alice_asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 1);
+			let alice_asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 1);
 			let asset_id = alice_asset_ids[0];
-			let _ = create_assets::<Instance1>(
-				SEASON_ID_0,
-				BOB,
-				InventoryTier::Three.get_asset_slots(),
-			);
+			let _ = create_assets::<()>(SEASON_ID_0, BOB, InventoryTier::Three.get_asset_slots());
 
 			// Trying to send an asset to BOB while his inventory is already full
 			assert_noop!(
 				Sage::transfer_asset(RuntimeOrigin::signed(ALICE), BOB, asset_id),
-				Error::<Test, Instance1>::MaxOwnershipReached
+				Error::<Test, ()>::MaxOwnershipReached
 			);
 		});
 }
@@ -234,22 +227,21 @@ fn transfer_asset_rejects_asset_not_matching_transfer_filters() {
 				AssetFilter::Transfer(transfer_filter)
 			));
 
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 2);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 2);
 			let asset_id_1 = asset_ids[0];
 			let asset_id_2 = asset_ids[1];
 
 			// Since asset_id_1 doest have its type match the filter we cannot set price for it
-			let (_, asset_1) =
-				Assets::<Test, Instance1>::get(asset_id_1).expect("Should get asset");
+			let (_, asset_1) = Assets::<Test, ()>::get(asset_id_1).expect("Should get asset");
 			assert_eq!(asset_1.asset_type, 0);
 			assert_noop!(
 				Sage::transfer_asset(RuntimeOrigin::signed(BOB), ALICE, asset_id_1),
-				Error::<Test, Instance1>::AssetCannotBeTransfered
+				Error::<Test, ()>::AssetCannotBeTransfered
 			);
 
 			// We change asset_id_2 type so that it matches the filter, allowing us to put it on
 			// sale
-			Assets::<Test, Instance1>::mutate(asset_id_2, |maybe_asset| {
+			Assets::<Test, ()>::mutate(asset_id_2, |maybe_asset| {
 				if let Some((_, ref mut asset)) = maybe_asset {
 					asset.asset_type = transfer_filter;
 				}

--- a/sage/pallet/src/tests/extrinsics/unlock_asset.rs
+++ b/sage/pallet/src/tests/extrinsics/unlock_asset.rs
@@ -19,13 +19,13 @@ use super::*;
 #[test]
 fn can_unlock_asset_successfully_with_sage_lock_id() {
 	ExtBuilder::default().balances(&[(ALICE, 1_000)]).build().execute_with(|| {
-		let asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 1);
+		let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 1);
 		let asset_id = asset_ids[0];
 		let expected_lock = Lock { id: *SAGE_LOCK_ID, locker: ALICE };
 
 		assert_ok!(Sage::lock_asset(RuntimeOrigin::signed(ALICE), asset_id));
 		assert_eq!(
-			LockedAssets::<Test, Instance1>::get(asset_id),
+			LockedAssets::<Test, ()>::get(asset_id),
 			Some(Lock { id: *SAGE_LOCK_ID, locker: ALICE })
 		);
 		assert_ok!(Sage::unlock_asset(RuntimeOrigin::signed(ALICE), asset_id));
@@ -33,6 +33,6 @@ fn can_unlock_asset_successfully_with_sage_lock_id() {
 			asset_id,
 			lock: expected_lock,
 		}));
-		assert_eq!(LockedAssets::<Test, Instance1>::get(asset_id), None);
+		assert_eq!(LockedAssets::<Test, ()>::get(asset_id), None);
 	});
 }

--- a/sage/pallet/src/tests/extrinsics/unlock_feature.rs
+++ b/sage/pallet/src/tests/extrinsics/unlock_feature.rs
@@ -24,19 +24,17 @@ fn unlock_feature_works_for_trade_asset_targets() {
 		.balances(&[(ALICE, initial_balance), (BOB, initial_balance)])
 		.build()
 		.execute_with(|| {
-			let season_id = <Test as Config<Instance1>>::SeasonHandler::get_current_season_id()
+			let season_id = <Test as Config<()>>::SeasonHandler::get_current_season_id()
 				.expect("Should get season_id");
 			let season_config =
-				<Test as Config<Instance1>>::SeasonHandler::get_season_config_for(&season_id)
+				<Test as Config<()>>::SeasonHandler::get_season_config_for(&season_id)
 					.expect("Should get season config");
 			let unlock_rule = UnlockRule::from([1, 0, 0, 0, 0]);
 
-			SeasonUnlocks::<Test, Instance1>::insert(season_id, feature_to_unlock, unlock_rule);
+			SeasonUnlocks::<Test, ()>::insert(season_id, feature_to_unlock, unlock_rule);
 
 			// Unlocking feature for oneself through the unlock filters
-			assert!(
-				!PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, season_id).locks.asset_trade
-			);
+			assert!(!PlayerSeasonConfigs::<Test, ()>::get(ALICE, season_id).locks.asset_trade);
 			// The first attempt fails since ALICE doesn't pass the filters
 			assert_noop!(
 				Sage::unlock_feature(
@@ -45,10 +43,10 @@ fn unlock_feature_works_for_trade_asset_targets() {
 					feature_to_unlock,
 					season_id
 				),
-				Error::<Test, Instance1>::UnlockCriteriaNotFulfilled
+				Error::<Test, ()>::UnlockCriteriaNotFulfilled
 			);
 			// We adjust her stats so that she does
-			PlayerSeasonStats::<Test, Instance1>::mutate(ALICE, season_id, |stats| {
+			PlayerSeasonStats::<Test, ()>::mutate(ALICE, season_id, |stats| {
 				stats.minted_amount = 1;
 			});
 			assert_ok!(Sage::unlock_feature(
@@ -63,13 +61,11 @@ fn unlock_feature_works_for_trade_asset_targets() {
 				season_id,
 				account: ALICE,
 			}));
-			assert!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, season_id).locks.asset_trade
-			);
+			assert!(PlayerSeasonConfigs::<Test, ()>::get(ALICE, season_id).locks.asset_trade);
 
 			// Unlocking feature for oneself through paying
 			assert_eq!(Balances::free_balance(BOB), initial_balance);
-			assert!(!PlayerSeasonConfigs::<Test, Instance1>::get(BOB, season_id).locks.asset_trade);
+			assert!(!PlayerSeasonConfigs::<Test, ()>::get(BOB, season_id).locks.asset_trade);
 			assert_ok!(Sage::unlock_feature(
 				RuntimeOrigin::signed(BOB),
 				UnlockTarget::OneselfPaying,
@@ -85,14 +81,10 @@ fn unlock_feature_works_for_trade_asset_targets() {
 				Balances::free_balance(BOB),
 				initial_balance - season_config.fee.unlock_trade_asset
 			);
-			assert!(PlayerSeasonConfigs::<Test, Instance1>::get(BOB, season_id).locks.asset_trade);
+			assert!(PlayerSeasonConfigs::<Test, ()>::get(BOB, season_id).locks.asset_trade);
 
 			// Unlocking feature for another through paying
-			assert!(
-				!PlayerSeasonConfigs::<Test, Instance1>::get(CHARLIE, season_id)
-					.locks
-					.asset_trade
-			);
+			assert!(!PlayerSeasonConfigs::<Test, ()>::get(CHARLIE, season_id).locks.asset_trade);
 			assert_ok!(Sage::unlock_feature(
 				RuntimeOrigin::signed(BOB),
 				UnlockTarget::OtherPaying(CHARLIE),
@@ -108,11 +100,7 @@ fn unlock_feature_works_for_trade_asset_targets() {
 				Balances::free_balance(BOB),
 				initial_balance - season_config.fee.unlock_trade_asset * 2
 			);
-			assert!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(CHARLIE, season_id)
-					.locks
-					.asset_trade
-			);
+			assert!(PlayerSeasonConfigs::<Test, ()>::get(CHARLIE, season_id).locks.asset_trade);
 		});
 }
 
@@ -124,21 +112,17 @@ fn unlock_feature_works_for_transfer_asset_targets() {
 		.balances(&[(ALICE, initial_balance), (BOB, initial_balance)])
 		.build()
 		.execute_with(|| {
-			let season_id = <Test as Config<Instance1>>::SeasonHandler::get_current_season_id()
+			let season_id = <Test as Config<()>>::SeasonHandler::get_current_season_id()
 				.expect("Should get season_id");
 			let season_config =
-				<Test as Config<Instance1>>::SeasonHandler::get_season_config_for(&season_id)
+				<Test as Config<()>>::SeasonHandler::get_season_config_for(&season_id)
 					.expect("Should get season config");
 			let unlock_rule = UnlockRule::from([0, 0, 3, 0, 0]);
 
-			SeasonUnlocks::<Test, Instance1>::insert(season_id, feature_to_unlock, unlock_rule);
+			SeasonUnlocks::<Test, ()>::insert(season_id, feature_to_unlock, unlock_rule);
 
 			// Unlocking feature for oneself through the unlock filters
-			assert!(
-				!PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, season_id)
-					.locks
-					.asset_transfer
-			);
+			assert!(!PlayerSeasonConfigs::<Test, ()>::get(ALICE, season_id).locks.asset_transfer);
 			// The first attempt fails since ALICE doesn't pass the filters
 			assert_noop!(
 				Sage::unlock_feature(
@@ -147,10 +131,10 @@ fn unlock_feature_works_for_transfer_asset_targets() {
 					feature_to_unlock,
 					season_id
 				),
-				Error::<Test, Instance1>::UnlockCriteriaNotFulfilled
+				Error::<Test, ()>::UnlockCriteriaNotFulfilled
 			);
 			// We adjust her stats so that she does
-			PlayerSeasonStats::<Test, Instance1>::mutate(ALICE, season_id, |stats| {
+			PlayerSeasonStats::<Test, ()>::mutate(ALICE, season_id, |stats| {
 				stats.forged_amount = 3;
 			});
 			assert_ok!(Sage::unlock_feature(
@@ -165,17 +149,11 @@ fn unlock_feature_works_for_transfer_asset_targets() {
 				season_id,
 				account: ALICE,
 			}));
-			assert!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, season_id)
-					.locks
-					.asset_transfer
-			);
+			assert!(PlayerSeasonConfigs::<Test, ()>::get(ALICE, season_id).locks.asset_transfer);
 
 			// Unlocking feature for oneself through paying
 			assert_eq!(Balances::free_balance(BOB), initial_balance);
-			assert!(
-				!PlayerSeasonConfigs::<Test, Instance1>::get(BOB, season_id).locks.asset_transfer
-			);
+			assert!(!PlayerSeasonConfigs::<Test, ()>::get(BOB, season_id).locks.asset_transfer);
 			assert_ok!(Sage::unlock_feature(
 				RuntimeOrigin::signed(BOB),
 				UnlockTarget::OneselfPaying,
@@ -191,16 +169,10 @@ fn unlock_feature_works_for_transfer_asset_targets() {
 				Balances::free_balance(BOB),
 				initial_balance - season_config.fee.unlock_trade_asset
 			);
-			assert!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(BOB, season_id).locks.asset_transfer
-			);
+			assert!(PlayerSeasonConfigs::<Test, ()>::get(BOB, season_id).locks.asset_transfer);
 
 			// Unlocking feature for another through paying
-			assert!(
-				!PlayerSeasonConfigs::<Test, Instance1>::get(CHARLIE, season_id)
-					.locks
-					.asset_transfer
-			);
+			assert!(!PlayerSeasonConfigs::<Test, ()>::get(CHARLIE, season_id).locks.asset_transfer);
 			assert_ok!(Sage::unlock_feature(
 				RuntimeOrigin::signed(BOB),
 				UnlockTarget::OtherPaying(CHARLIE),
@@ -216,10 +188,6 @@ fn unlock_feature_works_for_transfer_asset_targets() {
 				Balances::free_balance(BOB),
 				initial_balance - season_config.fee.unlock_trade_asset * 2
 			);
-			assert!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(CHARLIE, season_id)
-					.locks
-					.asset_transfer
-			);
+			assert!(PlayerSeasonConfigs::<Test, ()>::get(CHARLIE, season_id).locks.asset_transfer);
 		});
 }

--- a/sage/pallet/src/tests/extrinsics/update_asset_filter.rs
+++ b/sage/pallet/src/tests/extrinsics/update_asset_filter.rs
@@ -22,7 +22,7 @@ fn update_asset_filter_should_work_for_trade_filter() {
 		let filter_core = MockFilter::from(13_u32);
 		let filter = AssetFilter::Trade(filter_core);
 
-		assert_eq!(SeasonTradeFilters::<Test, Instance1>::get(SEASON_ID_0), 0);
+		assert_eq!(SeasonTradeFilters::<Test, ()>::get(SEASON_ID_0), 0);
 
 		assert_ok!(Sage::update_asset_filter(RuntimeOrigin::signed(ALICE), SEASON_ID_0, filter));
 		System::assert_last_event(RuntimeEvent::Sage(Event::UpdatedTradeFilter {
@@ -30,7 +30,7 @@ fn update_asset_filter_should_work_for_trade_filter() {
 			filter: filter_core,
 		}));
 
-		assert_eq!(SeasonTradeFilters::<Test, Instance1>::get(SEASON_ID_0), filter_core);
+		assert_eq!(SeasonTradeFilters::<Test, ()>::get(SEASON_ID_0), filter_core);
 	});
 }
 
@@ -40,7 +40,7 @@ fn update_asset_filter_should_work_for_transfer_filter() {
 		let filter_core = MockFilter::from(13_u32);
 		let filter = AssetFilter::Transfer(filter_core);
 
-		assert_eq!(SeasonTradeFilters::<Test, Instance1>::get(SEASON_ID_0), 0);
+		assert_eq!(SeasonTradeFilters::<Test, ()>::get(SEASON_ID_0), 0);
 
 		assert_ok!(Sage::update_asset_filter(RuntimeOrigin::signed(ALICE), SEASON_ID_0, filter));
 		System::assert_last_event(RuntimeEvent::Sage(Event::UpdatedTransferFilter {
@@ -48,7 +48,7 @@ fn update_asset_filter_should_work_for_transfer_filter() {
 			filter: filter_core,
 		}));
 
-		assert_eq!(SeasonTransferFilters::<Test, Instance1>::get(SEASON_ID_0), filter_core);
+		assert_eq!(SeasonTransferFilters::<Test, ()>::get(SEASON_ID_0), filter_core);
 	});
 }
 

--- a/sage/pallet/src/tests/extrinsics/update_general_config.rs
+++ b/sage/pallet/src/tests/extrinsics/update_general_config.rs
@@ -19,7 +19,7 @@ use super::*;
 #[test]
 fn update_general_config_should_work() {
 	ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
-		let config = GeneralConfigOf::<Test, Instance1>::default();
+		let config = GeneralConfigOf::<Test, ()>::default();
 		assert_ok!(Sage::update_general_config(RuntimeOrigin::signed(ALICE), config.clone()));
 		System::assert_last_event(RuntimeEvent::Sage(Event::UpdatedGeneralConfig {
 			updated_config: config,
@@ -33,7 +33,7 @@ fn update_general_config_should_reject_non_organizer_calls() {
 		assert_noop!(
 			Sage::update_general_config(
 				RuntimeOrigin::signed(BOB),
-				GeneralConfigOf::<Test, Instance1>::default()
+				GeneralConfigOf::<Test, ()>::default()
 			),
 			DispatchError::BadOrigin
 		);

--- a/sage/pallet/src/tests/extrinsics/upgrade_asset_inventory.rs
+++ b/sage/pallet/src/tests/extrinsics/upgrade_asset_inventory.rs
@@ -24,16 +24,16 @@ fn upgrade_asset_inventory_should_work() {
 		.build()
 		.execute_with(|| {
 			let season_config =
-				<Test as Config<Instance1>>::SeasonHandler::get_season_config_for(&SEASON_ID_0)
+				<Test as Config<()>>::SeasonHandler::get_season_config_for(&SEASON_ID_0)
 					.expect("Should get season config");
 			let upgrade_fee = season_config.fee.upgrade_asset_inventory;
 
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0).inventory_tier,
 				InventoryTier::One
 			);
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0)
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0)
 					.inventory_tier
 					.get_asset_slots(),
 				25
@@ -48,11 +48,11 @@ fn upgrade_asset_inventory_should_work() {
 			}));
 
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0).inventory_tier,
 				InventoryTier::Two
 			);
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0)
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0)
 					.inventory_tier
 					.get_asset_slots(),
 				50
@@ -67,11 +67,11 @@ fn upgrade_asset_inventory_should_work() {
 			}));
 
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0).inventory_tier,
 				InventoryTier::Three
 			);
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0)
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0)
 					.inventory_tier
 					.get_asset_slots(),
 				75
@@ -86,11 +86,11 @@ fn upgrade_asset_inventory_should_work() {
 			}));
 
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0).inventory_tier,
 				InventoryTier::Four
 			);
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0)
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0)
 					.inventory_tier
 					.get_asset_slots(),
 				100
@@ -105,11 +105,11 @@ fn upgrade_asset_inventory_should_work() {
 			}));
 
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0).inventory_tier,
 				InventoryTier::Five
 			);
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0)
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0)
 					.inventory_tier
 					.get_asset_slots(),
 				150
@@ -124,11 +124,11 @@ fn upgrade_asset_inventory_should_work() {
 			}));
 
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0).inventory_tier,
 				InventoryTier::Max
 			);
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0)
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0)
 					.inventory_tier
 					.get_asset_slots(),
 				200
@@ -145,11 +145,11 @@ fn upgrade_asset_inventory_should_work_on_different_beneficiary() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0).inventory_tier,
 				InventoryTier::One
 			);
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(BOB, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(BOB, SEASON_ID_0).inventory_tier,
 				InventoryTier::One
 			);
 
@@ -165,11 +165,11 @@ fn upgrade_asset_inventory_should_work_on_different_beneficiary() {
 			}));
 
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0).inventory_tier,
 				InventoryTier::One
 			);
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(BOB, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(BOB, SEASON_ID_0).inventory_tier,
 				InventoryTier::Two
 			);
 		});
@@ -183,11 +183,11 @@ fn upgrade_asset_inventory_should_work_on_different_season() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0).inventory_tier,
 				InventoryTier::One
 			);
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_1).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_1).inventory_tier,
 				InventoryTier::One
 			);
 
@@ -198,11 +198,11 @@ fn upgrade_asset_inventory_should_work_on_different_season() {
 			));
 
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_0).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_0).inventory_tier,
 				InventoryTier::One
 			);
 			assert_eq!(
-				PlayerSeasonConfigs::<Test, Instance1>::get(ALICE, SEASON_ID_1).inventory_tier,
+				PlayerSeasonConfigs::<Test, ()>::get(ALICE, SEASON_ID_1).inventory_tier,
 				InventoryTier::Two
 			);
 		});
@@ -226,13 +226,13 @@ fn upgrade_asset_inventory_should_reject_fully_upgraded_storage() {
 		.balances(&[(ALICE, alice_initial_balance)])
 		.build()
 		.execute_with(|| {
-			PlayerSeasonConfigs::<Test, Instance1>::mutate(ALICE, SEASON_ID_0, |config| {
+			PlayerSeasonConfigs::<Test, ()>::mutate(ALICE, SEASON_ID_0, |config| {
 				config.inventory_tier = InventoryTier::Max
 			});
 
 			assert_noop!(
 				Sage::upgrade_asset_inventory(RuntimeOrigin::signed(ALICE), None, None),
-				Error::<Test, Instance1>::MaxStorageTierReached
+				Error::<Test, ()>::MaxStorageTierReached
 			);
 		});
 }

--- a/sage/pallet/src/tests/mod.rs
+++ b/sage/pallet/src/tests/mod.rs
@@ -42,20 +42,13 @@ where
 	(0..n)
 		.map(|i| {
 			let asset_id = AssetId::random();
-			ASSET_SEASONS.with(|store| {
-				store.borrow_mut().insert(asset_id, season_id);
+			ASSET_SEASONS.with_borrow_mut(|store| {
+				store.insert(asset_id, season_id);
 			});
+			let asset_instance = Asset::create(asset_id, 0, 0, 0, [i; 32], 0, Level::One);
 
 			let asset_id = AssetIdOf::<Test, I>::from(asset_id.0);
-			let asset = AssetOf::<Test, I>::from(Asset {
-				collection_id: 0,
-				asset_type: 0,
-				asset_sub_type: 0,
-				dna: [i; 32],
-				minted_at: 0,
-				level: Level::One,
-				consumed: false,
-			});
+			let asset = AssetOf::<Test, I>::from(asset_instance);
 			Assets::<Test, I>::insert(&asset_id, (account, asset));
 			AssetOwners::<Test, I>::insert((account, &casted_season_id, &asset_id), ());
 			asset_id

--- a/sage/pallet/src/tests/pallet_impls/ensures.rs
+++ b/sage/pallet/src/tests/pallet_impls/ensures.rs
@@ -22,9 +22,9 @@ mod ensure_organizer {
 	#[test]
 	fn ensure_organizer_should_works() {
 		ExtBuilder::default().build().execute_with(|| {
-			assert_eq!(Organizer::<Test, Instance1>::get(), None);
+			assert_eq!(Organizer::<Test, ()>::get(), None);
 			assert_ok!(Sage::set_organizer(RuntimeOrigin::root(), DAVE));
-			assert_eq!(Organizer::<Test, Instance1>::get(), Some(DAVE));
+			assert_eq!(Organizer::<Test, ()>::get(), Some(DAVE));
 			assert_ok!(Sage::ensure_organizer(&DAVE));
 		});
 	}
@@ -32,8 +32,8 @@ mod ensure_organizer {
 	#[test]
 	fn ensure_organizer_should_reject_when_no_organizer_is_set() {
 		ExtBuilder::default().build().execute_with(|| {
-			assert_eq!(Organizer::<Test, Instance1>::get(), None);
-			assert_noop!(Sage::ensure_organizer(&DAVE), Error::<Test, Instance1>::OrganizerNotSet);
+			assert_eq!(Organizer::<Test, ()>::get(), None);
+			assert_noop!(Sage::ensure_organizer(&DAVE), Error::<Test, ()>::OrganizerNotSet);
 		});
 	}
 
@@ -58,7 +58,7 @@ mod ensure_ownership {
 	#[test]
 	fn ensure_ownership_works() {
 		ExtBuilder::default().build().execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 1);
 			let asset_id = asset_ids[0];
 			assert_ok!(Sage::ensure_ownership(&BOB, &asset_id));
 		});
@@ -67,11 +67,11 @@ mod ensure_ownership {
 	#[test]
 	fn ensure_ownership_should_reject_non_owned_asset() {
 		ExtBuilder::default().build().execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 1);
 			let asset_id = asset_ids[0];
 			assert_noop!(
 				Sage::ensure_ownership(&DAVE, &asset_id),
-				Error::<Test, Instance1>::AssetNotOwned
+				Error::<Test, ()>::AssetNotOwned
 			);
 		});
 	}
@@ -80,10 +80,7 @@ mod ensure_ownership {
 	fn ensure_ownership_should_reject_unknown_asset() {
 		ExtBuilder::default().build().execute_with(|| {
 			let asset_id = AssetId::random();
-			assert_noop!(
-				Sage::ensure_ownership(&DAVE, &asset_id),
-				Error::<Test, Instance1>::UnknownAsset
-			);
+			assert_noop!(Sage::ensure_ownership(&DAVE, &asset_id), Error::<Test, ()>::UnknownAsset);
 		});
 	}
 }
@@ -94,12 +91,12 @@ mod ensure_for_trade {
 	#[test]
 	fn ensure_for_trade_works() {
 		ExtBuilder::default().build().execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 1);
 			let asset_id = asset_ids[0];
-			let season_id = <Test as Config<Instance1>>::SeasonHandler::get_current_season_id()
+			let season_id = <Test as Config<()>>::SeasonHandler::get_current_season_id()
 				.expect("Should get season_id");
 
-			AssetTradePrices::<Test, Instance1>::insert(season_id, asset_id, 100);
+			AssetTradePrices::<Test, ()>::insert(season_id, asset_id, 100);
 			assert_ok!(Sage::ensure_for_trade(&asset_id));
 		});
 	}
@@ -108,20 +105,17 @@ mod ensure_for_trade {
 	fn ensure_for_trade_should_reject_unknown_asset() {
 		ExtBuilder::default().build().execute_with(|| {
 			let asset_id = AssetId::random();
-			assert_noop!(Sage::ensure_for_trade(&asset_id), Error::<Test, Instance1>::UnknownAsset);
+			assert_noop!(Sage::ensure_for_trade(&asset_id), Error::<Test, ()>::UnknownAsset);
 		});
 	}
 
 	#[test]
 	fn ensure_for_trade_should_reject_asset_not_in_trade() {
 		ExtBuilder::default().build().execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 1);
 			let asset_id = asset_ids[0];
 
-			assert_noop!(
-				Sage::ensure_for_trade(&asset_id),
-				Error::<Test, Instance1>::AssetNotInTrade
-			);
+			assert_noop!(Sage::ensure_for_trade(&asset_id), Error::<Test, ()>::AssetNotInTrade);
 		});
 	}
 }

--- a/sage/pallet/src/tests/pallet_impls/unlocks.rs
+++ b/sage/pallet/src/tests/pallet_impls/unlocks.rs
@@ -24,7 +24,7 @@ mod unlock_asset_trading_for {
 		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(
 				Sage::unlock_asset_trading_for(DAVE, UnlockTarget::OneselfFree, SEASON_ID_0),
-				Error::<Test, Instance1>::FeatureUnavailableInSeason
+				Error::<Test, ()>::FeatureUnavailableInSeason
 			);
 		});
 	}
@@ -33,13 +33,13 @@ mod unlock_asset_trading_for {
 	fn unlock_asset_trading_for_oneself_free_should_reject_if_criteria_not_fullfilled() {
 		ExtBuilder::default().build().execute_with(|| {
 			let unlock_rule = UnlockRule::from([2, 0, 3, 1, 1]);
-			SeasonUnlocks::<Test, Instance1>::insert(
+			SeasonUnlocks::<Test, ()>::insert(
 				SEASON_ID_0,
 				LockableFeature::TradeAsset,
 				unlock_rule,
 			);
 
-			let player_stats = PlayerSeasonStats::<Test, Instance1>::get(DAVE, SEASON_ID_0);
+			let player_stats = PlayerSeasonStats::<Test, ()>::get(DAVE, SEASON_ID_0);
 			// We don't fullfill the criteria
 			assert_eq!(player_stats.minted_amount, 0);
 			assert_eq!(player_stats.forged_amount, 0);
@@ -47,11 +47,11 @@ mod unlock_asset_trading_for {
 			assert_eq!(player_stats.sold_amount, 0);
 			assert_noop!(
 				Sage::unlock_asset_trading_for(DAVE, UnlockTarget::OneselfFree, SEASON_ID_0),
-				Error::<Test, Instance1>::UnlockCriteriaNotFulfilled
+				Error::<Test, ()>::UnlockCriteriaNotFulfilled
 			);
 
 			// Changed it to pass the criteria
-			PlayerSeasonStats::<Test, Instance1>::mutate(DAVE, SEASON_ID_0, |stats| {
+			PlayerSeasonStats::<Test, ()>::mutate(DAVE, SEASON_ID_0, |stats| {
 				stats.minted_amount = 2;
 				stats.forged_amount = 3;
 				stats.bought_amount = 1;
@@ -69,32 +69,32 @@ mod unlock_asset_trading_for {
 	fn unlock_asset_trading_through_payment_should_ignore_season_lock_on_feature() {
 		ExtBuilder::default().balances(&[(DAVE, 1_000)]).build().execute_with(|| {
 			assert_eq!(
-				SeasonUnlocks::<Test, Instance1>::get(SEASON_ID_0, LockableFeature::TradeAsset,),
+				SeasonUnlocks::<Test, ()>::get(SEASON_ID_0, LockableFeature::TradeAsset,),
 				None
 			);
 			assert_noop!(
 				Sage::unlock_asset_trading_for(DAVE, UnlockTarget::OneselfFree, SEASON_ID_0),
-				Error::<Test, Instance1>::FeatureUnavailableInSeason
+				Error::<Test, ()>::FeatureUnavailableInSeason
 			);
 
-			let player_config = PlayerSeasonConfigs::<Test, Instance1>::get(DAVE, SEASON_ID_0);
+			let player_config = PlayerSeasonConfigs::<Test, ()>::get(DAVE, SEASON_ID_0);
 			assert!(!player_config.locks.asset_trade);
 			assert_ok!(Sage::unlock_asset_trading_for(
 				DAVE,
 				UnlockTarget::OneselfPaying,
 				SEASON_ID_0
 			));
-			let player_config = PlayerSeasonConfigs::<Test, Instance1>::get(DAVE, SEASON_ID_0);
+			let player_config = PlayerSeasonConfigs::<Test, ()>::get(DAVE, SEASON_ID_0);
 			assert!(player_config.locks.asset_trade);
 
-			let player_config = PlayerSeasonConfigs::<Test, Instance1>::get(BOB, SEASON_ID_0);
+			let player_config = PlayerSeasonConfigs::<Test, ()>::get(BOB, SEASON_ID_0);
 			assert!(!player_config.locks.asset_trade);
 			assert_ok!(Sage::unlock_asset_trading_for(
 				DAVE,
 				UnlockTarget::OtherPaying(BOB),
 				SEASON_ID_0
 			));
-			let player_config = PlayerSeasonConfigs::<Test, Instance1>::get(BOB, SEASON_ID_0);
+			let player_config = PlayerSeasonConfigs::<Test, ()>::get(BOB, SEASON_ID_0);
 			assert!(player_config.locks.asset_trade);
 		});
 	}
@@ -108,7 +108,7 @@ mod unlock_asset_transfer_for {
 		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(
 				Sage::unlock_asset_transfer_for(DAVE, UnlockTarget::OneselfFree, SEASON_ID_0),
-				Error::<Test, Instance1>::FeatureUnavailableInSeason
+				Error::<Test, ()>::FeatureUnavailableInSeason
 			);
 		});
 	}
@@ -117,13 +117,13 @@ mod unlock_asset_transfer_for {
 	fn unlock_asset_transfer_for_oneself_free_should_reject_if_criteria_not_fullfilled() {
 		ExtBuilder::default().build().execute_with(|| {
 			let unlock_rule = UnlockRule::from([1, 0, 3, 4, 5]);
-			SeasonUnlocks::<Test, Instance1>::insert(
+			SeasonUnlocks::<Test, ()>::insert(
 				SEASON_ID_0,
 				LockableFeature::TradeAsset,
 				unlock_rule,
 			);
 
-			let player_stats = PlayerSeasonStats::<Test, Instance1>::get(DAVE, SEASON_ID_0);
+			let player_stats = PlayerSeasonStats::<Test, ()>::get(DAVE, SEASON_ID_0);
 			// We don't fullfill the criteria
 			assert_eq!(player_stats.minted_amount, 0);
 			assert_eq!(player_stats.forged_amount, 0);
@@ -131,11 +131,11 @@ mod unlock_asset_transfer_for {
 			assert_eq!(player_stats.sold_amount, 0);
 			assert_noop!(
 				Sage::unlock_asset_trading_for(DAVE, UnlockTarget::OneselfFree, SEASON_ID_0),
-				Error::<Test, Instance1>::UnlockCriteriaNotFulfilled
+				Error::<Test, ()>::UnlockCriteriaNotFulfilled
 			);
 
 			// Changed it to pass the criteria
-			PlayerSeasonStats::<Test, Instance1>::mutate(DAVE, SEASON_ID_0, |stats| {
+			PlayerSeasonStats::<Test, ()>::mutate(DAVE, SEASON_ID_0, |stats| {
 				stats.minted_amount = 1;
 				stats.forged_amount = 3;
 				stats.bought_amount = 4;
@@ -153,32 +153,32 @@ mod unlock_asset_transfer_for {
 	fn unlock_asset_transfer_through_payment_should_ignore_season_lock_on_feature() {
 		ExtBuilder::default().balances(&[(DAVE, 1_000)]).build().execute_with(|| {
 			assert_eq!(
-				SeasonUnlocks::<Test, Instance1>::get(SEASON_ID_0, LockableFeature::TradeAsset),
+				SeasonUnlocks::<Test, ()>::get(SEASON_ID_0, LockableFeature::TradeAsset),
 				None
 			);
 			assert_noop!(
 				Sage::unlock_asset_transfer_for(DAVE, UnlockTarget::OneselfFree, SEASON_ID_0),
-				Error::<Test, Instance1>::FeatureUnavailableInSeason
+				Error::<Test, ()>::FeatureUnavailableInSeason
 			);
 
-			let player_config = PlayerSeasonConfigs::<Test, Instance1>::get(DAVE, SEASON_ID_0);
+			let player_config = PlayerSeasonConfigs::<Test, ()>::get(DAVE, SEASON_ID_0);
 			assert!(!player_config.locks.asset_transfer);
 			assert_ok!(Sage::unlock_asset_transfer_for(
 				DAVE,
 				UnlockTarget::OneselfPaying,
 				SEASON_ID_0
 			));
-			let player_config = PlayerSeasonConfigs::<Test, Instance1>::get(DAVE, SEASON_ID_0);
+			let player_config = PlayerSeasonConfigs::<Test, ()>::get(DAVE, SEASON_ID_0);
 			assert!(player_config.locks.asset_transfer);
 
-			let player_config = PlayerSeasonConfigs::<Test, Instance1>::get(BOB, SEASON_ID_0);
+			let player_config = PlayerSeasonConfigs::<Test, ()>::get(BOB, SEASON_ID_0);
 			assert!(!player_config.locks.asset_transfer);
 			assert_ok!(Sage::unlock_asset_transfer_for(
 				DAVE,
 				UnlockTarget::OtherPaying(BOB),
 				SEASON_ID_0
 			));
-			let player_config = PlayerSeasonConfigs::<Test, Instance1>::get(BOB, SEASON_ID_0);
+			let player_config = PlayerSeasonConfigs::<Test, ()>::get(BOB, SEASON_ID_0);
 			assert!(player_config.locks.asset_transfer);
 		});
 	}

--- a/sage/pallet/src/tests/trait_impls/account_manager.rs
+++ b/sage/pallet/src/tests/trait_impls/account_manager.rs
@@ -24,7 +24,7 @@ mod is_organizer {
 		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(
 				<Sage as AccountManager>::is_organizer(&CHARLIE),
-				Error::<Test, Instance1>::OrganizerNotSet
+				Error::<Test, ()>::OrganizerNotSet
 			);
 
 			assert_ok!(Sage::set_organizer(RuntimeOrigin::root(), ALICE));

--- a/sage/pallet/src/tests/trait_impls/asset_manager.rs
+++ b/sage/pallet/src/tests/trait_impls/asset_manager.rs
@@ -32,7 +32,7 @@ mod lock_asset {
 			])
 			.build()
 			.execute_with(|| {
-				let asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 1);
+				let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 1);
 				let asset_id = asset_ids[0];
 				let expected_lock = Lock { id: *TEST_LOCK_ID, locker: ALICE };
 
@@ -46,17 +46,13 @@ mod lock_asset {
 				// Ensure ownership transferred to technical account
 				let technical_account = Sage::technical_account_id();
 
-				assert!(!AssetOwners::<Test, Instance1>::contains_key((
-					ALICE,
-					SEASON_ID_0,
-					asset_id
-				)));
-				assert!(!AssetOwners::<Test, Instance1>::contains_key((
+				assert!(!AssetOwners::<Test, ()>::contains_key((ALICE, SEASON_ID_0, asset_id)));
+				assert!(!AssetOwners::<Test, ()>::contains_key((
 					technical_account,
 					SEASON_ID_0,
 					asset_id
 				)));
-				assert_eq!(Assets::<Test, Instance1>::get(asset_id).unwrap().0, technical_account);
+				assert_eq!(Assets::<Test, ()>::get(asset_id).unwrap().0, technical_account);
 			});
 	}
 
@@ -66,11 +62,11 @@ mod lock_asset {
 			.balances(&[(ALICE, 1_000), (BOB, 1_000)])
 			.build()
 			.execute_with(|| {
-				let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 1);
+				let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 1);
 				let asset_id = asset_ids[0];
 				assert_noop!(
 					<Sage as AssetManager>::lock_asset(*TEST_LOCK_ID, ALICE, asset_id),
-					Error::<Test, Instance1>::AssetNotOwned
+					Error::<Test, ()>::AssetNotOwned
 				);
 			});
 	}
@@ -82,12 +78,12 @@ mod lock_asset {
 			.locks(&[(CHARLIE, SEASON_ID_0, Locks::all_unlocked())])
 			.build()
 			.execute_with(|| {
-				let asset_ids = create_assets::<Instance1>(SEASON_ID_0, CHARLIE, 1);
+				let asset_ids = create_assets::<()>(SEASON_ID_0, CHARLIE, 1);
 				let asset_id = asset_ids[0];
 				assert_ok!(Sage::set_asset_price(RuntimeOrigin::signed(CHARLIE), asset_id, 1_000));
 				assert_noop!(
 					<Sage as AssetManager>::lock_asset(*TEST_LOCK_ID, CHARLIE, asset_id),
-					Error::<Test, Instance1>::CannotLockAssetInTrade
+					Error::<Test, ()>::CannotLockAssetInTrade
 				);
 			});
 	}
@@ -95,7 +91,7 @@ mod lock_asset {
 	#[test]
 	fn cannot_lock_already_locked_asset() {
 		ExtBuilder::default().balances(&[(ALICE, 1_000)]).build().execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, DAVE, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, DAVE, 1);
 			let asset_id = asset_ids[0];
 			assert_ok!(<Sage as AssetManager>::lock_asset(*TEST_LOCK_ID, DAVE, asset_id));
 			assert_noop!(
@@ -104,7 +100,7 @@ mod lock_asset {
 					Sage::technical_account_id(),
 					asset_id
 				),
-				Error::<Test, Instance1>::AssetLocked
+				Error::<Test, ()>::AssetLocked
 			);
 		});
 	}
@@ -116,13 +112,13 @@ mod unlock_asset {
 	#[test]
 	fn can_unlock_asset_successfully() {
 		ExtBuilder::default().balances(&[(ALICE, 1_000)]).build().execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 1);
 			let asset_id = asset_ids[0];
 			let expected_lock = Lock { id: *TEST_LOCK_ID, locker: ALICE };
 
 			assert_ok!(<Sage as AssetManager>::lock_asset(*TEST_LOCK_ID, ALICE, asset_id));
 			assert_eq!(
-				LockedAssets::<Test, Instance1>::get(asset_id),
+				LockedAssets::<Test, ()>::get(asset_id),
 				Some(Lock { id: *TEST_LOCK_ID, locker: ALICE })
 			);
 			assert_ok!(<Sage as AssetManager>::unlock_asset(*TEST_LOCK_ID, ALICE, asset_id));
@@ -130,7 +126,7 @@ mod unlock_asset {
 				asset_id,
 				lock: expected_lock,
 			}));
-			assert_eq!(LockedAssets::<Test, Instance1>::get(asset_id), None);
+			assert_eq!(LockedAssets::<Test, ()>::get(asset_id), None);
 		});
 	}
 
@@ -140,12 +136,12 @@ mod unlock_asset {
 			.balances(&[(ALICE, 1_000), (BOB, 5_000)])
 			.build()
 			.execute_with(|| {
-				let asset_ids = create_assets::<Instance1>(SEASON_ID_0, BOB, 1);
+				let asset_ids = create_assets::<()>(SEASON_ID_0, BOB, 1);
 				let asset_id = asset_ids[0];
 				assert_ok!(<Sage as AssetManager>::lock_asset(*TEST_LOCK_ID, BOB, asset_id));
 				assert_noop!(
 					<Sage as AssetManager>::unlock_asset(*TEST_LOCK_ID, ALICE, asset_id),
-					Error::<Test, Instance1>::AssetNotOwned
+					Error::<Test, ()>::AssetNotOwned
 				);
 			});
 	}
@@ -153,7 +149,7 @@ mod unlock_asset {
 	#[test]
 	fn cannot_unlock_asset_locked_by_other_application() {
 		ExtBuilder::default().balances(&[(ALICE, 1_000)]).build().execute_with(|| {
-			let asset_ids = create_assets::<Instance1>(SEASON_ID_0, ALICE, 1);
+			let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 1);
 			let asset_id = asset_ids[0];
 
 			let other_lock_id = b"otherapp";
@@ -161,7 +157,7 @@ mod unlock_asset {
 
 			assert_noop!(
 				<Sage as AssetManager>::unlock_asset(*TEST_LOCK_ID, ALICE, asset_id),
-				Error::<Test, Instance1>::AssetLockedByOtherApplication
+				Error::<Test, ()>::AssetLockedByOtherApplication
 			);
 		});
 	}

--- a/sage/pallet/src/trait_impls/account_manager.rs
+++ b/sage/pallet/src/trait_impls/account_manager.rs
@@ -25,20 +25,7 @@ impl<T: Config<I>, I: 'static> AccountManager for Pallet<T, I> {
 		Ok(())
 	}
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_organizer(organizer: Self::AccountId) {
-		Organizer::<T, I>::put(organizer)
-	}
-
 	fn is_whitelisted_for(_identifier: &WhitelistKey, _account: &Self::AccountId) -> bool {
-		todo!()
-	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn try_set_whitelisted_for(
-		_identifier: &WhitelistKey,
-		_account: &Self::AccountId,
-	) -> Result<(), DispatchError> {
-		todo!()
+		unimplemented!()
 	}
 }

--- a/sage/pallet/src/trait_impls/asset_manager.rs
+++ b/sage/pallet/src/trait_impls/asset_manager.rs
@@ -92,12 +92,6 @@ impl<T: Config<I>, I: 'static> AssetManager for Pallet<T, I> {
 	) -> Result<(), DispatchError> {
 		todo!()
 	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn create_assets(_owner: Self::AccountId, _count: u32) -> Vec<(Self::AssetId, Self::Asset)> {
-		// TODO: Decide how to implement this
-		Vec::with_capacity(0)
-	}
 }
 
 impl<T: Config<I>, I: 'static> AssetInspector for Pallet<T, I> {

--- a/sage/pallet/src/weights.rs
+++ b/sage/pallet/src/weights.rs
@@ -49,14 +49,16 @@ pub trait WeightInfo {
 	fn update_general_config() -> Weight;
 	fn update_unlock_rule() -> Weight;
 	fn upgrade_asset_inventory() -> Weight;
-	fn update_asset_filter() -> Weight;
+	fn update_asset_trade_filter() -> Weight;
+	fn update_asset_transfer_filter() -> Weight;
 	fn transfer_asset() -> Weight;
 	fn set_asset_price() -> Weight;
 	fn remove_asset_price() -> Weight;
 	fn buy_asset() -> Weight;
 	fn lock_asset() -> Weight;
 	fn unlock_asset() -> Weight;
-	fn unlock_feature() -> Weight;
+	fn unlock_trade_asset_feature() -> Weight;
+	fn unlock_transfer_asset_feature() -> Weight;
     fn state_transition(n: u32, ) -> Weight;
 }
 
@@ -87,7 +89,13 @@ impl<T: frame_system::Config> WeightInfo for AjunaWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 
-	fn update_asset_filter() -> Weight {
+	fn update_asset_trade_filter() -> Weight {
+		// Minimum execution time: 26_582 nanoseconds.
+		Weight::from_parts(0, 0)
+			.saturating_add(T::DbWeight::get().writes(1))
+	}
+
+	fn update_asset_transfer_filter() -> Weight {
 		// Minimum execution time: 26_582 nanoseconds.
 		Weight::from_parts(0, 0)
 			.saturating_add(T::DbWeight::get().writes(1))
@@ -124,7 +132,12 @@ impl<T: frame_system::Config> WeightInfo for AjunaWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 
-	fn unlock_feature() -> Weight {
+	fn unlock_trade_asset_feature() -> Weight {
+		Weight::from_parts(0, 0)
+			.saturating_add(T::DbWeight::get().writes(1))
+	}
+
+	fn unlock_transfer_asset_feature() -> Weight {
 		Weight::from_parts(0, 0)
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -157,7 +170,13 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1))
 	}
 
-	fn update_asset_filter() -> Weight {
+	fn update_asset_trade_filter() -> Weight {
+		// Minimum execution time: 26_582 nanoseconds.
+		Weight::from_parts(0, 0)
+			.saturating_add(RocksDbWeight::get().writes(1))
+	}
+
+	fn update_asset_transfer_filter() -> Weight {
 		// Minimum execution time: 26_582 nanoseconds.
 		Weight::from_parts(0, 0)
 			.saturating_add(RocksDbWeight::get().writes(1))
@@ -193,7 +212,12 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1))
 	}
 
-	fn unlock_feature() -> Weight {
+	fn unlock_trade_asset_feature() -> Weight {
+		Weight::from_parts(0, 0)
+			.saturating_add(RocksDbWeight::get().writes(1))
+	}
+
+	fn unlock_transfer_asset_feature() -> Weight {
 		Weight::from_parts(0, 0)
 			.saturating_add(RocksDbWeight::get().writes(1))
 	}


### PR DESCRIPTION
## Description

This PR refactors and refines some of the code associated with the SAGE pallet and its API surface traits. The changes are the following:

* Added the `Identifiable` trait which is required for `Asset` types to implement, used to generate `AssetId`
* Move `TransitionConfig` to `SageGameTransition` trait
* Add missing benchmarks to `pallet-sage-core`
* Remove all methods in `ajuna-primitives` traits that required `runtime-benchmarks`

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
