### PR TITLE
add CI check to test if a crate compiles to wasm

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -104,3 +104,24 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  check-wasm:
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    name: Check wasm build
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./.github/scripts/free_disk_space.sh
+      - run: sudo apt-get install -y protobuf-compiler
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-lint-
+      - run: ./scripts/run_for_all_crates.sh check --no-default-features --features runtime-benchmark --target=wasm32-unknown-unknown

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -124,4 +124,4 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-lint-
-      - run: ./scripts/run_for_all_crates.sh check --no-default-features --features runtime-benchmark --target=wasm32-unknown-unknown
+      - run: ./scripts/run_for_all_crates.sh check --no-default-features --target=wasm32-unknown-unknown

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -124,4 +124,4 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-lint-
-      - run: ./scripts/run_for_all_crates.sh check --no-default-features --target=wasm32-unknown-unknown
+      - run: ./scripts/run_for_all_no_std_crates.sh check --no-default-features --target=wasm32-unknown-unknown

--- a/pallets/ajuna-affiliates/src/benchmarking.rs
+++ b/pallets/ajuna-affiliates/src/benchmarking.rs
@@ -53,7 +53,7 @@ fn assert_last_event<T: Config<I>, I: 'static>(avatars_event: Event<T, I>) {
 
 // Todo: these functions should exist with runtime-benchmarks enabled.
 fn setup_organizer<T: Config<I>, I: 'static>(organizer: T::AccountId) {
-	T::AccountManager::try_add_to_whitelist(&T::WhitelistKey::get(), &organizer)
+	T::AccountManager::try_add_to_whitelist(&T::WhitelistKey::get(), organizer.clone())
 		.expect("Should add to whitelist");
 	T::AccountManager::set_organizer(organizer);
 }

--- a/pallets/ajuna-affiliates/src/benchmarking.rs
+++ b/pallets/ajuna-affiliates/src/benchmarking.rs
@@ -14,33 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg(feature = "runtime-benchmarks")]
-#![cfg_attr(not(feature = "std"), no_std)]
-
-use crate::{
-	mock::{
-		AffiliateBenchmarkHelper, AffiliateMaxLevel, AffiliateWhitelistKey, Balances,
-		MockAccountManager, MockAffiliateRules, MockRuleId, MockUnlockParameter, RuntimeEvent,
-		System, Test,
-	},
-	Pallet as Affiliates, *,
-};
+use crate::{Pallet as Affiliates, *};
 use frame_benchmarking::benchmarks_instance_pallet;
 use frame_system::RawOrigin;
-use sp_runtime::BuildStorage;
-
-impl Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
-	type WhitelistKey = AffiliateWhitelistKey;
-	type AccountManager = MockAccountManager;
-	type RuleIdentifier = MockRuleId;
-	type AffiliateMaxLevel = AffiliateMaxLevel;
-	type UnlockParameters = MockUnlockParameter;
-	type AffiliatesUnlockRules = MockAffiliateRules;
-	type WeightInfo = ();
-	type BenchmarkHelper = AffiliateBenchmarkHelper;
-}
+use sp_std::prelude::*;
 
 const ACC_1: &str = "acc_1";
 const ACC_2: &str = "acc_2";
@@ -74,6 +51,13 @@ fn assert_last_event<T: Config<I>, I: 'static>(avatars_event: Event<T, I>) {
 	frame_system::Pallet::<T>::assert_last_event(event.into());
 }
 
+// Todo: these functions should exist with runtime-benchmarks enabled.
+fn setup_organizer<T: Config<I>, I: 'static>(organizer: T::AccountId) {
+	T::AccountManager::try_add_to_whitelist(&T::WhitelistKey::get(), &organizer)
+		.expect("Should add to whitelist");
+	T::AccountManager::set_organizer(organizer);
+}
+
 benchmarks_instance_pallet! {
 	enable_affiliator {
 		let acc_1 = account::<T, I>(ACC_1);
@@ -88,6 +72,7 @@ benchmarks_instance_pallet! {
 		let acc_1 = account::<T, I>(ACC_1);
 		let acc_2 = account::<T, I>(ACC_2);
 		let acc_3 = account::<T, I>(ACC_3);
+		setup_organizer::<T, I>(acc_1.clone());
 		mark_as_affiliatable::<T, I>(&acc_3);
 	}: _(RawOrigin::Signed(acc_1.clone()), Some(acc_2.clone()), 0)
 	verify {
@@ -96,6 +81,7 @@ benchmarks_instance_pallet! {
 
 	remove_affiliation {
 		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
 		mark_as_affiliatable::<T, I>(&acc_1);
 		let acc_2 = account::<T, I>(ACC_2);
 		mark_as_affiliatable::<T, I>(&acc_2);
@@ -116,6 +102,7 @@ benchmarks_instance_pallet! {
 
 	set_rule_for {
 		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
 		let rule_id = T::BenchmarkHelper::create_rule_id(1);
 		let rule = FeePropagationOf::<T,I>::try_from(vec![60, 20]).expect("Should create fee propagation");
 	}: _(RawOrigin::Signed(acc_1.clone()), rule_id.clone(), rule)
@@ -125,6 +112,7 @@ benchmarks_instance_pallet! {
 
 	clear_rule_for {
 		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
 		let rule_id = T::BenchmarkHelper::create_rule_id(1);
 		let rule = FeePropagationOf::<T,I>::try_from(vec![70, 15]).expect("Should create fee propagation");
 		<Affiliates<T, I> as RuleMutator<RuleIdentifierFor<T, I>, T::AffiliateMaxLevel>>::try_add_rule_for(
@@ -136,21 +124,8 @@ benchmarks_instance_pallet! {
 	}
 
 	impl_benchmark_test_suite!(
-		Affiliates,
-		new_test_ext(),
-		Test
+		Pallet,
+		crate::mock::new_test_ext(),
+		crate::mock::Test
 	);
-}
-
-pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	let mut ext = sp_io::TestExternalities::new(t);
-	ext.execute_with(|| System::set_block_number(1));
-	ext.execute_with(|| {
-		let acc_1 = account::<Test, ()>(ACC_1);
-		MockAccountManager::set_organizer(acc_1);
-		MockAccountManager::try_add_to_whitelist(&AffiliateWhitelistKey::get(), &acc_1)
-			.expect("Should add to whitelist");
-	});
-	ext
 }

--- a/pallets/ajuna-affiliates/src/benchmarking.rs
+++ b/pallets/ajuna-affiliates/src/benchmarking.rs
@@ -51,7 +51,6 @@ fn assert_last_event<T: Config<I>, I: 'static>(avatars_event: Event<T, I>) {
 	frame_system::Pallet::<T>::assert_last_event(event.into());
 }
 
-// Todo: these functions should exist with runtime-benchmarks enabled.
 fn setup_organizer<T: Config<I>, I: 'static>(organizer: T::AccountId) {
 	T::AccountManager::try_add_to_whitelist(&T::WhitelistKey::get(), organizer.clone())
 		.expect("Should add to whitelist");

--- a/pallets/ajuna-affiliates/src/lib.rs
+++ b/pallets/ajuna-affiliates/src/lib.rs
@@ -18,7 +18,7 @@
 
 pub use pallet::*;
 
-#[cfg(any(test))]
+#[cfg(test)]
 mod mock;
 
 #[cfg(test)]

--- a/pallets/ajuna-affiliates/src/lib.rs
+++ b/pallets/ajuna-affiliates/src/lib.rs
@@ -18,7 +18,7 @@
 
 pub use pallet::*;
 
-#[cfg(any(test, feature = "runtime-benchmarks"))]
+#[cfg(any(test))]
 mod mock;
 
 #[cfg(test)]

--- a/pallets/ajuna-affiliates/src/mock.rs
+++ b/pallets/ajuna-affiliates/src/mock.rs
@@ -142,12 +142,14 @@ impl AccountManager for MockAccountManager {
 		})
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
 	fn set_organizer(owner: MockAccountId) {
 		ORGANIZER.with(|maybe_account| {
 			*maybe_account.borrow_mut() = Some(owner);
 		});
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
 	fn try_add_to_whitelist(
 		identifier: &WhitelistKey,
 		account: MockAccountId,

--- a/pallets/ajuna-affiliates/src/mock.rs
+++ b/pallets/ajuna-affiliates/src/mock.rs
@@ -118,6 +118,14 @@ pub struct MockAccountManager;
 pub const ACCOUNT_IS_NOT_ORGANIZER: &str = "ACCOUNT_IS_NOT_ORGANIZER";
 pub const NO_ORGANIZER_SET: &str = "NO_ORGANIZER_SET";
 
+impl MockAccountManager {
+	pub fn set_organizer(owner: MockAccountId) {
+		ORGANIZER.with(|maybe_account| {
+			*maybe_account.borrow_mut() = Some(owner);
+		});
+	}
+}
+
 impl AccountManager for MockAccountManager {
 	type AccountId = MockAccountId;
 
@@ -143,16 +151,14 @@ impl AccountManager for MockAccountManager {
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn set_organizer(owner: MockAccountId) {
-		ORGANIZER.with(|maybe_account| {
-			*maybe_account.borrow_mut() = Some(owner);
-		});
+	fn set_organizer(owner: Self::AccountId) {
+		MockAccountManager::set_organizer(owner);
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn try_add_to_whitelist(
 		identifier: &WhitelistKey,
-		account: MockAccountId,
+		account: Self::AccountId,
 	) -> Result<(), DispatchError> {
 		WHITELISTED_ACCOUNTS.with(|accounts| {
 			if let Some(entry) = accounts.borrow_mut().get_mut(identifier) {

--- a/pallets/ajuna-affiliates/src/mock.rs
+++ b/pallets/ajuna-affiliates/src/mock.rs
@@ -124,6 +124,20 @@ impl MockAccountManager {
 			*maybe_account.borrow_mut() = Some(owner);
 		});
 	}
+
+	pub fn try_add_to_whitelist(
+		identifier: &WhitelistKey,
+		account: MockAccountId,
+	) -> Result<(), DispatchError> {
+		WHITELISTED_ACCOUNTS.with(|accounts| {
+			if let Some(entry) = accounts.borrow_mut().get_mut(identifier) {
+				entry.insert(account);
+				Ok(())
+			} else {
+				Err(DispatchError::Other("No account set for identifier"))
+			}
+		})
+	}
 }
 
 impl AccountManager for MockAccountManager {
@@ -160,14 +174,7 @@ impl AccountManager for MockAccountManager {
 		identifier: &WhitelistKey,
 		account: Self::AccountId,
 	) -> Result<(), DispatchError> {
-		WHITELISTED_ACCOUNTS.with(|accounts| {
-			if let Some(entry) = accounts.borrow_mut().get_mut(identifier) {
-				entry.insert(account);
-				Ok(())
-			} else {
-				Err(DispatchError::Other("No account set for identifier"))
-			}
-		})
+		MockAccountManager::try_add_to_whitelist(identifier, account)
 	}
 }
 

--- a/pallets/ajuna-affiliates/src/mock.rs
+++ b/pallets/ajuna-affiliates/src/mock.rs
@@ -20,12 +20,10 @@ use frame_support::{
 	ensure, parameter_types,
 	traits::{ConstU16, ConstU64},
 };
-#[cfg(test)]
-use sp_runtime::BuildStorage;
 use sp_runtime::{
 	testing::{TestSignature, H256},
 	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
-	DispatchError,
+	BuildStorage, DispatchError,
 };
 use sp_std::{
 	cell::RefCell,
@@ -120,28 +118,6 @@ pub struct MockAccountManager;
 pub const ACCOUNT_IS_NOT_ORGANIZER: &str = "ACCOUNT_IS_NOT_ORGANIZER";
 pub const NO_ORGANIZER_SET: &str = "NO_ORGANIZER_SET";
 
-impl MockAccountManager {
-	pub(crate) fn try_add_to_whitelist(
-		identifier: &WhitelistKey,
-		account: &MockAccountId,
-	) -> Result<(), DispatchError> {
-		WHITELISTED_ACCOUNTS.with(|accounts| {
-			if let Some(entry) = accounts.borrow_mut().get_mut(identifier) {
-				entry.insert(*account);
-				Ok(())
-			} else {
-				Err(DispatchError::Other("No account set for identifier"))
-			}
-		})
-	}
-
-	pub(crate) fn set_organizer(owner: MockAccountId) {
-		ORGANIZER.with(|maybe_account| {
-			*maybe_account.borrow_mut() = Some(owner);
-		});
-	}
-}
-
 impl AccountManager for MockAccountManager {
 	type AccountId = MockAccountId;
 
@@ -162,6 +138,26 @@ impl AccountManager for MockAccountManager {
 				entry.contains(account)
 			} else {
 				false
+			}
+		})
+	}
+
+	fn set_organizer(owner: MockAccountId) {
+		ORGANIZER.with(|maybe_account| {
+			*maybe_account.borrow_mut() = Some(owner);
+		});
+	}
+
+	fn try_add_to_whitelist(
+		identifier: &WhitelistKey,
+		account: MockAccountId,
+	) -> Result<(), DispatchError> {
+		WHITELISTED_ACCOUNTS.with(|accounts| {
+			if let Some(entry) = accounts.borrow_mut().get_mut(identifier) {
+				entry.insert(account);
+				Ok(())
+			} else {
+				Err(DispatchError::Other("No account set for identifier"))
 			}
 		})
 	}
@@ -232,7 +228,20 @@ impl pallet_ajuna_affiliates::Config<AffiliatesInstance2> for Test {
 	type BenchmarkHelper = AffiliateBenchmarkHelper;
 }
 
-#[cfg(test)]
+#[cfg(feature = "runtime-benchmarks")]
+impl Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type WhitelistKey = AffiliateWhitelistKey;
+	type AccountManager = MockAccountManager;
+	type RuleIdentifier = MockRuleId;
+	type AffiliateMaxLevel = AffiliateMaxLevel;
+	type UnlockParameters = MockUnlockParameter;
+	type AffiliatesUnlockRules = MockAffiliateRules;
+	type WeightInfo = ();
+	type BenchmarkHelper = AffiliateBenchmarkHelper;
+}
+
 #[derive(Default)]
 pub struct ExtBuilder {
 	balances: Vec<(MockAccountId, MockBalance)>,
@@ -240,7 +249,10 @@ pub struct ExtBuilder {
 	affiliators: Vec<MockAccountId>,
 }
 
-#[cfg(test)]
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	ExtBuilder::default().build()
+}
+
 impl ExtBuilder {
 	pub fn balances(mut self, balances: &[(MockAccountId, MockBalance)]) -> Self {
 		self.balances = balances.to_vec();

--- a/pallets/ajuna-affiliates/src/tests.rs
+++ b/pallets/ajuna-affiliates/src/tests.rs
@@ -49,7 +49,7 @@ mod extrinsic {
 			.affiliators(&[ALICE])
 			.build()
 			.execute_with(|| {
-				MockAccountManager::try_add_to_whitelist(&AffiliateWhitelistKey::get(), &CHARLIE)
+				MockAccountManager::try_add_to_whitelist(&AffiliateWhitelistKey::get(), CHARLIE)
 					.expect("Should be whitelisted");
 
 				assert_ok!(AffiliatesAlpha::add_affiliation(

--- a/pallets/ajuna-awesome-avatars/src/impls/account_manager.rs
+++ b/pallets/ajuna-awesome-avatars/src/impls/account_manager.rs
@@ -29,4 +29,15 @@ impl<T: Config> AccountManager for Pallet<T> {
 	fn is_whitelisted_for(_identifier: &WhitelistKey, account: &Self::AccountId) -> bool {
 		WhitelistedAccounts::<T>::get().contains(account)
 	}
+
+	fn set_organizer(_account: Self::AccountId) {
+		todo!()
+	}
+
+	fn try_add_to_whitelist(
+		_identifier: &WhitelistKey,
+		_account: Self::AccountId,
+	) -> Result<(), DispatchError> {
+		todo!()
+	}
 }

--- a/pallets/ajuna-awesome-avatars/src/impls/account_manager.rs
+++ b/pallets/ajuna-awesome-avatars/src/impls/account_manager.rs
@@ -25,21 +25,21 @@ impl<T: Config> AccountManager for Pallet<T> {
 		Ok(())
 	}
 
-	// TODO: For now we ignore the 'identifier' parameter in the AAA implementation
 	fn is_whitelisted_for(_identifier: &WhitelistKey, account: &Self::AccountId) -> bool {
 		WhitelistedAccounts::<T>::get().contains(account)
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn set_organizer(_account: Self::AccountId) {
-		todo!()
+	fn set_organizer(account: Self::AccountId) {
+		Organizer::<T>::put(&account)
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn try_add_to_whitelist(
 		_identifier: &WhitelistKey,
-		_account: Self::AccountId,
+		account: Self::AccountId,
 	) -> Result<(), DispatchError> {
-		todo!()
+		WhitelistedAccounts::<T>::try_mutate(|accounts| accounts.try_push(account))
+			.map_err(|_| Error::<T>::WhitelistedAccountsLimitReached.into())
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/impls/account_manager.rs
+++ b/pallets/ajuna-awesome-avatars/src/impls/account_manager.rs
@@ -30,10 +30,12 @@ impl<T: Config> AccountManager for Pallet<T> {
 		WhitelistedAccounts::<T>::get().contains(account)
 	}
 
+	#[cfg(features = "runtime-benchmarks")]
 	fn set_organizer(_account: Self::AccountId) {
 		todo!()
 	}
 
+	#[cfg(features = "runtime-benchmarks")]
 	fn try_add_to_whitelist(
 		_identifier: &WhitelistKey,
 		_account: Self::AccountId,

--- a/pallets/ajuna-awesome-avatars/src/impls/account_manager.rs
+++ b/pallets/ajuna-awesome-avatars/src/impls/account_manager.rs
@@ -30,12 +30,12 @@ impl<T: Config> AccountManager for Pallet<T> {
 		WhitelistedAccounts::<T>::get().contains(account)
 	}
 
-	#[cfg(features = "runtime-benchmarks")]
+	#[cfg(feature = "runtime-benchmarks")]
 	fn set_organizer(_account: Self::AccountId) {
 		todo!()
 	}
 
-	#[cfg(features = "runtime-benchmarks")]
+	#[cfg(feature = "runtime-benchmarks")]
 	fn try_add_to_whitelist(
 		_identifier: &WhitelistKey,
 		_account: Self::AccountId,

--- a/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
+++ b/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
@@ -33,10 +33,10 @@ use pallet_ajuna_nft_staking::{
 };
 use pallet_nfts::{BenchmarkHelper, ItemConfig};
 use sp_runtime::{
-	bounded_vec,
 	traits::{One, UniqueSaturatedFrom, UniqueSaturatedInto},
 	DispatchError,
 };
+use sp_std::{vec, vec::Vec};
 
 // Creator's collections.
 const CONTRACT_COLLECTION: u16 = 0;
@@ -305,7 +305,8 @@ benchmarks! {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
 		let creator = create_creator::<T>(None)?;
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Tokens(123_u64.unique_saturated_into())];
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+			.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 	}: create(RawOrigin::Signed(creator), contract_id, contract, None, None)
@@ -317,10 +318,10 @@ benchmarks! {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
 		let reward_nft_item = 123_u16;
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Nft(NftId(
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))];
+		))]).expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 		let creator = create_creator::<T>(Some(vec![reward_nft_item]))?;
@@ -332,7 +333,8 @@ benchmarks! {
 	remove_token_reward {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Tokens(123_u64.unique_saturated_into())];
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+			.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 		let creator = create_creator::<T>(None)?;
@@ -346,10 +348,10 @@ benchmarks! {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
 		let reward_nft_item = 2_u16;
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Nft(NftId(
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))];
+		))]).expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 		let creator = create_creator::<T>(Some(vec![reward_nft_item]))?;
@@ -362,7 +364,8 @@ benchmarks! {
 	accept_token_reward {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Tokens(123_u64.unique_saturated_into())];
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+			.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
@@ -381,10 +384,10 @@ benchmarks! {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
 		let reward_nft_item = 2_u16;
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Nft(
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(
 			NftId(REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))];
+		))]).expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
@@ -402,7 +405,8 @@ benchmarks! {
 	cancel_token_reward {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Tokens(123_u64.unique_saturated_into())];
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+			.expect("Should create rewards");
 		let mut contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		contract.stake_duration = 100_u32.unique_saturated_into();
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
@@ -422,10 +426,10 @@ benchmarks! {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
 		let reward_nft_item = 2_u16;
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Nft(NftId(
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))];
+		))]).expect("Should create rewards");
 		let mut contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		contract.stake_duration = 100_u32.unique_saturated_into();
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
@@ -444,7 +448,8 @@ benchmarks! {
 	claim_token_reward {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Tokens(123_u64.unique_saturated_into())];
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+			.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards.clone(), Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
@@ -463,10 +468,10 @@ benchmarks! {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
 		let reward_nft_item = 2_u16;
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Nft(NftId(
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))];
+		))]).expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards.clone(), Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
@@ -484,7 +489,8 @@ benchmarks! {
 	snipe_token_reward {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Tokens(123_u64.unique_saturated_into())];
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+			.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards.clone(), Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
@@ -517,18 +523,18 @@ benchmarks! {
 		let m in 0..T::MaxStakingClauses::get();
 		let n in 0..T::MaxFeeClauses::get();
 		let reward_nft_item = 2_u16;
-		let rewards: BoundedRewardsOf<T> = bounded_vec![Reward::Nft(NftId(
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))];
+		))]).expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards.clone(), Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
 		let sniper_reward_nft_item = 123_u16;
-		let sniper_rewards = bounded_vec![Reward::Nft(NftId(
+		let sniper_rewards = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(sniper_reward_nft_item),
-		))];
+		))]).expect("Should create rewards");
 		let mut sniper_contract = contract_with::<T>(m, n, sniper_rewards, Mode::Sniper);
 		sniper_contract.stake_duration = 100_u32.unique_saturated_into();
 		let sniper_contract_id = T::BenchmarkHelper::item_id(1_u16);

--- a/pallets/ajuna-nft-transfer/src/benchmarking.rs
+++ b/pallets/ajuna-nft-transfer/src/benchmarking.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg(feature = "runtime-benchmarks")]
-
 use crate::{traits::IpfsUrl, *};
 use ajuna_primitives::account_manager::AccountManager;
 use frame_benchmarking::benchmarks;

--- a/pallets/ajuna-nft-transfer/src/benchmarking.rs
+++ b/pallets/ajuna-nft-transfer/src/benchmarking.rs
@@ -15,30 +15,16 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg(feature = "runtime-benchmarks")]
-#![cfg_attr(not(feature = "std"), no_std)]
 
-use crate::{
-	mock::{MockAccountManager, System, Test},
-	traits::IpfsUrl,
-	*,
-};
+use crate::{traits::IpfsUrl, *};
+use ajuna_primitives::account_manager::AccountManager;
 use frame_benchmarking::benchmarks;
-use frame_support::{pallet_prelude::DispatchError, traits::Currency};
+use frame_support::pallet_prelude::DispatchError;
 use frame_system::RawOrigin;
-use sp_runtime::{BuildStorage, SaturatedConversion};
+use sp_runtime::SaturatedConversion;
 
-type CurrencyOf<T> = <T as pallet_nfts::Config>::Currency;
 type CollectionIdOf<T> = <T as crate::Config>::CollectionId;
 type ItemIdOf<T> = <T as crate::Config>::ItemId;
-
-pub struct Pallet<T: Config>(crate::Pallet<T>);
-
-// Todo: If we can't get rid of the pallet-nfts constraint here
-// we can just as well make the pallet-ajuna-nft-transfer depend
-// on it.
-pub trait Config: pallet_nfts::Config + crate::Config {}
-
-impl Config for Test {}
 
 fn account<T: Config>(name: &'static str) -> T::AccountId {
 	let index = 0;
@@ -64,7 +50,7 @@ fn create_service_account_and_prepare_avatar<T: Config>(
 
 fn enable_fee_payment<T: Config>(player: &T::AccountId) {
 	let prepare_fee = 100_000_000_000_000u128;
-	CurrencyOf::<T>::make_free_balance_be(player, prepare_fee.saturated_into());
+	T::BenchmarkHelper::set_account_balance(player, prepare_fee.saturated_into());
 }
 
 fn assert_last_event<T: Config>(avatars_event: Event<T>) {
@@ -76,6 +62,7 @@ benchmarks! {
 	set_collection_id {
 		let organizer = account::<T>("organizer");
 		let collection_id = CollectionIdOf::<T>::from(u32::MAX);
+		T::AccountManager::set_organizer(organizer.clone());
 	}: _(RawOrigin::Signed(organizer), collection_id)
 	verify {
 		assert_last_event::<T>(Event::CollectionIdSet { collection_id })
@@ -122,19 +109,7 @@ benchmarks! {
 
 	impl_benchmark_test_suite!(
 		Pallet,
-		crate::benchmarking::new_test_ext(),
+		crate::mock::new_test_ext(),
 		crate::mock::Test
 	);
-}
-
-pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	let mut ext = sp_io::TestExternalities::new(t);
-	ext.execute_with(|| System::set_block_number(1));
-	ext.execute_with(|| {
-		let organizer = account::<Test>("organizer");
-		MockAccountManager::set_organizer(organizer);
-	});
-
-	ext
 }

--- a/pallets/ajuna-nft-transfer/src/benchmarking.rs
+++ b/pallets/ajuna-nft-transfer/src/benchmarking.rs
@@ -17,10 +17,11 @@
 use crate::{traits::IpfsUrl, *};
 use ajuna_primitives::account_manager::AccountManager;
 use frame_benchmarking::benchmarks;
-use frame_support::pallet_prelude::DispatchError;
+use frame_support::{pallet_prelude::DispatchError, traits::Currency};
 use frame_system::RawOrigin;
 use sp_runtime::SaturatedConversion;
 
+type CurrencyOf<T> = <T as pallet_nfts::Config>::Currency;
 type CollectionIdOf<T> = <T as crate::Config>::CollectionId;
 type ItemIdOf<T> = <T as crate::Config>::ItemId;
 
@@ -36,7 +37,7 @@ fn create_service_account<T: Config>() -> T::AccountId {
 	service_account
 }
 
-fn create_service_account_and_prepare_avatar<T: Config>(
+fn create_service_account_and_prepare_avatar<T: Config + pallet_nfts::Config>(
 	player: T::AccountId,
 	asset_id: ItemIdOf<T>,
 ) -> Result<T::AccountId, DispatchError> {
@@ -46,9 +47,9 @@ fn create_service_account_and_prepare_avatar<T: Config>(
 	Ok(service_account)
 }
 
-fn enable_fee_payment<T: Config>(player: &T::AccountId) {
+fn enable_fee_payment<T: Config + pallet_nfts::Config>(player: &T::AccountId) {
 	let prepare_fee = 100_000_000_000_000u128;
-	T::BenchmarkHelper::set_account_balance(player, prepare_fee.saturated_into());
+	CurrencyOf::<T>::make_free_balance_be(player, prepare_fee.saturated_into());
 }
 
 fn assert_last_event<T: Config>(avatars_event: Event<T>) {
@@ -57,6 +58,8 @@ fn assert_last_event<T: Config>(avatars_event: Event<T>) {
 }
 
 benchmarks! {
+	where_clause { where T: pallet_nfts::Config }
+
 	set_collection_id {
 		let organizer = account::<T>("organizer");
 		let collection_id = CollectionIdOf::<T>::from(u32::MAX);

--- a/pallets/ajuna-nft-transfer/src/lib.rs
+++ b/pallets/ajuna-nft-transfer/src/lib.rs
@@ -18,7 +18,7 @@
 
 pub use pallet::*;
 
-#[cfg(any(test, feature = "runtime-benchmarks"))]
+#[cfg(test)]
 mod mock;
 
 #[cfg(test)]
@@ -60,6 +60,8 @@ pub mod pallet {
 	#[cfg(feature = "runtime-benchmarks")]
 	pub trait BenchmarkHelper<AccountId, ItemId> {
 		fn create_items(owner: AccountId, count: u32) -> sp_std::vec::Vec<ItemId>;
+
+		fn set_account_balance(account: &AccountId, balance: u32);
 	}
 
 	#[pallet::pallet]

--- a/pallets/ajuna-nft-transfer/src/lib.rs
+++ b/pallets/ajuna-nft-transfer/src/lib.rs
@@ -60,8 +60,6 @@ pub mod pallet {
 	#[cfg(feature = "runtime-benchmarks")]
 	pub trait BenchmarkHelper<AccountId, ItemId> {
 		fn create_items(owner: AccountId, count: u32) -> sp_std::vec::Vec<ItemId>;
-
-		fn set_account_balance(account: &AccountId, balance: u32);
 	}
 
 	#[pallet::pallet]

--- a/pallets/ajuna-nft-transfer/src/mock.rs
+++ b/pallets/ajuna-nft-transfer/src/mock.rs
@@ -430,6 +430,12 @@ impl AssetManager for MockAssetManager {
 /// Hence, we implement our own little account manager here.
 pub struct MockAccountManager;
 
+impl MockAccountManager {
+	pub fn set_organizer(account: Self::AccountId) {
+		ORGANIZER.with_borrow_mut(|maybe_organizer| *maybe_organizer = Some(account))
+	}
+}
+
 pub const ACCOUNT_IS_NOT_ORGANIZER: &str = "ACCOUNT_IS_NOT_ORGANIZER";
 pub const NO_ORGANIZER_SET: &str = "NO_ORGANIZER_SET";
 
@@ -453,7 +459,7 @@ impl ajuna_primitives::account_manager::AccountManager for MockAccountManager {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_organizer(account: Self::AccountId) {
-		ORGANIZER.with_borrow_mut(|maybe_organizer| *maybe_organizer = Some(account))
+		MockAccountManager::set_organizer(account);
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/pallets/ajuna-nft-transfer/src/mock.rs
+++ b/pallets/ajuna-nft-transfer/src/mock.rs
@@ -451,10 +451,12 @@ impl ajuna_primitives::account_manager::AccountManager for MockAccountManager {
 		unimplemented!()
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
 	fn set_organizer(account: Self::AccountId) {
 		ORGANIZER.with_borrow_mut(|maybe_organizer| *maybe_organizer = Some(account))
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
 	fn try_add_to_whitelist(
 		_identifier: &WhitelistKey,
 		_account: Self::AccountId,

--- a/pallets/ajuna-nft-transfer/src/mock.rs
+++ b/pallets/ajuna-nft-transfer/src/mock.rs
@@ -215,11 +215,6 @@ impl crate::BenchmarkHelper<MockAccountId, ItemId> for NftTransferBenchmarkHelpe
 	fn create_items(owner: MockAccountId, count: u32) -> Vec<ItemId> {
 		MockAssetManager::create_items(owner, count)
 	}
-
-	fn set_account_balance(account: &MockAccountId, balance: u32) {
-		Balances::force_set_balance(RuntimeOrigin::root(), *account, balance as u64)
-			.expect("Should set balance");
-	}
 }
 
 impl pallet_ajuna_nft_transfer::Config for Test {

--- a/pallets/ajuna-nft-transfer/src/mock.rs
+++ b/pallets/ajuna-nft-transfer/src/mock.rs
@@ -431,7 +431,7 @@ impl AssetManager for MockAssetManager {
 pub struct MockAccountManager;
 
 impl MockAccountManager {
-	pub fn set_organizer(account: Self::AccountId) {
+	pub fn set_organizer(account: MockAccountId) {
 		ORGANIZER.with_borrow_mut(|maybe_organizer| *maybe_organizer = Some(account))
 	}
 }

--- a/pallets/ajuna-nft-transfer/src/mock.rs
+++ b/pallets/ajuna-nft-transfer/src/mock.rs
@@ -34,12 +34,11 @@ use pallet_nfts::{PalletFeature, PalletFeatures};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::{
-	bounded_vec,
 	testing::{TestSignature, H256},
 	traits::{BlakeTwo256, Get, IdentifyAccount, IdentityLookup, Verify},
-	DispatchError,
+	DispatchError, RuntimeAppPublic,
 };
-use sp_std::{cell::RefCell, collections::btree_map::BTreeMap};
+use sp_std::{cell::RefCell, collections::btree_map::BTreeMap, vec, vec::Vec};
 
 pub type MockSignature = TestSignature;
 pub type MockAccountPublic = <MockSignature as Verify>::Signer;
@@ -48,8 +47,7 @@ pub type MockBlock = frame_system::mocking::MockBlock<Test>;
 pub type MockBalance = u64;
 pub type MockCollectionId = u32;
 
-#[cfg(feature = "runtime-benchmarks")]
-use sp_runtime::RuntimeAppPublic;
+use crate::tests::ExtBuilder;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
@@ -217,6 +215,11 @@ impl crate::BenchmarkHelper<MockAccountId, ItemId> for NftTransferBenchmarkHelpe
 	fn create_items(owner: MockAccountId, count: u32) -> Vec<ItemId> {
 		MockAssetManager::create_items(owner, count)
 	}
+
+	fn set_account_balance(account: &MockAccountId, balance: u32) {
+		Balances::force_set_balance(RuntimeOrigin::root(), *account, balance as u64)
+			.expect("Should set balance");
+	}
 }
 
 impl pallet_ajuna_nft_transfer::Config for Test {
@@ -260,14 +263,27 @@ impl NftConvertible<KeyLimit, ValueLimit> for MockItem {
 	const IPFS_URL_CODE: &'static [u8] = &[21];
 
 	fn get_attribute_codes() -> Vec<NFTAttribute<KeyLimit>> {
-		vec![bounded_vec![111], bounded_vec![222], bounded_vec![240]]
+		vec![
+			BoundedVec::try_from(vec![111]).expect("Should create vec"),
+			BoundedVec::try_from(vec![222]).expect("Should create vec"),
+			BoundedVec::try_from(vec![240]).expect("Should create vec"),
+		]
 	}
 
 	fn get_encoded_attributes(&self) -> Vec<(NFTAttribute<KeyLimit>, NFTAttribute<ValueLimit>)> {
 		vec![
-			(bounded_vec![111], BoundedVec::try_from(self.field_1.clone()).unwrap()),
-			(bounded_vec![222], BoundedVec::try_from(self.field_2.to_le_bytes().to_vec()).unwrap()),
-			(bounded_vec![240], BoundedVec::try_from(vec![self.field_3 as u8]).unwrap()),
+			(
+				BoundedVec::try_from(vec![111]).expect("Should create vec"),
+				BoundedVec::try_from(self.field_1.clone()).unwrap(),
+			),
+			(
+				BoundedVec::try_from(vec![222]).expect("Should create vec"),
+				BoundedVec::try_from(self.field_2.to_le_bytes().to_vec()).unwrap(),
+			),
+			(
+				BoundedVec::try_from(vec![240]).expect("Should create vec"),
+				BoundedVec::try_from(vec![self.field_3 as u8]).unwrap(),
+			),
 		]
 	}
 }
@@ -417,12 +433,6 @@ pub struct MockAccountManager;
 pub const ACCOUNT_IS_NOT_ORGANIZER: &str = "ACCOUNT_IS_NOT_ORGANIZER";
 pub const NO_ORGANIZER_SET: &str = "NO_ORGANIZER_SET";
 
-impl MockAccountManager {
-	pub fn set_organizer(organizer: MockAccountId) {
-		ORGANIZER.with(|o| *o.borrow_mut() = Some(organizer))
-	}
-}
-
 impl ajuna_primitives::account_manager::AccountManager for MockAccountManager {
 	type AccountId = MockAccountId;
 
@@ -440,4 +450,19 @@ impl ajuna_primitives::account_manager::AccountManager for MockAccountManager {
 	fn is_whitelisted_for(_identifier: &WhitelistKey, _account: &Self::AccountId) -> bool {
 		unimplemented!()
 	}
+
+	fn set_organizer(account: Self::AccountId) {
+		ORGANIZER.with_borrow_mut(|maybe_organizer| *maybe_organizer = Some(account))
+	}
+
+	fn try_add_to_whitelist(
+		_identifier: &WhitelistKey,
+		_account: Self::AccountId,
+	) -> Result<(), DispatchError> {
+		unimplemented!()
+	}
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	ExtBuilder::default().build()
 }

--- a/pallets/ajuna-nft-transfer/src/tests.rs
+++ b/pallets/ajuna-nft-transfer/src/tests.rs
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{mock::*, traits::*, Error, *};
-use ajuna_primitives::account_manager::AccountManager;
 use frame_support::{
 	assert_err, assert_noop, assert_ok,
 	traits::tokens::nonfungibles_v2::{Create, Inspect},

--- a/pallets/ajuna-nft-transfer/src/tests.rs
+++ b/pallets/ajuna-nft-transfer/src/tests.rs
@@ -70,7 +70,7 @@ mod set_collection_id {
 	fn set_collection_id_works() {
 		ExtBuilder::default().build().execute_with(|| {
 			let collection_id = 369;
-			<MockAccountManager as AccountManager>::set_organizer(ALICE);
+			MockAccountManager::set_organizer(ALICE);
 			assert_ok!(NftTransfer::set_collection_id(RuntimeOrigin::signed(ALICE), collection_id));
 			assert_eq!(CollectionId::<Test>::get(), Some(collection_id));
 		});

--- a/pallets/ajuna-nft-transfer/src/tests.rs
+++ b/pallets/ajuna-nft-transfer/src/tests.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{mock::*, traits::*, Error, *};
+use ajuna_primitives::account_manager::AccountManager;
 use frame_support::{
 	assert_err, assert_noop, assert_ok,
 	traits::tokens::nonfungibles_v2::{Create, Inspect},
@@ -69,7 +70,7 @@ mod set_collection_id {
 	fn set_collection_id_works() {
 		ExtBuilder::default().build().execute_with(|| {
 			let collection_id = 369;
-			MockAccountManager::set_organizer(ALICE);
+			<MockAccountManager as AccountManager>::set_organizer(ALICE);
 			assert_ok!(NftTransfer::set_collection_id(RuntimeOrigin::signed(ALICE), collection_id));
 			assert_eq!(CollectionId::<Test>::get(), Some(collection_id));
 		});

--- a/pallets/ajuna-seasons/src/benchmarking.rs
+++ b/pallets/ajuna-seasons/src/benchmarking.rs
@@ -14,33 +14,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg(feature = "runtime-benchmarks")]
-#![cfg_attr(not(feature = "std"), no_std)]
-
-use crate::{
-	mock::{
-		run_to_block, Balances, MockAccountManager, MockAssetId, MockSeasonData, MockSeasonId,
-		RuntimeEvent, SeasonsBenchmarkHelper, System, Test,
-	},
-	Pallet as Seasons, *,
-};
+use crate::{Pallet as Seasons, *};
 use ajuna_primitives::season_manager::SeasonFeeConfig;
 
 use frame_benchmarking::benchmarks_instance_pallet;
 use frame_support::BoundedVec;
 use frame_system::RawOrigin;
-use sp_runtime::BuildStorage;
-
-impl Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type SeasonId = MockSeasonId;
-	type SeasonData = MockSeasonData;
-	type AssetId = MockAssetId;
-	type AccountHandler = MockAccountManager;
-	type Currency = Balances;
-	type WeightInfo = ();
-	type BenchmarkHelper = SeasonsBenchmarkHelper;
-}
+use sp_runtime::Saturating;
 
 const ACC_1: &str = "acc_1";
 
@@ -55,10 +35,29 @@ fn assert_last_event<T: Config<I>, I: 'static>(avatars_event: Event<T, I>) {
 	frame_system::Pallet::<T>::assert_last_event(event.into());
 }
 
+fn setup_organizer<T: Config<I>, I: 'static>(organizer: T::AccountId) {
+	T::AccountHandler::set_organizer(organizer);
+}
+
+fn run_to_block<T: Config<I>, I: 'static>(n: BlockNumberFor<T>) {
+	while frame_system::Pallet::<T>::block_number() < n {
+		let mut current_block = frame_system::Pallet::<T>::block_number();
+		if current_block > 1_u32.into() {
+			frame_system::Pallet::<T>::on_finalize(current_block);
+			crate::Pallet::<T, I>::on_finalize(current_block);
+		}
+		current_block = current_block.saturating_add(1_u32.into());
+		frame_system::Pallet::<T>::set_block_number(current_block);
+		frame_system::Pallet::<T>::on_initialize(current_block);
+		crate::Pallet::<T, I>::on_initialize(current_block);
+	}
+}
+
 benchmarks_instance_pallet! {
 	update_season {
 		let season_id = T::BenchmarkHelper::create_season_id(1_u32);
 		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
 		let config = SeasonConfigOf::<T, I> {
 				fee: SeasonFeeConfig {
 					transfer_asset: 10_u32.into(),
@@ -94,6 +93,7 @@ benchmarks_instance_pallet! {
 	interrupt_active_season {
 		let season_id = T::BenchmarkHelper::create_season_id(2_u32);
 		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
 		let config = SeasonConfigOf::<T, I> {
 				fee: SeasonFeeConfig {
 					transfer_asset: 10_u32.into(),
@@ -123,7 +123,7 @@ benchmarks_instance_pallet! {
 			Some(metadata),
 			Some(schedule)
 		).expect("Should update season");
-		run_to_block(25_u32.into());
+		run_to_block::<T, I>(25_u32.into());
 	}: _(RawOrigin::Signed(acc_1))
 	verify {
 		assert_last_event::<T, I>(Event::SeasonEarlyEnded {
@@ -133,19 +133,7 @@ benchmarks_instance_pallet! {
 
 	impl_benchmark_test_suite!(
 		Seasons,
-		new_test_ext(),
-		Test
+		crate::mock::new_test_ext(),
+		crate::mock::Test
 	);
-}
-
-#[allow(dead_code)]
-pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	let mut ext = sp_io::TestExternalities::new(t);
-	ext.execute_with(|| System::set_block_number(1));
-	ext.execute_with(|| {
-		let acc_1 = account::<Test, ()>(ACC_1);
-		MockAccountManager::set_organizer(acc_1);
-	});
-	ext
 }

--- a/pallets/ajuna-seasons/src/lib.rs
+++ b/pallets/ajuna-seasons/src/lib.rs
@@ -22,7 +22,7 @@ pub mod weights;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
-#[cfg(any(test, feature = "runtime-benchmarks"))]
+#[cfg(test)]
 mod mock;
 #[cfg(test)]
 mod test_impls;

--- a/pallets/ajuna-seasons/src/mock.rs
+++ b/pallets/ajuna-seasons/src/mock.rs
@@ -19,7 +19,6 @@ use frame_support::{
 	parameter_types,
 	traits::{ConstU16, ConstU64},
 };
-#[cfg(test)]
 use sp_runtime::BuildStorage;
 
 use ajuna_primitives::{account_manager::WhitelistKey, season_manager::Validate};
@@ -110,14 +109,6 @@ pub struct MockAccountManager;
 pub const ACCOUNT_IS_NOT_ORGANIZER: &str = "ACCOUNT_IS_NOT_ORGANIZER";
 pub const NO_ORGANIZER_SET: &str = "NO_ORGANIZER_SET";
 
-impl MockAccountManager {
-	pub(crate) fn set_organizer(owner: MockAccountId) {
-		ORGANIZER.with(|maybe_account| {
-			*maybe_account.borrow_mut() = Some(owner);
-		});
-	}
-}
-
 impl AccountManager for MockAccountManager {
 	type AccountId = MockAccountId;
 
@@ -133,6 +124,19 @@ impl AccountManager for MockAccountManager {
 	}
 
 	fn is_whitelisted_for(_identifier: &WhitelistKey, _account: &Self::AccountId) -> bool {
+		unimplemented!()
+	}
+
+	fn set_organizer(account: Self::AccountId) {
+		ORGANIZER.with(|maybe_account| {
+			*maybe_account.borrow_mut() = Some(account);
+		});
+	}
+
+	fn try_add_to_whitelist(
+		identifier: &WhitelistKey,
+		account: Self::AccountId,
+	) -> Result<(), DispatchError> {
 		unimplemented!()
 	}
 }
@@ -177,6 +181,18 @@ impl pallet_ajuna_seasons::Config<SeasonsInstance1> for Test {
 	type BenchmarkHelper = SeasonsBenchmarkHelper;
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+impl Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type SeasonId = MockSeasonId;
+	type SeasonData = MockSeasonData;
+	type AssetId = MockAssetId;
+	type AccountHandler = MockAccountManager;
+	type Currency = Balances;
+	type WeightInfo = ();
+	type BenchmarkHelper = SeasonsBenchmarkHelper;
+}
+
 #[cfg(test)]
 #[derive(Default)]
 pub struct ExtBuilder {
@@ -203,6 +219,10 @@ impl ExtBuilder {
 		});
 		ext
 	}
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	ExtBuilder::default().build()
 }
 
 pub fn run_to_block(n: u64) {

--- a/pallets/ajuna-seasons/src/mock.rs
+++ b/pallets/ajuna-seasons/src/mock.rs
@@ -134,8 +134,8 @@ impl AccountManager for MockAccountManager {
 	}
 
 	fn try_add_to_whitelist(
-		identifier: &WhitelistKey,
-		account: Self::AccountId,
+		_identifier: &WhitelistKey,
+		_account: Self::AccountId,
 	) -> Result<(), DispatchError> {
 		unimplemented!()
 	}

--- a/pallets/ajuna-seasons/src/mock.rs
+++ b/pallets/ajuna-seasons/src/mock.rs
@@ -127,12 +127,14 @@ impl AccountManager for MockAccountManager {
 		unimplemented!()
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
 	fn set_organizer(account: Self::AccountId) {
 		ORGANIZER.with(|maybe_account| {
 			*maybe_account.borrow_mut() = Some(account);
 		});
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
 	fn try_add_to_whitelist(
 		_identifier: &WhitelistKey,
 		_account: Self::AccountId,

--- a/pallets/ajuna-seasons/src/mock.rs
+++ b/pallets/ajuna-seasons/src/mock.rs
@@ -106,6 +106,14 @@ thread_local! {
 
 pub struct MockAccountManager;
 
+impl MockAccountManager {
+	pub fn set_organizer(owner: MockAccountId) {
+		ORGANIZER.with(|maybe_account| {
+			*maybe_account.borrow_mut() = Some(owner);
+		});
+	}
+}
+
 pub const ACCOUNT_IS_NOT_ORGANIZER: &str = "ACCOUNT_IS_NOT_ORGANIZER";
 pub const NO_ORGANIZER_SET: &str = "NO_ORGANIZER_SET";
 
@@ -129,9 +137,7 @@ impl AccountManager for MockAccountManager {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_organizer(account: Self::AccountId) {
-		ORGANIZER.with(|maybe_account| {
-			*maybe_account.borrow_mut() = Some(account);
-		});
+		MockAccountManager::set_organizer(account);
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/pallets/ajuna-tournament/src/benchmarking.rs
+++ b/pallets/ajuna-tournament/src/benchmarking.rs
@@ -14,35 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg(feature = "runtime-benchmarks")]
-#![cfg_attr(not(feature = "std"), no_std)]
-
-use crate::{
-	mock::{
-		run_to_block, Balances, MinimumTournamentPhaseDuration, MockAccountManager,
-		MockAssetManager, MockCategoryId, MockEntity, MockEntityId, MockRanker, RuntimeEvent,
-		RuntimeOrigin, System, Test, TournamentBenchmarkHelper, TournamentPalletId1,
-	},
-	Pallet as Tournament, *,
-};
+use crate::{Pallet as Tournament, *};
+use ajuna_primitives::account_manager::AccountManager;
 use frame_benchmarking::benchmarks_instance_pallet;
+use frame_support::traits::Currency;
 use frame_system::RawOrigin;
-use sp_runtime::BuildStorage;
-
-impl Config for Test {
-	type PalletId = TournamentPalletId1;
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
-	type TournamentCategoryId = MockCategoryId;
-	type EntityId = MockEntityId;
-	type RankedEntity = MockEntity;
-	type EntityRanker = MockRanker;
-	type AccountManager = MockAccountManager;
-	type AssetManager = MockAssetManager;
-	type MinimumTournamentPhaseDuration = MinimumTournamentPhaseDuration;
-	type WeightInfo = ();
-	type BenchmarkHelper = TournamentBenchmarkHelper;
-}
+use sp_arithmetic::traits::Saturating;
 
 const ACC_1: &str = "acc_1";
 
@@ -64,9 +41,33 @@ fn assert_last_event<T: Config<I>, I: 'static>(avatars_event: Event<T, I>) {
 	frame_system::Pallet::<T>::assert_last_event(event.into());
 }
 
+fn setup_organizer<T: Config<I>, I: 'static>(organizer: T::AccountId) {
+	T::AccountManager::set_organizer(organizer);
+}
+
+fn set_account_balance<T: Config<I>, I: 'static>(account: &T::AccountId, balance: BalanceOf<T, I>) {
+	let _ = T::Currency::deposit_creating(account, balance);
+}
+
+fn run_to_block<T: Config<I>, I: 'static>(n: BlockNumberFor<T>) {
+	while frame_system::Pallet::<T>::block_number() < n {
+		let mut current_block = frame_system::Pallet::<T>::block_number();
+		if current_block > 1_u32.into() {
+			frame_system::Pallet::<T>::on_finalize(current_block);
+			crate::Pallet::<T, I>::on_finalize(current_block);
+		}
+		current_block = current_block.saturating_add(1_u32.into());
+		frame_system::Pallet::<T>::set_block_number(current_block);
+		frame_system::Pallet::<T>::on_initialize(current_block);
+		crate::Pallet::<T, I>::on_initialize(current_block);
+	}
+}
+
 benchmarks_instance_pallet! {
 	create_tournament {
 		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
+		set_account_balance::<T, I>(&acc_1, 1000_u32.into());
 		let category_id = T::BenchmarkHelper::create_category_id(1);
 		let tournament_config = T::BenchmarkHelper::create_default_tournament_config();
 	}: _(RawOrigin::Signed(acc_1), category_id, tournament_config)
@@ -76,6 +77,8 @@ benchmarks_instance_pallet! {
 
 	remove_latest_tournament {
 		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
+		set_account_balance::<T, I>(&acc_1, 1000_u32.into());
 		let category_id = T::BenchmarkHelper::create_category_id(1);
 		let tournament_config = T::BenchmarkHelper::create_default_tournament_config();
 		Tournament::<T, I>::create_tournament(RawOrigin::Signed(acc_1.clone()).into(), category_id, tournament_config)?;
@@ -86,15 +89,17 @@ benchmarks_instance_pallet! {
 
 	claim_tournament_reward_for {
 		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
+		set_account_balance::<T, I>(&acc_1, 1000_u32.into());
 		let category_id = T::BenchmarkHelper::create_category_id(1);
 		let (entity_id, entity) = create_owned_entity::<T, I>(acc_1.clone());
 		let tournament_config = T::BenchmarkHelper::create_default_tournament_config();
 		Tournament::<T, I>::create_tournament(RawOrigin::Signed(acc_1.clone()).into(), category_id, tournament_config)?;
-		run_to_block(20);
+		run_to_block::<T, I>(20_u32.into());
 		<Tournament<T, I> as TournamentRanker<T::TournamentCategoryId, T::RankedEntity, T::EntityId>>::try_rank_entity_in_tournament_for(
 			&category_id, &entity_id, &entity
 		)?;
-		run_to_block(60);
+		run_to_block::<T, I>(60_u32.into());
 	}: _(RawOrigin::Signed(acc_1.clone()), category_id, entity_id.clone())
 	verify {
 		assert_last_event::<T, I>(Event::RankingRewardClaimed { category_id, tournament_id: 0, entity_id ,account: acc_1 })
@@ -102,15 +107,17 @@ benchmarks_instance_pallet! {
 
 	claim_golden_duck_for {
 		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
+		set_account_balance::<T, I>(&acc_1, 1000_u32.into());
 		let category_id = T::BenchmarkHelper::create_category_id(1);
 		let (entity_id, _) = create_owned_entity::<T, I>(acc_1.clone());
 		let tournament_config = T::BenchmarkHelper::create_default_tournament_config();
 		Tournament::<T, I>::create_tournament(RawOrigin::Signed(acc_1.clone()).into(), category_id, tournament_config)?;
-		run_to_block(20);
+		run_to_block::<T, I>(20_u32.into());
 		<Tournament<T, I> as TournamentRanker<T::TournamentCategoryId, T::RankedEntity, T::EntityId>>::try_rank_entity_for_golden_duck(
 			&category_id, &entity_id
 		)?;
-		run_to_block(60);
+		run_to_block::<T, I>(60_u32.into());
 	}: _(RawOrigin::Signed(acc_1.clone()), category_id, entity_id.clone())
 	verify {
 		assert_last_event::<T, I>(Event::GoldenDuckRewardClaimed { category_id, tournament_id: 0, entity_id ,account: acc_1 })
@@ -118,20 +125,7 @@ benchmarks_instance_pallet! {
 
 	impl_benchmark_test_suite!(
 		Tournament,
-		new_test_ext(),
-		Test
+		crate::mock::new_test_ext(),
+		crate::mock::Test
 	);
-}
-
-pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	let mut ext = sp_io::TestExternalities::new(t);
-	ext.execute_with(|| System::set_block_number(1));
-	ext.execute_with(|| {
-		let acc_1 = account::<Test, ()>(ACC_1);
-		Balances::force_set_balance(RuntimeOrigin::root(), acc_1.clone(), 1_000)
-			.expect("Should set balance");
-		MockAccountManager::set_organizer(acc_1);
-	});
-	ext
 }

--- a/pallets/ajuna-tournament/src/lib.rs
+++ b/pallets/ajuna-tournament/src/lib.rs
@@ -20,7 +20,7 @@ pub use pallet::*;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
-#[cfg(any(test, feature = "runtime-benchmarks"))]
+#[cfg(test)]
 mod mock;
 #[cfg(test)]
 mod tests;

--- a/pallets/ajuna-tournament/src/mock.rs
+++ b/pallets/ajuna-tournament/src/mock.rs
@@ -142,6 +142,12 @@ pub struct MockAccountManager;
 pub const ACCOUNT_IS_NOT_ORGANIZER: &str = "ACCOUNT_IS_NOT_ORGANIZER";
 pub const NO_ORGANIZER_SET: &str = "NO_ORGANIZER_SET";
 
+impl MockAccountManager {
+	pub fn set_organizer(account: MockAccountId) {
+		ORGANIZER.with_borrow_mut(|maybe_organizer| *maybe_organizer = Some(account))
+	}
+}
+
 impl AccountManager for MockAccountManager {
 	type AccountId = MockAccountId;
 
@@ -162,9 +168,7 @@ impl AccountManager for MockAccountManager {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_organizer(account: Self::AccountId) {
-		ORGANIZER.with(|maybe_account| {
-			*maybe_account.borrow_mut() = Some(account);
-		});
+		MockAccountManager::set_organizer(account);
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/pallets/ajuna-tournament/src/mock.rs
+++ b/pallets/ajuna-tournament/src/mock.rs
@@ -25,13 +25,10 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
-#[cfg(test)]
-use sp_runtime::BuildStorage;
-
 use sp_runtime::{
 	testing::H256,
 	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
-	MultiSignature,
+	BuildStorage, MultiSignature,
 };
 use sp_std::{cell::RefCell, cmp::Ordering, collections::btree_map::BTreeMap};
 
@@ -330,6 +327,22 @@ impl pallet_ajuna_tournament::Config<TournamentInstance2> for Test {
 	type BenchmarkHelper = TournamentBenchmarkHelper;
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+impl Config for Test {
+	type PalletId = TournamentPalletId1;
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type TournamentCategoryId = MockCategoryId;
+	type EntityId = MockEntityId;
+	type RankedEntity = MockEntity;
+	type EntityRanker = MockRanker;
+	type AccountManager = MockAccountManager;
+	type AssetManager = MockAssetManager;
+	type MinimumTournamentPhaseDuration = MinimumTournamentPhaseDuration;
+	type WeightInfo = ();
+	type BenchmarkHelper = TournamentBenchmarkHelper;
+}
+
 #[cfg(test)]
 pub struct ExtBuilder {
 	balances: Vec<(MockAccountId, MockBalance)>,
@@ -379,6 +392,10 @@ impl ExtBuilder {
 		});
 		ext
 	}
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	ExtBuilder::default().build()
 }
 
 pub fn run_to_block(n: u64) {

--- a/pallets/ajuna-tournament/src/mock.rs
+++ b/pallets/ajuna-tournament/src/mock.rs
@@ -142,14 +142,6 @@ pub struct MockAccountManager;
 pub const ACCOUNT_IS_NOT_ORGANIZER: &str = "ACCOUNT_IS_NOT_ORGANIZER";
 pub const NO_ORGANIZER_SET: &str = "NO_ORGANIZER_SET";
 
-impl MockAccountManager {
-	pub(crate) fn set_organizer(owner: MockAccountId) {
-		ORGANIZER.with(|maybe_account| {
-			*maybe_account.borrow_mut() = Some(owner);
-		});
-	}
-}
-
 impl AccountManager for MockAccountManager {
 	type AccountId = MockAccountId;
 
@@ -165,6 +157,19 @@ impl AccountManager for MockAccountManager {
 	}
 
 	fn is_whitelisted_for(_identifier: &WhitelistKey, _account: &Self::AccountId) -> bool {
+		unimplemented!()
+	}
+
+	fn set_organizer(account: Self::AccountId) {
+		ORGANIZER.with(|maybe_account| {
+			*maybe_account.borrow_mut() = Some(account);
+		});
+	}
+
+	fn try_add_to_whitelist(
+		_identifier: &WhitelistKey,
+		_account: Self::AccountId,
+	) -> Result<(), DispatchError> {
 		unimplemented!()
 	}
 }

--- a/pallets/ajuna-tournament/src/mock.rs
+++ b/pallets/ajuna-tournament/src/mock.rs
@@ -160,12 +160,14 @@ impl AccountManager for MockAccountManager {
 		unimplemented!()
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
 	fn set_organizer(account: Self::AccountId) {
 		ORGANIZER.with(|maybe_account| {
 			*maybe_account.borrow_mut() = Some(account);
 		});
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
 	fn try_add_to_whitelist(
 		_identifier: &WhitelistKey,
 		_account: Self::AccountId,

--- a/primitives/src/account_manager.rs
+++ b/primitives/src/account_manager.rs
@@ -27,4 +27,13 @@ pub trait AccountManager {
 	fn is_organizer(account: &Self::AccountId) -> Result<(), DispatchError>;
 
 	fn is_whitelisted_for(identifier: &WhitelistKey, account: &Self::AccountId) -> bool;
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn set_organizer(account: Self::AccountId);
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_add_to_whitelist(
+		identifier: &WhitelistKey,
+		account: Self::AccountId,
+	) -> Result<(), DispatchError>;
 }

--- a/sage/pallet/src/benchmarking.rs
+++ b/sage/pallet/src/benchmarking.rs
@@ -18,13 +18,13 @@ use crate::{
 	config::{InventoryTier, Locks},
 	pallet::{AssetFilterOf, TradeFilterOf, TransferFilterOf},
 	AssetTradePrices, BalanceOf, BenchmarkHelper, Call, Config, Event, ExtraOf, GeneralConfigOf,
-	GeneralConfigStore, LockableFeature, Organizer, Pallet, PlayerSeasonConfigs, SeasonUnlocks,
-	UnlockRule, UnlockTarget, SAGE_LOCK_ID,
+	GeneralConfigStore, LockableFeature, Organizer, Pallet, PlayerSeasonConfigs, SeasonIdOf,
+	SeasonUnlocks, UnlockRule, UnlockTarget, SAGE_LOCK_ID,
 };
 use ajuna_primitives::{asset_manager::Lock, season_manager::SeasonManager};
 use frame_benchmarking::benchmarks;
+use frame_support::traits::Currency;
 use frame_system::RawOrigin;
-use sp_runtime::BuildStorage;
 
 const ACC_1: &str = "acc_1";
 const ACC_2: &str = "acc_2";
@@ -40,6 +40,36 @@ fn assert_last_event<T: Config<I>, I: 'static>(avatars_event: Event<T, I>) {
 	frame_system::Pallet::<T>::assert_last_event(event.into());
 }
 
+fn setup_organizer<T: Config<I>, I: 'static>(organizer: T::AccountId) {
+	Organizer::<T, I>::set(Some(organizer));
+}
+
+fn set_account_balance<T: Config<I>, I: 'static>(account: &T::AccountId, balance: BalanceOf<T, I>) {
+	let _ = T::Currency::deposit_creating(account, balance);
+}
+
+fn unlock_season_features_for<T: Config<I>, I: 'static>(season_id: &SeasonIdOf<T, I>) {
+	GeneralConfigStore::<T, I>::mutate(|config| {
+		config.trade.open = true;
+		config.transfer.open = true;
+	});
+	SeasonUnlocks::<T, I>::mutate(season_id, LockableFeature::TradeAsset, |rule| {
+		*rule = Some(UnlockRule::from([0, 0, 0, 0, 0]));
+	});
+	SeasonUnlocks::<T, I>::mutate(season_id, LockableFeature::TransferAsset, |rule| {
+		*rule = Some(UnlockRule::from([0, 0, 0, 0, 0]));
+	});
+}
+
+fn unlock_player_features_for<T: Config<I>, I: 'static>(
+	account: &T::AccountId,
+	season_id: &SeasonIdOf<T, I>,
+) {
+	PlayerSeasonConfigs::<T, I>::mutate(account, season_id, |config| {
+		config.locks = Locks::all_unlocked();
+	});
+}
+
 benchmarks! {
 	set_organizer {
 		let acc_2 = account::<T, ()>(ACC_2);
@@ -50,6 +80,7 @@ benchmarks! {
 
 	update_general_config {
 		let acc_1 = account::<T, ()>(ACC_1);
+		setup_organizer::<T, ()>(acc_1.clone());
 		let general_config = GeneralConfigOf::<T, ()>::default();
 	}: _(RawOrigin::Signed(acc_1), general_config.clone())
 	verify {
@@ -58,6 +89,7 @@ benchmarks! {
 
 	update_unlock_rule {
 		let acc_1 = account::<T, ()>(ACC_1);
+		setup_organizer::<T, ()>(acc_1.clone());
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let feature = LockableFeature::TradeAsset;
@@ -73,6 +105,8 @@ benchmarks! {
 
 	upgrade_asset_inventory {
 		let acc_1 = account::<T, ()>(ACC_1);
+		setup_organizer::<T, ()>(acc_1.clone());
+		set_account_balance::<T, ()>(&acc_1, 100_u32.into());
 		let acc_2 = account::<T, ()>(ACC_2);
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
@@ -89,6 +123,7 @@ benchmarks! {
 
 	update_asset_trade_filter {
 		let acc_1 = account::<T, ()>(ACC_1);
+		setup_organizer::<T, ()>(acc_1.clone());
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let filter = TradeFilterOf::<T, ()>::default();
@@ -103,6 +138,7 @@ benchmarks! {
 
 	update_asset_transfer_filter {
 		let acc_1 = account::<T, ()>(ACC_1);
+		setup_organizer::<T, ()>(acc_1.clone());
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let filter = TransferFilterOf::<T, ()>::default();
@@ -117,9 +153,12 @@ benchmarks! {
 
 	transfer_asset {
 		let acc_1 = account::<T, ()>(ACC_1);
+		set_account_balance::<T, ()>(&acc_1, 100_u32.into());
 		let acc_2 = account::<T, ()>(ACC_2);
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
+		unlock_season_features_for::<T, ()>(&season_id);
+		unlock_player_features_for::<T, ()>(&acc_1, &season_id);
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 2);
 		let payment = T::BenchmarkHelper::create_payment_kind();
 	}: _(RawOrigin::Signed(acc_1.clone()), acc_2.clone(), asset_id.clone(), Some(payment))
@@ -135,6 +174,8 @@ benchmarks! {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
+		unlock_season_features_for::<T, ()>(&season_id);
+		unlock_player_features_for::<T, ()>(&acc_1, &season_id);
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let price = 45_242_u32;
 	}: _(RawOrigin::Signed(acc_1), asset_id.clone(), price.into())
@@ -149,6 +190,7 @@ benchmarks! {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
+		unlock_season_features_for::<T, ()>(&season_id);
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let price = BalanceOf::<T, ()>::from(45_242_u32);
 		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, price);
@@ -162,6 +204,7 @@ benchmarks! {
 	buy_asset {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let acc_2 = account::<T, ()>(ACC_2);
+		set_account_balance::<T, ()>(&acc_2, 100_000_u32.into());
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
@@ -216,6 +259,7 @@ benchmarks! {
 		let feature = LockableFeature::TradeAsset;
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
+		unlock_season_features_for::<T, ()>(&season_id);
 		let payment = T::BenchmarkHelper::create_payment_kind();
 	}: unlock_feature(RawOrigin::Signed(acc_1.clone()), target, feature, season_id.clone(), Some(payment))
 	verify {
@@ -232,6 +276,7 @@ benchmarks! {
 		let feature = LockableFeature::TransferAsset;
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
+		unlock_season_features_for::<T, ()>(&season_id);
 		let payment = T::BenchmarkHelper::create_payment_kind();
 	}: unlock_feature(RawOrigin::Signed(acc_1.clone()), target, feature, season_id.clone(), Some(payment))
 	verify {
@@ -244,6 +289,7 @@ benchmarks! {
 
 	state_transition {
 		let acc_1 = account::<T, ()>(ACC_1);
+		set_account_balance::<T, ()>(&acc_1, 100_u32.into());
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let (transition_id, asset_ids) = T::BenchmarkHelper::create_bench_transition_for(&acc_1, &season_id, 99);
@@ -259,43 +305,7 @@ benchmarks! {
 
 	impl_benchmark_test_suite!(
 		Pallet,
-		new_benchmark_ext(),
+		crate::mock::new_test_ext(),
 		crate::mock::Test
 	);
-}
-
-pub fn new_benchmark_ext() -> sp_io::TestExternalities {
-	use crate::mock::{Balances, RuntimeOrigin, System, Test, SEASON_ID_0};
-
-	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	let mut ext = sp_io::TestExternalities::new(t);
-	ext.execute_with(|| System::set_block_number(1));
-	ext.execute_with(|| {
-		GeneralConfigStore::<Test, ()>::mutate(|config| {
-			config.trade.open = true;
-			config.transfer.open = true;
-		});
-		SeasonUnlocks::<Test, ()>::mutate(SEASON_ID_0, LockableFeature::TradeAsset, |rule| {
-			*rule = Some(UnlockRule::from([0, 0, 0, 0, 0]));
-		});
-		SeasonUnlocks::<Test, ()>::mutate(SEASON_ID_0, LockableFeature::TransferAsset, |rule| {
-			*rule = Some(UnlockRule::from([0, 0, 0, 0, 0]));
-		});
-
-		let acc_1 = account::<Test, ()>(ACC_1);
-		Organizer::<Test, ()>::put(acc_1);
-		PlayerSeasonConfigs::<Test, ()>::mutate(acc_1, SEASON_ID_0, |config| {
-			config.locks = Locks::all_unlocked();
-		});
-		Balances::force_set_balance(RuntimeOrigin::root(), acc_1, 100_000)
-			.expect("Should set balance");
-
-		let acc_2 = account::<Test, ()>(ACC_2);
-		PlayerSeasonConfigs::<Test, ()>::mutate(acc_2, SEASON_ID_0, |config| {
-			config.locks = Locks::all_unlocked();
-		});
-		Balances::force_set_balance(RuntimeOrigin::root(), acc_2, 100_000)
-			.expect("Should set balance");
-	});
-	ext
 }

--- a/sage/pallet/src/lib.rs
+++ b/sage/pallet/src/lib.rs
@@ -28,7 +28,7 @@ mod trait_impls;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
-#[cfg(any(test, feature = "runtime-benchmarks"))]
+#[cfg(test)]
 pub mod mock;
 #[cfg(test)]
 mod tests;
@@ -398,8 +398,9 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::set_organizer())]
 		pub fn set_organizer(origin: OriginFor<T>, organizer: AccountIdOf<T>) -> DispatchResult {
 			ensure_root(origin)?;
-			Organizer::<T, I>::put(&organizer);
-			Self::deposit_event(Event::OrganizerSet { organizer });
+
+			<Self as AccountManager>::set_organizer(organizer);
+
 			Ok(())
 		}
 

--- a/sage/pallet/src/lib.rs
+++ b/sage/pallet/src/lib.rs
@@ -398,9 +398,8 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::set_organizer())]
 		pub fn set_organizer(origin: OriginFor<T>, organizer: AccountIdOf<T>) -> DispatchResult {
 			ensure_root(origin)?;
-
-			<Self as AccountManager>::set_organizer(organizer);
-
+			Organizer::<T, I>::put(&organizer);
+			Self::deposit_event(Event::OrganizerSet { organizer });
 			Ok(())
 		}
 

--- a/sage/pallet/src/mock.rs
+++ b/sage/pallet/src/mock.rs
@@ -480,3 +480,43 @@ impl ExtBuilder {
 		ext
 	}
 }
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	ExtBuilder::default().build()
+}
+
+/*pub fn new_benchmark_ext() -> sp_io::TestExternalities {
+	use crate::mock::{Balances, RuntimeOrigin, System, Test, SEASON_ID_0};
+
+	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| System::set_block_number(1));
+	ext.execute_with(|| {
+		GeneralConfigStore::<Test, ()>::mutate(|config| {
+			config.trade.open = true;
+			config.transfer.open = true;
+		});
+		SeasonUnlocks::<Test, ()>::mutate(SEASON_ID_0, LockableFeature::TradeAsset, |rule| {
+			*rule = Some(UnlockRule::from([0, 0, 0, 0, 0]));
+		});
+		SeasonUnlocks::<Test, ()>::mutate(SEASON_ID_0, LockableFeature::TransferAsset, |rule| {
+			*rule = Some(UnlockRule::from([0, 0, 0, 0, 0]));
+		});
+
+		let acc_1 = crate::benchmarking::account::<Test, ()>(crate::benchmarking::ACC_1);
+		Organizer::<Test, ()>::put(acc_1);
+		PlayerSeasonConfigs::<Test, ()>::mutate(acc_1, SEASON_ID_0, |config| {
+			config.locks = Locks::all_unlocked();
+		});
+		Balances::force_set_balance(RuntimeOrigin::root(), acc_1, 100_000)
+			.expect("Should set balance");
+
+		let acc_2 = crate::benchmarking::account::<Test, ()>(crate::benchmarking::ACC_2);
+		PlayerSeasonConfigs::<Test, ()>::mutate(acc_2, SEASON_ID_0, |config| {
+			config.locks = Locks::all_unlocked();
+		});
+		Balances::force_set_balance(RuntimeOrigin::root(), acc_2, 100_000)
+			.expect("Should set balance");
+	});
+	ext
+}*/

--- a/sage/pallet/src/mock.rs
+++ b/sage/pallet/src/mock.rs
@@ -484,39 +484,3 @@ impl ExtBuilder {
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	ExtBuilder::default().build()
 }
-
-/*pub fn new_benchmark_ext() -> sp_io::TestExternalities {
-	use crate::mock::{Balances, RuntimeOrigin, System, Test, SEASON_ID_0};
-
-	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	let mut ext = sp_io::TestExternalities::new(t);
-	ext.execute_with(|| System::set_block_number(1));
-	ext.execute_with(|| {
-		GeneralConfigStore::<Test, ()>::mutate(|config| {
-			config.trade.open = true;
-			config.transfer.open = true;
-		});
-		SeasonUnlocks::<Test, ()>::mutate(SEASON_ID_0, LockableFeature::TradeAsset, |rule| {
-			*rule = Some(UnlockRule::from([0, 0, 0, 0, 0]));
-		});
-		SeasonUnlocks::<Test, ()>::mutate(SEASON_ID_0, LockableFeature::TransferAsset, |rule| {
-			*rule = Some(UnlockRule::from([0, 0, 0, 0, 0]));
-		});
-
-		let acc_1 = crate::benchmarking::account::<Test, ()>(crate::benchmarking::ACC_1);
-		Organizer::<Test, ()>::put(acc_1);
-		PlayerSeasonConfigs::<Test, ()>::mutate(acc_1, SEASON_ID_0, |config| {
-			config.locks = Locks::all_unlocked();
-		});
-		Balances::force_set_balance(RuntimeOrigin::root(), acc_1, 100_000)
-			.expect("Should set balance");
-
-		let acc_2 = crate::benchmarking::account::<Test, ()>(crate::benchmarking::ACC_2);
-		PlayerSeasonConfigs::<Test, ()>::mutate(acc_2, SEASON_ID_0, |config| {
-			config.locks = Locks::all_unlocked();
-		});
-		Balances::force_set_balance(RuntimeOrigin::root(), acc_2, 100_000)
-			.expect("Should set balance");
-	});
-	ext
-}*/

--- a/sage/pallet/src/trait_impls/account_manager.rs
+++ b/sage/pallet/src/trait_impls/account_manager.rs
@@ -29,13 +29,13 @@ impl<T: Config<I>, I: 'static> AccountManager for Pallet<T, I> {
 		unimplemented!()
 	}
 
-	#[cfg(features = "runtime-benchmarks")]
+	#[cfg(feature = "runtime-benchmarks")]
 	fn set_organizer(account: Self::AccountId) {
 		Organizer::<T, I>::put(&account);
 		Self::deposit_event(Event::OrganizerSet { organizer: account });
 	}
 
-	#[cfg(features = "runtime-benchmarks")]
+	#[cfg(feature = "runtime-benchmarks")]
 	fn try_add_to_whitelist(
 		_identifier: &WhitelistKey,
 		_account: Self::AccountId,

--- a/sage/pallet/src/trait_impls/account_manager.rs
+++ b/sage/pallet/src/trait_impls/account_manager.rs
@@ -28,4 +28,16 @@ impl<T: Config<I>, I: 'static> AccountManager for Pallet<T, I> {
 	fn is_whitelisted_for(_identifier: &WhitelistKey, _account: &Self::AccountId) -> bool {
 		unimplemented!()
 	}
+
+	fn set_organizer(account: Self::AccountId) {
+		Organizer::<T, I>::put(&account);
+		Self::deposit_event(Event::OrganizerSet { organizer: account });
+	}
+
+	fn try_add_to_whitelist(
+		_identifier: &WhitelistKey,
+		_account: Self::AccountId,
+	) -> Result<(), DispatchError> {
+		unimplemented!()
+	}
 }

--- a/sage/pallet/src/trait_impls/account_manager.rs
+++ b/sage/pallet/src/trait_impls/account_manager.rs
@@ -29,11 +29,13 @@ impl<T: Config<I>, I: 'static> AccountManager for Pallet<T, I> {
 		unimplemented!()
 	}
 
+	#[cfg(features = "runtime-benchmarks")]
 	fn set_organizer(account: Self::AccountId) {
 		Organizer::<T, I>::put(&account);
 		Self::deposit_event(Event::OrganizerSet { organizer: account });
 	}
 
+	#[cfg(features = "runtime-benchmarks")]
 	fn try_add_to_whitelist(
 		_identifier: &WhitelistKey,
 		_account: Self::AccountId,

--- a/scripts/run_for_all_crates.sh
+++ b/scripts/run_for_all_crates.sh
@@ -10,5 +10,11 @@ shift
 set -x
 
 for file in **/Cargo.toml; do
-	cargo $COMMAND $@ --manifest-path "$file";
+  if grep -q "\[features\]" "$file" && grep -q "runtime-benchmarks" "$file"; then
+      echo "Feature 'runtime-benchmarks' found, adding this feature."
+      cargo $COMMAND $@ --features runtime-benchmarks --manifest-path "$file"
+  else
+      echo "Feature 'runtime-benchmarks' not found, running command without this feature"
+      cargo $COMMAND $@ --manifest-path "$file";
+  fi
 done

--- a/scripts/run_for_all_crates.sh
+++ b/scripts/run_for_all_crates.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 # Useful for checking individual crates for correctness, i.e., if they compile to wasm.
+#
+# Example usage: ./scripts/run_for_all_crates.sh check --no-default-features --target=wasm32-unknown-unknown
 
 set -e
 

--- a/scripts/run_for_all_crates.sh
+++ b/scripts/run_for_all_crates.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Useful for checking individual crates for correctness, i.e., if they compile to wasm.
+
+set -e
+
+COMMAND=$1
+shift
+
+set -x
+
+for file in **/Cargo.toml; do
+	cargo $COMMAND $@ --manifest-path "$file";
+done

--- a/scripts/run_for_all_crates.sh
+++ b/scripts/run_for_all_crates.sh
@@ -9,12 +9,15 @@ shift
 
 set -x
 
-for file in **/Cargo.toml; do
-  if grep -q "\[features\]" "$file" && grep -q "runtime-benchmarks" "$file"; then
+find . -name "Cargo.toml" | while read -r CARGO_TOML; do
+  DIR=$(dirname "$CARGO_TOML")
+  echo "Checking in directory: $DIR"
+
+  if grep -q "\[features\]" "$CARGO_TOML" && grep -q "runtime-benchmarks" "$CARGO_TOML"; then
       echo "Feature 'runtime-benchmarks' found, adding this feature."
-      cargo $COMMAND $@ --features runtime-benchmarks --manifest-path "$file"
+      cargo $COMMAND $@ --features runtime-benchmarks --manifest-path "$CARGO_TOML"
   else
       echo "Feature 'runtime-benchmarks' not found, running command without this feature"
-      cargo $COMMAND $@ --manifest-path "$file";
+      cargo $COMMAND $@ --manifest-path "$CARGO_TOML";
   fi
 done

--- a/scripts/run_for_all_no_std_crates.sh
+++ b/scripts/run_for_all_no_std_crates.sh
@@ -2,7 +2,7 @@
 
 # Useful for checking individual crates for correctness, i.e., if they compile to wasm.
 #
-# Example usage: ./scripts/run_for_all_crates.sh check --no-default-features --target=wasm32-unknown-unknown
+# Example usage: ./scripts/run_for_all_no_std_crates.sh check --no-default-features --target=wasm32-unknown-unknown
 
 set -e
 
@@ -15,7 +15,13 @@ find . -name "Cargo.toml" | while read -r CARGO_TOML; do
   DIR=$(dirname "$CARGO_TOML")
   echo "Checking in directory: $DIR"
 
-  if grep -q "\[features\]" "$CARGO_TOML" && grep -q "runtime-benchmarks" "$CARGO_TOML"; then
+  # Skip the loop if the crate does not have a feature `std`
+  if ! grep -q "\[features\]" "$CARGO_TOML" || ! grep -q "std = \[" "$CARGO_TOML"; then
+      echo "Feature 'std' not found in $CARGO_TOML. Skipping."
+      continue
+  fi
+
+  if grep -q "\[features\]" "$CARGO_TOML" && grep -q "runtime-benchmarks = \[" "$CARGO_TOML"; then
       echo "Feature 'runtime-benchmarks' found, adding this feature."
       cargo $COMMAND $@ --features runtime-benchmarks --manifest-path "$CARGO_TOML"
   else


### PR DESCRIPTION
The benchmarks don't compile in the node currently, with the proper CI check this could not have been overlooked. This PR adds a CI check that tests for each crate individually if it compiles to wasm, and it enabled the `runtime-benchmarks` feature if a crate has that feature.

Basically this PR ensures that all pallets work with:
* cargo test -p "crate" --features runtime-benchmarks 
* clear && cargo check -p "crate" --no-default-features --features runtime-benchmarks --target=wasm32-unknown-unknown  

Both tests are executed in the CI already