### PR TITLE
[AJUN-910] Update benchmarks to V2 syntax

### DIFF
--- a/orml-pallets-benchmarking/Cargo.toml
+++ b/orml-pallets-benchmarking/Cargo.toml
@@ -38,9 +38,6 @@ std = [
     "sp-std/std",
     "sp-runtime/std",
 ]
-# Note: Either the `benchmarks!` or the `define_benchmarks!` macro demand the
-# existence of this feature flag. Otherwise, the benchmarks can't be found in the
-# node.
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
     "frame-support/runtime-benchmarks",

--- a/orml-pallets-benchmarking/src/vesting.rs
+++ b/orml-pallets-benchmarking/src/vesting.rs
@@ -17,7 +17,7 @@
 use super::utils::{
 	get_vesting_account, lookup_of_account, set_balance, AccountIdFor, BalanceFor, CurrencyFor,
 };
-use frame_benchmarking::{account, benchmarks, whitelisted_caller};
+use frame_benchmarking::v2::*;
 use frame_support::traits::{Currency, Get};
 use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use sp_runtime::Saturating;
@@ -42,11 +42,13 @@ pub fn schedule<T: Config>(
 	Schedule::<T> { start: start.into(), period: period.into(), period_count, per_period }
 }
 
-benchmarks! {
-	vested_transfer {
-		let schedule = schedule::<T>(
-			0, 2,3,<T>::MinVestedTransfer::get()
-		);
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn vested_transfer() {
+		let schedule = schedule::<T>(0, 2, 3, <T>::MinVestedTransfer::get());
 
 		let from = get_vesting_account::<T>();
 		let ed_times_two = CurrencyFor::<T>::minimum_balance().saturating_mul(2u32.into());
@@ -54,19 +56,16 @@ benchmarks! {
 
 		let to: AccountIdFor<T> = account("to", 0, SEED);
 		let to_lookup = lookup_of_account::<T>(to.clone());
-	}: _(RawOrigin::Signed(from), to_lookup, schedule.clone())
-	verify {
-		assert_eq!(CurrencyFor::<T>::total_balance(&to),
-			schedule.total_amount().unwrap()
-		);
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(from), to_lookup, schedule.clone());
+
+		assert_eq!(CurrencyFor::<T>::total_balance(&to), schedule.total_amount().unwrap());
 	}
 
-	claim {
-		let i in 1 .. <T>::MaxVestingSchedules::get();
-
-		let mut schedule = schedule::<T>(
-			0, 2,3,<T>::MinVestedTransfer::get()
-		);
+	#[benchmark]
+	fn claim(i: Linear<1, { T::MaxVestingSchedules::get() }>) {
+		let mut schedule = schedule::<T>(0, 2, 3, <T>::MinVestedTransfer::get());
 
 		let from: AccountIdFor<T> = get_vesting_account::<T>();
 		let ed_times_two = CurrencyFor::<T>::minimum_balance().saturating_mul(2u32.into());
@@ -76,26 +75,30 @@ benchmarks! {
 
 		for _ in 0..i {
 			schedule.start = i.into();
-			orml_vesting::Pallet::<T>::vested_transfer(RawOrigin::Signed(from.clone()).into(), to_lookup.clone(), schedule.clone())?;
+			orml_vesting::Pallet::<T>::vested_transfer(
+				RawOrigin::Signed(from.clone()).into(),
+				to_lookup.clone(),
+				schedule.clone(),
+			)
+			.expect("Should make vested transfer");
 		}
 		frame_system::Pallet::<T>::set_block_number(schedule.end().unwrap() + 1u32.into());
-	}: _(RawOrigin::Signed(to.clone()))
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(to.clone()));
+
 		assert_eq!(
 			CurrencyFor::<T>::free_balance(&to),
 			schedule.total_amount().unwrap() * i.into(),
 		);
 	}
 
-	update_vesting_schedules {
-		let i in 1 .. <T>::MaxVestingSchedules::get();
+	#[benchmark]
+	fn update_vesting_schedules(i: Linear<1, { T::MaxVestingSchedules::get() }>) {
+		let mut schedule = schedule::<T>(0, 2, 3, <T>::MinVestedTransfer::get());
 
-		let mut schedule = schedule::<T>(
-			0, 2,3,<T>::MinVestedTransfer::get()
-		);
-
-		let to: AccountIdFor<T>= account("to", 0, SEED);
-		set_balance::<T>(to.clone(),schedule.total_amount().unwrap() * i.into());
+		let to: AccountIdFor<T> = account("to", 0, SEED);
+		set_balance::<T>(to.clone(), schedule.total_amount().unwrap() * i.into());
 		let to_lookup = lookup_of_account::<T>(to.clone());
 
 		let mut schedules = vec![];
@@ -103,17 +106,15 @@ benchmarks! {
 			schedule.start = i.into();
 			schedules.push(schedule.clone());
 		}
-	}: _(RawOrigin::Root, to_lookup, schedules)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Root, to_lookup, schedules);
+
 		assert_eq!(
 			CurrencyFor::<T>::free_balance(&to),
 			schedule.total_amount().unwrap() * i.into()
 		);
 	}
 
-	impl_benchmark_test_suite!(
-		Pallet,
-		crate::mock::new_test_ext(),
-		crate::mock::Runtime
-	);
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Runtime);
 }

--- a/pallets/ajuna-affiliates/src/benchmarking.rs
+++ b/pallets/ajuna-affiliates/src/benchmarking.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{Pallet as Affiliates, *};
-use frame_benchmarking::benchmarks_instance_pallet;
+use frame_benchmarking::v2::*;
 use frame_system::RawOrigin;
 use sp_std::prelude::*;
 
@@ -57,28 +57,41 @@ fn setup_organizer<T: Config<I>, I: 'static>(organizer: T::AccountId) {
 	T::AccountManager::set_organizer(organizer);
 }
 
-benchmarks_instance_pallet! {
-	enable_affiliator {
+#[instance_benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn enable_affiliator() {
 		let acc_1 = account::<T, I>(ACC_1);
 		let acc_2 = account::<T, I>(ACC_2);
 		let params = T::BenchmarkHelper::create_params(1);
-	}: _(RawOrigin::Signed(acc_1), Some(acc_2.clone()), params)
-	verify {
-		assert_last_event::<T, I>(Event::AccountMarkedAsAffiliatable { account: acc_2, affiliate_id: 0 })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), Some(acc_2.clone()), params);
+
+		assert_last_event::<T, I>(Event::AccountMarkedAsAffiliatable {
+			account: acc_2,
+			affiliate_id: 0,
+		});
 	}
 
-	add_affiliation {
+	#[benchmark]
+	fn add_affiliation() {
 		let acc_1 = account::<T, I>(ACC_1);
 		let acc_2 = account::<T, I>(ACC_2);
 		let acc_3 = account::<T, I>(ACC_3);
 		setup_organizer::<T, I>(acc_1.clone());
 		mark_as_affiliatable::<T, I>(&acc_3);
-	}: _(RawOrigin::Signed(acc_1.clone()), Some(acc_2.clone()), 0)
-	verify {
-		assert_last_event::<T, I>(Event::AccountAffiliated { account: acc_2, to: acc_3 })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1.clone()), Some(acc_2.clone()), 0);
+
+		assert_last_event::<T, I>(Event::AccountAffiliated { account: acc_2, to: acc_3 });
 	}
 
-	remove_affiliation {
+	#[benchmark]
+	fn remove_affiliation() {
 		let acc_1 = account::<T, I>(ACC_1);
 		setup_organizer::<T, I>(acc_1.clone());
 		mark_as_affiliatable::<T, I>(&acc_1);
@@ -89,42 +102,47 @@ benchmarks_instance_pallet! {
 		let acc_4 = account::<T, I>(ACC_4);
 		mark_as_affiliatable::<T, I>(&acc_4);
 		let acc_5 = account::<T, I>(ACC_5);
-		let key = T::WhitelistKey::get();
 		affiliate_account_to::<T, I>(&acc_1, &acc_2);
 		affiliate_account_to::<T, I>(&acc_2, &acc_3);
 		affiliate_account_to::<T, I>(&acc_3, &acc_4);
 		affiliate_account_to::<T, I>(&acc_4, &acc_5);
-	}: _(RawOrigin::Signed(acc_1.clone()), acc_5.clone())
-	verify {
-		assert_last_event::<T, I>(Event::AccountUnaffiliated { account: acc_5 })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1.clone()), acc_5.clone());
+
+		assert_last_event::<T, I>(Event::AccountUnaffiliated { account: acc_5 });
 	}
 
-	set_rule_for {
+	#[benchmark]
+	fn set_rule_for() {
 		let acc_1 = account::<T, I>(ACC_1);
 		setup_organizer::<T, I>(acc_1.clone());
 		let rule_id = T::BenchmarkHelper::create_rule_id(1);
-		let rule = FeePropagationOf::<T,I>::try_from(vec![60, 20]).expect("Should create fee propagation");
-	}: _(RawOrigin::Signed(acc_1.clone()), rule_id.clone(), rule)
-	verify {
-		assert_last_event::<T, I>(Event::RuleAdded { rule_id })
+		let rule = FeePropagationOf::<T, I>::try_from(vec![60, 20])
+			.expect("Should create fee propagation");
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1.clone()), rule_id.clone(), rule);
+
+		assert_last_event::<T, I>(Event::RuleAdded { rule_id });
 	}
 
-	clear_rule_for {
+	#[benchmark]
+	fn clear_rule_for() {
 		let acc_1 = account::<T, I>(ACC_1);
 		setup_organizer::<T, I>(acc_1.clone());
 		let rule_id = T::BenchmarkHelper::create_rule_id(1);
-		let rule = FeePropagationOf::<T,I>::try_from(vec![70, 15]).expect("Should create fee propagation");
+		let rule = FeePropagationOf::<T, I>::try_from(vec![70, 15])
+			.expect("Should create fee propagation");
 		<Affiliates<T, I> as RuleMutator<RuleIdentifierFor<T, I>, T::AffiliateMaxLevel>>::try_add_rule_for(
 			rule_id.clone(), rule
 		).expect("Should be able to add rule");
-	}: _(RawOrigin::Signed(acc_1.clone()), rule_id.clone())
-	verify {
-		assert_last_event::<T, I>(Event::RuleCleared { rule_id })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1.clone()), rule_id.clone());
+
+		assert_last_event::<T, I>(Event::RuleCleared { rule_id });
 	}
 
-	impl_benchmark_test_suite!(
-		Pallet,
-		crate::mock::new_test_ext(),
-		crate::mock::Test
-	);
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -20,7 +20,7 @@
 
 mod mock;
 
-use frame_benchmarking::benchmarks;
+use frame_benchmarking::v2::*;
 use frame_support::traits::{Currency, Get};
 use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use pallet_ajuna_awesome_avatars::{
@@ -49,107 +49,132 @@ fn assert_last_event<T: Config>(avatars_event: Event<T>) {
 	frame_system::Pallet::<T>::assert_last_event(event.into());
 }
 
-benchmarks! {
-	mint_free {
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn mint_free(n: Linear<0, { MaxAvatarsPerPlayer::get() - 6 }>) {
 		let name = "player";
 		let caller = account::<T>(name);
-		let n in 0 .. (MaxAvatarsPerPlayer::get() - 6);
-		create_avatars::<T>(caller.clone(), n)?;
+		create_avatars::<T>(caller.clone(), n).expect("Should create avatars");
 
 		PlayerConfigs::<T>::mutate(&caller, |account| account.free_mints = MintCount::MAX);
 
-		let mint_option = MintOption { payment: MintPayment::Free, pack_size: MintPackSize::Six,
-			pack_type: PackType::Material, };
-	}: mint(RawOrigin::Signed(caller.clone()), mint_option)
-	verify {
-		let n = n as usize;
+		let mint_option = MintOption {
+			payment: MintPayment::Free,
+			pack_size: MintPackSize::Six,
+			pack_type: PackType::Material,
+		};
+
+		#[extrinsic_call]
+		mint(RawOrigin::Signed(caller.clone()), mint_option);
+
+		let i = n as usize;
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
-		let avatar_ids = Owners::<T>::get(caller, season_id)[n..(n + 6)].to_vec();
-		assert_last_event::<T>(Event::AvatarsMinted { avatar_ids })
+		let avatar_ids = Owners::<T>::get(caller, season_id)[i..(i + 6)].to_vec();
+		assert_last_event::<T>(Event::AvatarsMinted { avatar_ids });
 	}
 
-	mint_normal {
+	#[benchmark]
+	fn mint_normal(n: Linear<0, { MaxAvatarsPerPlayer::get() - 6 }>) {
 		let name = "player";
 		let caller = account::<T>(name);
 
-		let n in 0 .. (MaxAvatarsPerPlayer::get() - 6);
-		create_avatars::<T>(caller.clone(), n)?;
+		create_avatars::<T>(caller.clone(), n).expect("Should create avatars");
 
 		let season = Seasons::<T>::get(CurrentSeasonStatus::<T>::get().season_id).unwrap();
 		let mint_fee = season.fee.mint.fee_for(&MintPackSize::Six);
 		let ed = CurrencyOf::<T>::minimum_balance();
 		CurrencyOf::<T>::make_free_balance_be(&caller, mint_fee + ed);
 
-		let mint_option = MintOption { payment: MintPayment::Normal, pack_size: MintPackSize::Six,
-			pack_type: PackType::Material };
-	}: mint(RawOrigin::Signed(caller.clone()), mint_option)
-	verify {
-		let n = n as usize;
+		let mint_option = MintOption {
+			payment: MintPayment::Normal,
+			pack_size: MintPackSize::Six,
+			pack_type: PackType::Material,
+		};
+
+		#[extrinsic_call]
+		mint(RawOrigin::Signed(caller.clone()), mint_option);
+
+		let i = n as usize;
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
-		let avatar_ids = Owners::<T>::get(caller, season_id)[n..(n + 6)].to_vec();
-		assert_last_event::<T>(Event::AvatarsMinted { avatar_ids })
+		let avatar_ids = Owners::<T>::get(caller, season_id)[i..(i + 6)].to_vec();
+		assert_last_event::<T>(Event::AvatarsMinted { avatar_ids });
 	}
 
-	forge {
+	#[benchmark]
+	fn forge(n: Linear<5, { MaxAvatarsPerPlayer::get() - 10 }>) {
 		let name = "player";
 		let player = account::<T>(name);
-		let n in 5 .. (MaxAvatarsPerPlayer::get() - 10);
-		create_avatars::<T>(player.clone(), n)?;
+		create_avatars::<T>(player.clone(), n).expect("Should create avatars");
 
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_ids = Owners::<T>::get(&player, season_id);
 		let avatar_id = avatar_ids[0];
-		let (_owner, original_avatar) = Avatars::<T>::get(avatar_id).unwrap();
-	}: _(RawOrigin::Signed(player), avatar_id, avatar_ids[1..5].to_vec())
-	verify {
-		let (_owner, upgraded_avatar) = Avatars::<T>::get(avatar_id).unwrap();
+		let (_, original_avatar) = Avatars::<T>::get(avatar_id).unwrap();
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(player), avatar_id, avatar_ids[1..5].to_vec());
+
+		let (_, upgraded_avatar) = Avatars::<T>::get(avatar_id).unwrap();
 		let original_tiers = original_avatar.dna.into_iter().map(|x| x >> 4);
 		let upgraded_tiers = upgraded_avatar.dna.into_iter().map(|x| x >> 4);
-		let upgraded_components = original_tiers.zip(upgraded_tiers).fold(
-			0, |mut count, (lhs, rhs)| {
+		let upgraded_components =
+			original_tiers.zip(upgraded_tiers).fold(0, |mut count, (lhs, rhs)| {
 				if lhs != rhs {
-					count+=1;
+					count += 1;
 				}
 				count
-			}
-		);
-		assert_last_event::<T>(Event::AvatarsForged { avatar_ids: vec![(avatar_id, upgraded_components)] })
+			});
+		assert_last_event::<T>(Event::AvatarsForged {
+			avatar_ids: vec![(avatar_id, upgraded_components)],
+		});
 	}
 
-	transfer_avatar_normal {
+	#[benchmark]
+	fn transfer_avatar_normal(n: Linear<1, { MaxAvatarsPerPlayer::get() }>) {
 		let from = account::<T>("from");
 		let to = account::<T>("to");
-		let n in 1 .. MaxAvatarsPerPlayer::get();
-		create_avatars::<T>(from.clone(), MaxAvatarsPerPlayer::get())?;
-		create_avatars::<T>(to.clone(), MaxAvatarsPerPlayer::get() - n)?;
+		create_avatars::<T>(from.clone(), MaxAvatarsPerPlayer::get())
+			.expect("Should create avatars");
+		create_avatars::<T>(to.clone(), MaxAvatarsPerPlayer::get() - n)
+			.expect("Should create avatars");
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_id = Owners::<T>::get(&from, season_id)[n as usize - 1];
 
 		let Season { fee, .. } = Seasons::<T>::get(season_id).unwrap();
 		CurrencyOf::<T>::make_free_balance_be(&from, fee.transfer_avatar);
-	}: transfer_avatar(RawOrigin::Signed(from.clone()), to.clone(), avatar_id)
-	verify {
-		assert_last_event::<T>(Event::AvatarTransferred { from, to, avatar_id })
+
+		#[extrinsic_call]
+		transfer_avatar(RawOrigin::Signed(from.clone()), to.clone(), avatar_id);
+
+		assert_last_event::<T>(Event::AvatarTransferred { from, to, avatar_id });
 	}
 
-	transfer_avatar_organizer {
+	#[benchmark]
+	fn transfer_avatar_organizer(n: Linear<1, { MaxAvatarsPerPlayer::get() }>) {
 		let organizer = account::<T>("organizer");
 		let to = account::<T>("to");
-		let n in 1 .. MaxAvatarsPerPlayer::get();
-		create_avatars::<T>(organizer.clone(), MaxAvatarsPerPlayer::get())?;
-		create_avatars::<T>(to.clone(), MaxAvatarsPerPlayer::get() - n)?;
+		create_avatars::<T>(organizer.clone(), MaxAvatarsPerPlayer::get())
+			.expect("Should create avatars");
+		create_avatars::<T>(to.clone(), MaxAvatarsPerPlayer::get() - n)
+			.expect("Should create avatars");
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_id = Owners::<T>::get(&organizer, season_id)[n as usize - 1];
 
 		let Season { fee, .. } = Seasons::<T>::get(season_id).unwrap();
 		CurrencyOf::<T>::make_free_balance_be(&organizer, fee.transfer_avatar);
-	}: transfer_avatar(RawOrigin::Signed(organizer.clone()), to.clone(), avatar_id)
-	verify {
-		assert_last_event::<T>(Event::AvatarTransferred { from: organizer, to, avatar_id })
+
+		#[extrinsic_call]
+		transfer_avatar(RawOrigin::Signed(organizer.clone()), to.clone(), avatar_id);
+
+		assert_last_event::<T>(Event::AvatarTransferred { from: organizer, to, avatar_id });
 	}
 
-	transfer_free_mints {
-		create_seasons::<T>(1)?;
+	#[benchmark]
+	fn transfer_free_mints() {
+		create_seasons::<T>(1).expect("Should create seasons");
 		let from = account::<T>("from");
 		let to = account::<T>("to");
 		let GlobalConfig { freemint_transfer, .. } = GlobalConfigs::<T>::get();
@@ -161,41 +186,51 @@ benchmarks! {
 			stats.forged = 1;
 		});
 		PlayerConfigs::<T>::mutate(&from, |account| account.free_mints = MintCount::MAX);
-	}: _(RawOrigin::Signed(from.clone()), to.clone(), how_many)
-	verify {
-		assert_last_event::<T>(Event::FreeMintsTransferred { from, to, how_many })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(from.clone()), to.clone(), how_many);
+
+		assert_last_event::<T>(Event::FreeMintsTransferred { from, to, how_many });
 	}
 
-	set_price {
+	#[benchmark]
+	fn set_price() {
 		let name = "player";
 		let caller = account::<T>(name);
-		create_avatars::<T>(caller.clone(), MaxAvatarsPerPlayer::get())?;
+		create_avatars::<T>(caller.clone(), MaxAvatarsPerPlayer::get())
+			.expect("Should create avatars");
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_id = Owners::<T>::get(&caller, season_id)[0];
 		let price = BalanceOf::<T>::unique_saturated_from(u128::MAX);
-	}: _(RawOrigin::Signed(caller), avatar_id, price)
-	verify {
-		assert_last_event::<T>(Event::AvatarPriceSet { avatar_id, price })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(caller), avatar_id, price);
+
+		assert_last_event::<T>(Event::AvatarPriceSet { avatar_id, price });
 	}
 
-	remove_price {
+	#[benchmark]
+	fn remove_price() {
 		let name = "player";
 		let caller = account::<T>(name);
-		create_avatars::<T>(caller.clone(), MaxAvatarsPerPlayer::get())?;
+		create_avatars::<T>(caller.clone(), MaxAvatarsPerPlayer::get())
+			.expect("Should create avatars");
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_id = Owners::<T>::get(&caller, season_id)[0];
 		Trade::<T>::insert(season_id, avatar_id, BalanceOf::<T>::unique_saturated_from(u128::MAX));
-	}: _(RawOrigin::Signed(caller), avatar_id)
-	verify {
-		assert_last_event::<T>(Event::AvatarPriceUnset { avatar_id })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(caller), avatar_id);
+
+		assert_last_event::<T>(Event::AvatarPriceUnset { avatar_id });
 	}
 
-	buy {
+	#[benchmark]
+	fn buy(n: Linear<1, { MaxAvatarsPerPlayer::get() }>) {
 		let (buyer_name, seller_name) = ("buyer", "seller");
 		let (buyer, seller) = (account::<T>(buyer_name), account::<T>(seller_name));
-		let n in 1 .. MaxAvatarsPerPlayer::get();
-		create_avatars::<T>(buyer.clone(), n - 1)?;
-		create_avatars::<T>(seller.clone(), n)?;
+		create_avatars::<T>(buyer.clone(), n - 1).expect("Should create avatars");
+		create_avatars::<T>(seller.clone(), n).expect("Should create avatars");
 
 		let ed = CurrencyOf::<T>::minimum_balance();
 		let current_season_id = CurrentSeasonStatus::<T>::get().season_id;
@@ -211,42 +246,60 @@ benchmarks! {
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_id = Owners::<T>::get(&seller, season_id)[0];
 		Trade::<T>::insert(season_id, avatar_id, sell_fee);
-	}: _(RawOrigin::Signed(buyer.clone()), avatar_id)
-	verify {
-		assert_last_event::<T>(Event::AvatarTraded { avatar_id, from: seller, to: buyer, price: sell_fee })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(buyer.clone()), avatar_id);
+
+		assert_last_event::<T>(Event::AvatarTraded {
+			avatar_id,
+			from: seller,
+			to: buyer,
+			price: sell_fee,
+		});
 	}
 
-	upgrade_storage {
-		create_seasons::<T>(1)?;
+	#[benchmark]
+	fn upgrade_storage() {
+		create_seasons::<T>(1).expect("Should create seasons");
 		let player = account::<T>("player");
 		let current_season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let season = Seasons::<T>::get(current_season_id).unwrap();
 		let ed = CurrencyOf::<T>::minimum_balance();
 		CurrencyOf::<T>::make_free_balance_be(&player, season.fee.upgrade_storage + ed);
-	}: _(RawOrigin::Signed(player.clone()), None, None)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(player.clone()), None, None);
+
 		assert_last_event::<T>(Event::StorageTierUpgraded {
-			account: player, season_id: current_season_id,
-		})
+			account: player,
+			season_id: current_season_id,
+		});
 	}
 
-	set_organizer {
+	#[benchmark]
+	fn set_organizer() {
 		let organizer = account::<T>("organizer");
-	}: _(RawOrigin::Root, organizer.clone())
-	verify {
-		assert_last_event::<T>(Event::<T>::OrganizerSet { organizer })
+
+		#[extrinsic_call]
+		_(RawOrigin::Root, organizer.clone());
+
+		assert_last_event::<T>(Event::<T>::OrganizerSet { organizer });
 	}
 
-	set_treasurer {
+	#[benchmark]
+	fn set_treasurer() {
 		let season_id = 369;
 		let treasurer = account::<T>("treasurer");
-	}: _(RawOrigin::Root, season_id, treasurer.clone())
-	verify {
-		assert_last_event::<T>(Event::TreasurerSet { season_id, treasurer })
+
+		#[extrinsic_call]
+		_(RawOrigin::Root, season_id, treasurer.clone());
+
+		assert_last_event::<T>(Event::TreasurerSet { season_id, treasurer });
 	}
 
-	claim_treasury {
-		create_seasons::<T>(3)?;
+	#[benchmark]
+	fn claim_treasury() {
+		create_seasons::<T>(3).expect("Should create seasons");
 		let season_id = 1;
 		let treasurer = account::<T>("treasurer");
 		let amount = 1_000_000_000_000_u64.unique_saturated_into();
@@ -254,12 +307,15 @@ benchmarks! {
 		Treasury::<T>::mutate(season_id, |balance| balance.saturating_accrue(amount));
 		CurrencyOf::<T>::deposit_creating(&AAvatars::<T>::treasury_account_id(), amount);
 		CurrencyOf::<T>::make_free_balance_be(&treasurer, CurrencyOf::<T>::minimum_balance());
-	}: _(RawOrigin::Signed(treasurer.clone()), season_id)
-	verify {
-		assert_last_event::<T>(Event::TreasuryClaimed { season_id, treasurer, amount })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(treasurer.clone()), season_id);
+
+		assert_last_event::<T>(Event::TreasuryClaimed { season_id, treasurer, amount });
 	}
 
-	set_season {
+	#[benchmark]
+	fn set_season() {
 		let organizer = account::<T>("organizer");
 		Organizer::<T>::put(&organizer);
 
@@ -311,23 +367,41 @@ benchmarks! {
 			start: BlockNumberFor::<T>::from(u32::MAX - 1),
 			end: BlockNumberFor::<T>::from(u32::MAX),
 		};
-		let trade_filters = TradeFilters(sp_runtime::BoundedVec::try_from(vec![
-			u32::from_le_bytes([0x11, 0x07, 0x00, 0x00]), // CrazyDude pet
-			u32::from_le_bytes([0x12, 0x36, 0x00, 0x00]), // GiantWoodStick armor front pet part
-			u32::from_le_bytes([0x25, 0x07, 0x00, 0xFF]), // Metals of quantity 255
-			u32::from_le_bytes([0x25, 0x02, 0x00, 0x00]), // Electronics of any quantity
-			u32::from_le_bytes([0x30, 0x00, 0x00, 0x00]), // Any Essence
-			u32::from_le_bytes([0x41, 0x00, 0x00, 0xF0]), // ArmorBase of quantity 240
-			u32::from_le_bytes([0x45, 0x00, 0x00, 0x0F]), // WeaponVersion1 of quantity 15
-		]).expect("Should create vec"));
-	}: _(RawOrigin::Signed(organizer), season_id, Some(season.clone()), Some(season_meta.clone()), Some(season_schedule.clone()), Some(trade_filters.clone()))
-	verify {
+		let trade_filters = TradeFilters(
+			sp_runtime::BoundedVec::try_from(vec![
+				u32::from_le_bytes([0x11, 0x07, 0x00, 0x00]), // CrazyDude pet
+				u32::from_le_bytes([0x12, 0x36, 0x00, 0x00]), /* GiantWoodStick armor front pet
+				                                               * part */
+				u32::from_le_bytes([0x25, 0x07, 0x00, 0xFF]), // Metals of quantity 255
+				u32::from_le_bytes([0x25, 0x02, 0x00, 0x00]), // Electronics of any quantity
+				u32::from_le_bytes([0x30, 0x00, 0x00, 0x00]), // Any Essence
+				u32::from_le_bytes([0x41, 0x00, 0x00, 0xF0]), // ArmorBase of quantity 240
+				u32::from_le_bytes([0x45, 0x00, 0x00, 0x0F]), // WeaponVersion1 of quantity 15
+			])
+			.expect("Should create vec"),
+		);
+
+		#[extrinsic_call]
+		_(
+			RawOrigin::Signed(organizer),
+			season_id,
+			Some(season.clone()),
+			Some(season_meta.clone()),
+			Some(season_schedule.clone()),
+			Some(trade_filters.clone()),
+		);
+
 		assert_last_event::<T>(Event::UpdatedSeason {
-			season_id, season: Some(season), meta: Some(season_meta), schedule: Some(season_schedule), trade_filters: Some(trade_filters)
-		})
+			season_id,
+			season: Some(season),
+			meta: Some(season_meta),
+			schedule: Some(season_schedule),
+			trade_filters: Some(trade_filters),
+		});
 	}
 
-	update_global_config {
+	#[benchmark]
+	fn update_global_config() {
 		let organizer = account::<T>("organizer");
 		Organizer::<T>::put(&organizer);
 
@@ -338,9 +412,7 @@ benchmarks! {
 				free_mint_fee_multiplier: MintCount::MAX,
 			},
 			forge: ForgeConfig { open: true },
-			avatar_transfer: AvatarTransferConfig {
-				open: true,
-			},
+			avatar_transfer: AvatarTransferConfig { open: true },
 			freemint_transfer: FreemintTransferConfig {
 				mode: FreeMintTransferMode::Open,
 				free_mint_transfer_fee: MintCount::MAX,
@@ -350,59 +422,61 @@ benchmarks! {
 			nft_transfer: NftTransferConfig { open: true },
 			affiliate_config: AffiliateConfig::default(),
 		};
-	}: _(RawOrigin::Signed(organizer), config.clone())
-	verify {
-		assert_last_event::<T>(Event::UpdatedGlobalConfig(config))
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(organizer), config.clone());
+
+		assert_last_event::<T>(Event::UpdatedGlobalConfig(config));
 	}
 
-	set_free_mints {
+	#[benchmark]
+	fn set_free_mints() {
 		let organizer = account::<T>("organizer");
 		Organizer::<T>::put(&organizer);
 
 		let target = account::<T>("target");
 		let how_many = MintCount::MAX;
-	}: _(RawOrigin::Signed(organizer), target.clone(), how_many)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(organizer), target.clone(), how_many);
+
 		assert_last_event::<T>(Event::FreeMintsSet { target, how_many });
 	}
 
-	lock_avatar {
+	#[benchmark]
+	fn lock_avatar(n: Linear<1, { MaxAvatarsPerPlayer::get() }>) {
 		let name = "player";
 		let player = account::<T>(name);
-		let n in 1 .. MaxAvatarsPerPlayer::get();
-		create_avatars::<T>(player.clone(), n)?;
+		create_avatars::<T>(player.clone(), n).expect("Should create avatars");
 
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_ids = Owners::<T>::get(&player, season_id);
 		let avatar_id = avatar_ids[avatar_ids.len() - 1];
 
-		let organizer = account::<T>("organizer");
-	}: _(RawOrigin::Signed(player), avatar_id)
-	verify {
-		assert_last_event::<T>(Event::AvatarLocked { avatar_id })
+		#[extrinsic_call]
+		_(RawOrigin::Signed(player), avatar_id);
+
+		assert_last_event::<T>(Event::AvatarLocked { avatar_id });
 	}
 
-	unlock_avatar {
+	#[benchmark]
+	fn unlock_avatar(n: Linear<1, { MaxAvatarsPerPlayer::get() }>) {
 		let name = "player";
 		let player = account::<T>(name);
-		let n in 1 .. MaxAvatarsPerPlayer::get();
-		create_avatars::<T>(player.clone(), n)?;
+		create_avatars::<T>(player.clone(), n).expect("Should create avatars");
 
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_ids = Owners::<T>::get(&player, season_id);
 		let avatar_id = avatar_ids[avatar_ids.len() - 1];
 
-		let organizer = account::<T>("organizer");
+		AAvatars::<T>::lock_avatar(RawOrigin::Signed(player.clone()).into(), avatar_id)
+			.expect("Should lock avatar");
 
-		AAvatars::<T>::lock_avatar(RawOrigin::Signed(player.clone()).into(), avatar_id)?;
-	}: _(RawOrigin::Signed(player), avatar_id)
-	verify {
-		assert_last_event::<T>(Event::AvatarUnlocked { avatar_id })
+		#[extrinsic_call]
+		_(RawOrigin::Signed(player), avatar_id);
+
+		assert_last_event::<T>(Event::AvatarUnlocked { avatar_id });
 	}
 
-	impl_benchmark_test_suite!(
-		Pallet,
-		crate::mock::new_test_ext(),
-		crate::mock::Runtime
-	);
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Runtime);
 }

--- a/pallets/ajuna-battle-mogs/src/benchmarking.rs
+++ b/pallets/ajuna-battle-mogs/src/benchmarking.rs
@@ -19,7 +19,7 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use crate::{Config as BattleMogsConfig, *};
-use frame_benchmarking::{benchmarks, whitelist_account, whitelisted_caller};
+use frame_benchmarking::v2::*;
 use frame_system::RawOrigin;
 use sp_runtime::traits::UniqueSaturatedInto;
 
@@ -47,123 +47,202 @@ fn force_mogwai_rarity<T: Config>(mogwai_id: &MogwaiIdOf<T>, rarity: RarityType)
 	});
 }
 
-benchmarks! {
-	set_organizer {
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn set_organizer() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 20_000_000_u32.into());
-	}: _(RawOrigin::Root, origin.clone())
-	verify {
-		assert_eq!(Pallet::<T>::organizer(), Some(origin))
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+
+		#[extrinsic_call]
+		_(RawOrigin::Root, origin.clone());
+
+		assert_eq!(Pallet::<T>::organizer(), Some(origin));
 	}
 
-	update_config {
+	#[benchmark]
+	fn update_config() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 20_000_000_u32.into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())
+			.expect("Organizer should be set");
 		let expected_config: [u8; 10] = [0, 1, 0, 0, 0, 0, 0, 0, 0, 0];
-	}: _(RawOrigin::Signed(origin.clone()), 1, Some(1))
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin.clone()), 1, Some(1));
+
 		assert_eq!(Pallet::<T>::account_config(origin), Some(expected_config));
 	}
 
-	set_price {
+	#[benchmark]
+	fn set_price() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 20_000_000_u32.into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())
+			.expect("Organizer should be set");
 
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())?;
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())
+			.expect("Should create mogwai");
 		let mogwai_id = Mogwais::<T>::iter_values().next().unwrap().id;
 
 		let price = 1000_u32.into();
-	}: _(RawOrigin::Signed(origin), mogwai_id, price)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin), mogwai_id, price);
+
 		assert_eq!(Pallet::<T>::mogwai_prices(mogwai_id), Some(price));
 	}
 
-	remove_price {
+	#[benchmark]
+	fn remove_price() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 20_000_000_u32.into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())
+			.expect("Organizer should be set");
 
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())?;
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())
+			.expect("Should create mogwai");
 		let mogwai_id = Mogwais::<T>::iter_values().next().unwrap().id;
 		let price = 1000_u32.into();
-		Pallet::<T>::set_price(RawOrigin::Signed(origin.clone()).into(), mogwai_id, price)?;
-	}: _(RawOrigin::Signed(origin), mogwai_id)
-	verify {
+		Pallet::<T>::set_price(RawOrigin::Signed(origin.clone()).into(), mogwai_id, price)
+			.expect("Should set price");
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin), mogwai_id);
+
 		assert_eq!(Pallet::<T>::mogwai_prices(mogwai_id), None);
 	}
 
-	create_mogwai {
+	#[benchmark]
+	fn create_mogwai() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 20_000_000_u32.into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())?;
-	}: _(RawOrigin::Signed(origin.clone()))
-	verify {
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())
+			.expect("Organizer should be set");
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin.clone()));
+
 		assert_eq!(Pallet::<T>::owned_mogwais_count(origin), 1_u64);
 	}
 
-	remove_mogwai {
+	#[benchmark]
+	fn remove_mogwai() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 20_000_000_u32.into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())
+			.expect("Organizer should be set");
 
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())?;
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())
+			.expect("Should create mogwai");
 		let mogwai_id = Mogwais::<T>::iter_values().next().unwrap().id;
-	}: _(RawOrigin::Signed(origin), mogwai_id)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin), mogwai_id);
+
 		assert_eq!(Pallet::<T>::all_mogwais_count(), 0_u64);
 	}
 
-	transfer {
+	#[benchmark]
+	fn transfer() {
 		let origin_1: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin_1, T::Currency::minimum_balance() * 20_000_000_u32.into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin_1.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin_1,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin_1.clone())
+			.expect("Should set organizer");
 		let origin_2: T::AccountId = account::<T>("origin_2");
 		whitelist_account!(origin_2);
 
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin_1.clone()).into())?;
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin_1.clone()).into())
+			.expect("Should create mogwai");
 		let mogwai_id = Mogwais::<T>::iter_values().next().unwrap().id;
-	}: _(RawOrigin::Signed(origin_1.clone()), origin_2.clone(), mogwai_id)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin_1.clone()), origin_2.clone(), mogwai_id);
+
 		assert_eq!(Pallet::<T>::owned_mogwais_count(origin_1), 0_u64);
 		assert_eq!(Pallet::<T>::owned_mogwais_count(origin_2), 1_u64);
 	}
 
-	hatch_mogwai {
+	#[benchmark]
+	fn hatch_mogwai() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 20_000_000_u32.into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())
+			.expect("Organizer should be set");
 
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())?;
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())
+			.expect("Should create mogwai");
 		let mogwai_id = Mogwais::<T>::iter_values().next().unwrap().id;
 
 		frame_system::Pallet::<T>::set_block_number(1000_u32.into());
-	}: _(RawOrigin::Signed(origin.clone()), mogwai_id)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin.clone()), mogwai_id);
+
 		assert_eq!(Pallet::<T>::mogwai(mogwai_id).unwrap().phase, PhaseType::Hatched);
 	}
 
-	sacrifice {
+	#[benchmark]
+	fn sacrifice() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 20_000_000_u32.into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())
+			.expect("Organizer should be set");
 
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())?;
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())
+			.expect("Should create mogwai");
 		let mogwai_id = Mogwais::<T>::iter_values().next().unwrap().id;
 		force_hatch_mogwai::<T>(&mogwai_id);
-	}: _(RawOrigin::Signed(origin.clone()), mogwai_id)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin.clone()), mogwai_id);
+
 		assert_eq!(Pallet::<T>::mogwai(mogwai_id), None);
 	}
 
-	sacrifice_into {
+	#[benchmark]
+	fn sacrifice_into() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 20_000_000_u32.into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())
+			.expect("Organizer should be set");
 
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())?;
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())?;
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())
+			.expect("Should create mogwai");
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())
+			.expect("Should create mogwai");
 		let mut mogwai_iter = Mogwais::<T>::iter_values();
 		let mogwai_id_1 = mogwai_iter.next().unwrap().id;
 		let mogwai_id_2 = mogwai_iter.next().unwrap().id;
@@ -171,54 +250,83 @@ benchmarks! {
 		force_hatch_mogwai::<T>(&mogwai_id_2);
 		force_mogwai_rarity::<T>(&mogwai_id_1, RarityType::Epic);
 		force_mogwai_rarity::<T>(&mogwai_id_2, RarityType::Epic);
-	}: _(RawOrigin::Signed(origin.clone()), mogwai_id_1, mogwai_id_2)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin.clone()), mogwai_id_1, mogwai_id_2);
+
 		assert_eq!(Pallet::<T>::mogwai(mogwai_id_1), None);
 		assert!(Pallet::<T>::mogwai(mogwai_id_2).is_some());
 	}
 
-	buy_mogwai {
+	#[benchmark]
+	fn buy_mogwai() {
 		let origin_1: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin_1, T::Currency::minimum_balance() * 20_000_000_u32.into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin_1.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin_1,
+			T::Currency::minimum_balance() * 20_000_000_u32.into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin_1.clone())
+			.expect("Should set organizer");
 		let origin_2: T::AccountId = account::<T>("origin_2");
 		whitelist_account!(origin_2);
 
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin_1.clone()).into())?;
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin_1.clone()).into())
+			.expect("Should create mogwai");
 		let mogwai_id = Mogwais::<T>::iter_values().next().unwrap().id;
 
 		let price = 1000_u32.into();
-		Pallet::<T>::set_price(RawOrigin::Signed(origin_1.clone()).into(), mogwai_id, price)?;
-	}: _(RawOrigin::Signed(origin_2.clone()), mogwai_id, price)
-	verify {
+		Pallet::<T>::set_price(RawOrigin::Signed(origin_1.clone()).into(), mogwai_id, price)
+			.expect("Should set price");
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin_2.clone()), mogwai_id, price);
+
 		assert_eq!(Pallet::<T>::owned_mogwais_count(origin_1), 0_u64);
 		assert_eq!(Pallet::<T>::owned_mogwais_count(origin_2), 1_u64);
 	}
 
-	morph_mogwai {
+	#[benchmark]
+	fn morph_mogwai() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 10_000_000_000_u64.unique_saturated_into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 10_000_000_000_u64.unique_saturated_into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())
+			.expect("Organizer should be set");
 
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())?;
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())
+			.expect("Should create mogwai");
 		let mogwai_id = Mogwais::<T>::iter_values().next().unwrap().id;
 		force_hatch_mogwai::<T>(&mogwai_id);
-	}: _(RawOrigin::Signed(origin.clone()), mogwai_id)
 
-	breed_mogwai {
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin.clone()), mogwai_id);
+	}
+
+	#[benchmark]
+	fn breed_mogwai() {
 		let origin: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&origin, T::Currency::minimum_balance() * 10_000_000_000_u64.unique_saturated_into());
-		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())?;
+		T::Currency::make_free_balance_be(
+			&origin,
+			T::Currency::minimum_balance() * 10_000_000_000_u64.unique_saturated_into(),
+		);
+		Pallet::<T>::set_organizer(RawOrigin::Root.into(), origin.clone())
+			.expect("Organizer should be set");
 
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())?;
-		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())?;
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())
+			.expect("Should create mogwai");
+		Pallet::<T>::create_mogwai(RawOrigin::Signed(origin.clone()).into())
+			.expect("Should create mogwai");
 		let mut mogwai_iter = Mogwais::<T>::iter_values();
 		let mogwai_id_1 = mogwai_iter.next().unwrap().id;
 		let mogwai_id_2 = mogwai_iter.next().unwrap().id;
 		force_hatch_mogwai::<T>(&mogwai_id_1);
 		force_hatch_mogwai::<T>(&mogwai_id_2);
-	}: _(RawOrigin::Signed(origin.clone()), mogwai_id_1, mogwai_id_2)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(origin.clone()), mogwai_id_1, mogwai_id_2);
+
 		assert_eq!(Pallet::<T>::all_mogwais_count(), 3_u64);
 	}
 

--- a/pallets/ajuna-board/src/benchmarking.rs
+++ b/pallets/ajuna-board/src/benchmarking.rs
@@ -19,7 +19,7 @@ use crate::{
 	dot4gravity::{Coordinates, Side, Turn},
 	Pallet as AjunaBoard,
 };
-use frame_benchmarking::{account, benchmarks};
+use frame_benchmarking::v2::*;
 use frame_support::assert_ok;
 use frame_system::RawOrigin;
 use sp_runtime::SaturatedConversion;
@@ -90,30 +90,36 @@ fn create_and_play_until_win<T: Config>(players: Vec<T::AccountId>) {
 	each_player_drops_stone(win_position, lose_position);
 }
 
-benchmarks! {
-	play {
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn play() {
 		let players = players::<T::AccountId>(T::Players::get());
 		create_new_game::<T>(players.clone());
 
 		let player_1 = players.into_iter().next().unwrap();
 		let turn = Turn::DropBomb(Coordinates::new(1, 2));
-	}: play(RawOrigin::Signed(player_1), turn.into())
 
-	play_turn_until_finished {
+		#[extrinsic_call]
+		_(RawOrigin::Signed(player_1), turn.into());
+	}
+
+	#[benchmark]
+	fn play_turn_until_finished() {
 		let board_id = T::BoardId::saturated_from(0_u32);
 		let players = players::<T::AccountId>(T::Players::get());
 		create_and_play_until_win::<T>(players.clone());
 
 		let winner = players.into_iter().next().unwrap();
 		let turn = Turn::DropStone((Side::South, 1));
-	}: play(RawOrigin::Signed(winner.clone()), turn.into())
-	verify {
+
+		#[extrinsic_call]
+		play(RawOrigin::Signed(winner.clone()), turn.into());
+
 		assert_last_event::<T>(Event::GameFinished { board_id, winner }.into());
 	}
 
-	impl_benchmark_test_suite!(
-		AjunaBoard,
-		crate::mock::new_test_ext(),
-		crate::mock::Test,
-	)
+	impl_benchmark_test_suite!(AjunaBoard, crate::mock::new_test_ext(), crate::mock::Test,);
 }

--- a/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
+++ b/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
@@ -19,7 +19,7 @@
 
 mod mock;
 
-use frame_benchmarking::benchmarks;
+use frame_benchmarking::v2::*;
 use frame_support::{
 	pallet_prelude::*,
 	traits::{
@@ -101,19 +101,20 @@ fn assert_last_event<T: Config>(avatars_event: Event<T>) {
 
 fn create_creator<T: Config>(reward_item: Option<Vec<u16>>) -> Result<T::AccountId, DispatchError> {
 	let creator = account::<T>("creator");
-	create_contract_collection::<T>(&creator)?; // reserve CONTRACT_COLLECTION
-	create_collections::<T>(&creator, 1)?; // reserve REWARD_COLLECTION
+	create_contract_collection::<T>(&creator).expect("Account should be created"); // reserve CONTRACT_COLLECTION
+	create_collections::<T>(&creator, 1).expect("Account should be created"); // reserve REWARD_COLLECTION
 	if let Some(item_ids) = reward_item {
 		item_ids
 			.into_iter()
-			.try_for_each(|item_id| mint_item::<T>(&creator, REWARD_COLLECTION, item_id))?;
+			.try_for_each(|item_id| mint_item::<T>(&creator, REWARD_COLLECTION, item_id))
+			.expect("Account should be created");
 	}
 	Creator::<T>::put(&creator);
 	Ok(creator)
 }
 
 fn create_contract_collection<T: Config>(creator: &T::AccountId) -> DispatchResult {
-	create_collection::<T>(creator)?;
+	create_collection::<T>(creator).expect("Account should be created");
 	ContractCollectionId::<T>::put(CollectionIdOf::<T>::from(CONTRACT_COLLECTION));
 	Ok(())
 }
@@ -132,7 +133,8 @@ fn create_collection<T: Config>(owner: &T::AccountId) -> DispatchResult {
 			max_supply: Default::default(),
 			mint_settings: Default::default(),
 		},
-	)?;
+	)
+	.expect("Account should be created");
 	Ok(())
 }
 
@@ -157,7 +159,8 @@ fn accept_contract<T: Config>(
 	contract_id: ItemIdOf<T>,
 	mode: Mode,
 ) -> DispatchResult {
-	let (stakes, fees) = stakes_and_fees::<T>(num_stake_clauses, num_fee_clauses, &staker, mode)?;
+	let (stakes, fees) = stakes_and_fees::<T>(num_stake_clauses, num_fee_clauses, &staker, mode)
+		.expect("Account should be created");
 	pallet_ajuna_nft_staking::Pallet::<T>::accept(
 		RawOrigin::Signed(staker).into(),
 		contract_id,
@@ -176,7 +179,8 @@ fn mint_item<T: Config>(owner: &T::AccountId, collection_id: u16, item_id: u16) 
 		owner,
 		&ItemConfig::default(),
 		false,
-	)?;
+	)
+	.expect("Account should be created");
 	Ok(())
 }
 
@@ -193,7 +197,8 @@ fn set_attribute<T: Config>(
 		item_id,
 		&[key],
 		&[value],
-	)?;
+	)
+	.expect("Account should be created");
 	Ok(())
 }
 
@@ -209,8 +214,9 @@ fn stakes_and_fees<T: Config>(
 	for i in 0..num_stake_clauses {
 		let item_id = i as u16;
 		let attr_key = i;
-		mint_item::<T>(who, stake_collection, item_id)?;
-		set_attribute::<T>(stake_collection, item_id, (attr_key as u8) * 3, ATTRIBUTE_VALUE)?;
+		mint_item::<T>(who, stake_collection, item_id).expect("Account should be created");
+		set_attribute::<T>(stake_collection, item_id, (attr_key as u8) * 3, ATTRIBUTE_VALUE)
+			.expect("Account should be created");
 		stakes.push(NftId(
 			CollectionIdOf::<T>::unique_saturated_from(stake_collection),
 			T::BenchmarkHelper::item_id(item_id),
@@ -219,8 +225,9 @@ fn stakes_and_fees<T: Config>(
 	for i in num_stake_clauses..num_stake_clauses + num_fee_clauses {
 		let item_id = i as u16;
 		let attr_key = i;
-		mint_item::<T>(who, fee_collection, item_id)?;
-		set_attribute::<T>(fee_collection, item_id, (attr_key as u8) * 3, ATTRIBUTE_VALUE)?;
+		mint_item::<T>(who, fee_collection, item_id).expect("Account should be created");
+		set_attribute::<T>(fee_collection, item_id, (attr_key as u8) * 3, ATTRIBUTE_VALUE)
+			.expect("Account should be created");
 		fees.push(NftId(
 			CollectionIdOf::<T>::unique_saturated_from(fee_collection),
 			T::BenchmarkHelper::item_id(item_id),
@@ -276,221 +283,299 @@ fn contract_with<T: Config>(
 	}
 }
 
-benchmarks! {
-	set_creator {
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn set_creator() {
 		let creator = account::<T>("creator");
-	}: _(RawOrigin::Root, creator.clone())
-	verify {
-		assert_last_event::<T>(Event::CreatorSet { creator })
+
+		#[extrinsic_call]
+		_(RawOrigin::Root, creator.clone());
+
+		assert_last_event::<T>(Event::CreatorSet { creator });
 	}
 
-	set_contract_collection_id {
-		let creator = create_creator::<T>(None)?;
+	#[benchmark]
+	fn set_contract_collection_id() {
+		let creator = create_creator::<T>(None).expect("Account should be created");
 		let collection_id = CollectionIdOf::<T>::unique_saturated_from(0_u32);
 		ContractCollectionId::<T>::kill();
-	}: _(RawOrigin::Signed(creator), collection_id)
-	verify {
-		assert_last_event::<T>(Event::ContractCollectionSet { collection_id })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(creator), collection_id);
+
+		assert_last_event::<T>(Event::ContractCollectionSet { collection_id });
 	}
 
-	set_global_config {
-		let creator = create_creator::<T>(None)?;
+	#[benchmark]
+	fn set_global_config() {
+		let creator = create_creator::<T>(None).expect("Account should be created");
 		let new_config = GlobalConfig::default();
-	}: _(RawOrigin::Signed(creator), new_config)
-	verify {
-		assert_last_event::<T>(Event::SetGlobalConfig { new_config })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(creator), new_config);
+
+		assert_last_event::<T>(Event::SetGlobalConfig { new_config });
 	}
 
-	create_token_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
-		let creator = create_creator::<T>(None)?;
-		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
-			.expect("Should create rewards");
+	#[benchmark]
+	fn create_token_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
+		let creator = create_creator::<T>(None).expect("Account should be created");
+		let rewards: BoundedRewardsOf<T> =
+			BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+				.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
-	}: create(RawOrigin::Signed(creator), contract_id, contract, None, None)
-	verify {
-		assert_last_event::<T>(Event::Created { contract_id })
+
+		#[extrinsic_call]
+		create(RawOrigin::Signed(creator), contract_id, contract, None, None);
+
+		assert_last_event::<T>(Event::Created { contract_id });
 	}
 
-	create_nft_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
+	#[benchmark]
+	fn create_nft_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
 		let reward_nft_item = 123_u16;
 		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))]).expect("Should create rewards");
+		))])
+		.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
-		let creator = create_creator::<T>(Some(vec![reward_nft_item]))?;
-	}: create(RawOrigin::Signed(creator), contract_id, contract, None, None)
-	verify {
-		assert_last_event::<T>(Event::Created { contract_id })
+		let creator =
+			create_creator::<T>(Some(vec![reward_nft_item])).expect("Account should be created");
+
+		#[extrinsic_call]
+		create(RawOrigin::Signed(creator), contract_id, contract, None, None);
+
+		assert_last_event::<T>(Event::Created { contract_id });
 	}
 
-	remove_token_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
-		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
-			.expect("Should create rewards");
+	#[benchmark]
+	fn remove_token_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
+		let rewards: BoundedRewardsOf<T> =
+			BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+				.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
-		let creator = create_creator::<T>(None)?;
-		create_contract::<T>(creator.clone(), contract_id, contract)?;
-	}: remove(RawOrigin::Signed(creator), contract_id)
-	verify {
-		assert_last_event::<T>(Event::Removed { contract_id })
+		let creator = create_creator::<T>(None).expect("Account should be created");
+		create_contract::<T>(creator.clone(), contract_id, contract)
+			.expect("Contract should be created");
+
+		#[extrinsic_call]
+		remove(RawOrigin::Signed(creator), contract_id);
+
+		assert_last_event::<T>(Event::Removed { contract_id });
 	}
 
-	remove_nft_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
+	#[benchmark]
+	fn remove_nft_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
 		let reward_nft_item = 2_u16;
 		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))]).expect("Should create rewards");
+		))])
+		.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
-		let creator = create_creator::<T>(Some(vec![reward_nft_item]))?;
-		create_contract::<T>(creator.clone(), contract_id, contract)?;
-	}: remove(RawOrigin::Signed(creator), contract_id)
-	verify {
-		assert_last_event::<T>(Event::Removed { contract_id })
+		let creator =
+			create_creator::<T>(Some(vec![reward_nft_item])).expect("Account should be created");
+		create_contract::<T>(creator.clone(), contract_id, contract)
+			.expect("Contract should be created");
+
+		#[extrinsic_call]
+		remove(RawOrigin::Signed(creator), contract_id);
+
+		assert_last_event::<T>(Event::Removed { contract_id });
 	}
 
-	accept_token_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
-		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
-			.expect("Should create rewards");
+	#[benchmark]
+	fn accept_token_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
+		let rewards: BoundedRewardsOf<T> =
+			BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+				.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
-		let creator = create_creator::<T>(None)?;
-		create_contract::<T>(creator, contract_id, contract)?;
+		let creator = create_creator::<T>(None).expect("Account should be created");
+		create_contract::<T>(creator, contract_id, contract).expect("Contract should be created");
 
 		let by = account::<T>("staker");
-		create_collections::<T>(&by, 2)?;
-		let (stakes, fees) = stakes_and_fees::<T>(m, n, &by, Mode::Staker)?;
-	}: accept(RawOrigin::Signed(by.clone()), contract_id, stakes, fees)
-	verify {
-		assert_last_event::<T>(Event::Accepted { by, contract_id })
+		create_collections::<T>(&by, 2).expect("Collections should be created");
+		let (stakes, fees) = stakes_and_fees::<T>(m, n, &by, Mode::Staker)
+			.expect("Stakes and fees should be created");
+
+		#[extrinsic_call]
+		accept(RawOrigin::Signed(by.clone()), contract_id, stakes, fees);
+
+		assert_last_event::<T>(Event::Accepted { by, contract_id });
 	}
 
-	accept_nft_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
+	#[benchmark]
+	fn accept_nft_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
 		let reward_nft_item = 2_u16;
-		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(
-			NftId(REWARD_COLLECTION.unique_saturated_into(),
+		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
+			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))]).expect("Should create rewards");
+		))])
+		.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
-		let creator = create_creator::<T>(Some(vec![reward_nft_item]))?;
-		create_contract::<T>(creator, contract_id, contract)?;
+		let creator =
+			create_creator::<T>(Some(vec![reward_nft_item])).expect("Account should be created");
+		create_contract::<T>(creator, contract_id, contract).expect("Contract should be created");
 
 		let by = account::<T>("staker");
-		create_collections::<T>(&by, 2)?;
-		let (stakes, fees) = stakes_and_fees::<T>(m, n, &by, Mode::Staker)?;
-	}: accept(RawOrigin::Signed(by.clone()), contract_id, stakes, fees)
-	verify {
-		assert_last_event::<T>(Event::Accepted { by, contract_id })
+		create_collections::<T>(&by, 2).expect("Collections should be created");
+		let (stakes, fees) = stakes_and_fees::<T>(m, n, &by, Mode::Staker)
+			.expect("Stakes and fees should be created");
+
+		#[extrinsic_call]
+		accept(RawOrigin::Signed(by.clone()), contract_id, stakes, fees);
+
+		assert_last_event::<T>(Event::Accepted { by, contract_id });
 	}
 
-	cancel_token_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
-		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
-			.expect("Should create rewards");
+	#[benchmark]
+	fn cancel_token_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
+		let rewards: BoundedRewardsOf<T> =
+			BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+				.expect("Should create rewards");
 		let mut contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		contract.stake_duration = 100_u32.unique_saturated_into();
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
-		let creator = create_creator::<T>(None)?;
-		create_contract::<T>(creator, contract_id, contract)?;
+		let creator = create_creator::<T>(None).expect("Account should be created");
+		create_contract::<T>(creator, contract_id, contract).expect("Contract should be created");
 
 		let by = account::<T>("staker");
-		create_collections::<T>(&by, 2)?;
-		accept_contract::<T>(m, n, by.clone(), contract_id, Mode::Staker)?;
-	}: cancel(RawOrigin::Signed(by.clone()), contract_id)
-	verify {
-		assert_last_event::<T>(Event::Cancelled { by, contract_id })
+		create_collections::<T>(&by, 2).expect("Collections should be created");
+		accept_contract::<T>(m, n, by.clone(), contract_id, Mode::Staker)
+			.expect("Contract should be accepted");
+
+		#[extrinsic_call]
+		cancel(RawOrigin::Signed(by.clone()), contract_id);
+
+		assert_last_event::<T>(Event::Cancelled { by, contract_id });
 	}
 
-	cancel_nft_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
+	#[benchmark]
+	fn cancel_nft_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
 		let reward_nft_item = 2_u16;
 		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))]).expect("Should create rewards");
+		))])
+		.expect("Should create rewards");
 		let mut contract = contract_with::<T>(m, n, rewards, Mode::Staker);
 		contract.stake_duration = 100_u32.unique_saturated_into();
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
-		let creator = create_creator::<T>(Some(vec![reward_nft_item]))?;
-		create_contract::<T>(creator, contract_id, contract)?;
+		let creator =
+			create_creator::<T>(Some(vec![reward_nft_item])).expect("Account should be created");
+		create_contract::<T>(creator, contract_id, contract).expect("Contract should be created");
 
 		let by = account::<T>("staker");
-		create_collections::<T>(&by, 2)?;
-		accept_contract::<T>(m, n, by.clone(), contract_id, Mode::Staker)?;
-	}: cancel(RawOrigin::Signed(by.clone()), contract_id)
-	verify {
-		assert_last_event::<T>(Event::Cancelled { by, contract_id })
+		create_collections::<T>(&by, 2).expect("Collections should be created");
+		accept_contract::<T>(m, n, by.clone(), contract_id, Mode::Staker)
+			.expect("Contract should be accepted");
+
+		#[extrinsic_call]
+		cancel(RawOrigin::Signed(by.clone()), contract_id);
+
+		assert_last_event::<T>(Event::Cancelled { by, contract_id });
 	}
 
-	claim_token_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
-		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
-			.expect("Should create rewards");
+	#[benchmark]
+	fn claim_token_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
+		let rewards: BoundedRewardsOf<T> =
+			BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+				.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards.clone(), Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
-		let creator = create_creator::<T>(None)?;
-		create_contract::<T>(creator, contract_id, contract)?;
+		let creator = create_creator::<T>(None).expect("Account should be created");
+		create_contract::<T>(creator, contract_id, contract).expect("Contract should be created");
 
 		let by = account::<T>("staker");
-		create_collections::<T>(&by, 2)?;
-		accept_contract::<T>(m, n, by.clone(), contract_id, Mode::Staker)?;
-	}: claim(RawOrigin::Signed(by.clone()), contract_id, None)
-	verify {
-		assert_last_event::<T>(Event::Claimed { by, contract_id, rewards })
+		create_collections::<T>(&by, 2).expect("Collections should be created");
+		accept_contract::<T>(m, n, by.clone(), contract_id, Mode::Staker)
+			.expect("Contract should be accepted");
+
+		#[extrinsic_call]
+		claim(RawOrigin::Signed(by.clone()), contract_id, None);
+
+		assert_last_event::<T>(Event::Claimed { by, contract_id, rewards });
 	}
 
-	claim_nft_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
+	#[benchmark]
+	fn claim_nft_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
 		let reward_nft_item = 2_u16;
 		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))]).expect("Should create rewards");
+		))])
+		.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards.clone(), Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
-		let creator = create_creator::<T>(Some(vec![reward_nft_item]))?;
-		create_contract::<T>(creator, contract_id, contract)?;
+		let creator =
+			create_creator::<T>(Some(vec![reward_nft_item])).expect("Account should be created");
+		create_contract::<T>(creator, contract_id, contract).expect("Contract should be created");
 
 		let by = account::<T>("staker");
-		create_collections::<T>(&by, 2)?;
-		accept_contract::<T>(m, n, by.clone(), contract_id, Mode::Staker)?;
-	}: claim(RawOrigin::Signed(by.clone()), contract_id, None)
-	verify {
-		assert_last_event::<T>(Event::Claimed { by, contract_id, rewards })
+		create_collections::<T>(&by, 2).expect("Collections should be created");
+		accept_contract::<T>(m, n, by.clone(), contract_id, Mode::Staker)
+			.expect("Contract should be accepted");
+
+		#[extrinsic_call]
+		claim(RawOrigin::Signed(by.clone()), contract_id, None);
+
+		assert_last_event::<T>(Event::Claimed { by, contract_id, rewards });
 	}
 
-	snipe_token_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
-		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
-			.expect("Should create rewards");
+	#[benchmark]
+	fn snipe_token_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
+		let rewards: BoundedRewardsOf<T> =
+			BoundedVec::try_from(vec![Reward::Tokens(123_u64.unique_saturated_into())])
+				.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards.clone(), Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
@@ -498,35 +583,44 @@ benchmarks! {
 		sniper_contract.stake_duration = 100_u32.unique_saturated_into();
 		let sniper_contract_id = T::BenchmarkHelper::item_id(1_u16);
 
-		let creator = create_creator::<T>(None)?;
-		create_contract::<T>(creator.clone(), contract_id, contract.clone())?;
-		create_contract::<T>(creator, sniper_contract_id, sniper_contract)?;
+		let creator = create_creator::<T>(None).expect("Account should be created");
+		create_contract::<T>(creator.clone(), contract_id, contract.clone())
+			.expect("Contract should be created");
+		create_contract::<T>(creator, sniper_contract_id, sniper_contract)
+			.expect("Contract should be created");
 
 		let by = account::<T>("staker");
-		create_collections::<T>(&by, 2)?;
-		accept_contract::<T>(m, n, by, contract_id, Mode::Staker)?;
+		create_collections::<T>(&by, 2).expect("Collections should be created");
+		accept_contract::<T>(m, n, by, contract_id, Mode::Staker)
+			.expect("Contract should be accepted");
 
 		let sniper = account::<T>("sniper");
-		create_collections::<T>(&sniper, 2)?;
-		accept_contract::<T>(m, n, sniper.clone(), sniper_contract_id, Mode::Sniper)?;
+		create_collections::<T>(&sniper, 2).expect("Collections should be created");
+		accept_contract::<T>(m, n, sniper.clone(), sniper_contract_id, Mode::Sniper)
+			.expect("Contract should be accepted");
 
 		// Advance block past contract expiry.
 		frame_system::Pallet::<T>::set_block_number(
-			contract.stake_duration + contract.claim_duration + One::one()
+			contract.stake_duration + contract.claim_duration + One::one(),
 		);
-	}: snipe(RawOrigin::Signed(sniper.clone()), contract_id)
-	verify {
-		assert_last_event::<T>(Event::Sniped { by: sniper, contract_id, rewards })
+
+		#[extrinsic_call]
+		snipe(RawOrigin::Signed(sniper.clone()), contract_id);
+
+		assert_last_event::<T>(Event::Sniped { by: sniper, contract_id, rewards });
 	}
 
-	snipe_nft_reward {
-		let m in 0..T::MaxStakingClauses::get();
-		let n in 0..T::MaxFeeClauses::get();
+	#[benchmark]
+	fn snipe_nft_reward(
+		m: Linear<0, { T::MaxStakingClauses::get() }>,
+		n: Linear<0, { T::MaxFeeClauses::get() }>,
+	) {
 		let reward_nft_item = 2_u16;
 		let rewards: BoundedRewardsOf<T> = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(reward_nft_item),
-		))]).expect("Should create rewards");
+		))])
+		.expect("Should create rewards");
 		let contract = contract_with::<T>(m, n, rewards.clone(), Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 
@@ -534,35 +628,39 @@ benchmarks! {
 		let sniper_rewards = BoundedVec::try_from(vec![Reward::Nft(NftId(
 			REWARD_COLLECTION.unique_saturated_into(),
 			T::BenchmarkHelper::item_id(sniper_reward_nft_item),
-		))]).expect("Should create rewards");
+		))])
+		.expect("Should create rewards");
 		let mut sniper_contract = contract_with::<T>(m, n, sniper_rewards, Mode::Sniper);
 		sniper_contract.stake_duration = 100_u32.unique_saturated_into();
 		let sniper_contract_id = T::BenchmarkHelper::item_id(1_u16);
 
-		let creator = create_creator::<T>(Some(vec![reward_nft_item, sniper_reward_nft_item]))?;
-		create_contract::<T>(creator.clone(), contract_id, contract.clone())?;
-		create_contract::<T>(creator, sniper_contract_id, sniper_contract)?;
+		let creator = create_creator::<T>(Some(vec![reward_nft_item, sniper_reward_nft_item]))
+			.expect("Account should be created");
+		create_contract::<T>(creator.clone(), contract_id, contract.clone())
+			.expect("Contract should be created");
+		create_contract::<T>(creator, sniper_contract_id, sniper_contract)
+			.expect("Contract should be created");
 
 		let by = account::<T>("staker");
-		create_collections::<T>(&by, 2)?;
-		accept_contract::<T>(m, n, by, contract_id, Mode::Staker)?;
+		create_collections::<T>(&by, 2).expect("Collections should be created");
+		accept_contract::<T>(m, n, by, contract_id, Mode::Staker)
+			.expect("Contract should be accepted");
 
 		let sniper = account::<T>("sniper");
-		create_collections::<T>(&sniper, 2)?;
-		accept_contract::<T>(m, n, sniper.clone(), sniper_contract_id, Mode::Sniper)?;
+		create_collections::<T>(&sniper, 2).expect("Collections should be created");
+		accept_contract::<T>(m, n, sniper.clone(), sniper_contract_id, Mode::Sniper)
+			.expect("Contract should be accepted");
 
 		// Advance block past contract expiry.
 		frame_system::Pallet::<T>::set_block_number(
-			contract.stake_duration + contract.claim_duration + One::one()
+			contract.stake_duration + contract.claim_duration + One::one(),
 		);
-	}: snipe(RawOrigin::Signed(sniper.clone()), contract_id)
-	verify {
-		assert_last_event::<T>(Event::Sniped { by: sniper, contract_id, rewards })
+
+		#[extrinsic_call]
+		snipe(RawOrigin::Signed(sniper.clone()), contract_id);
+
+		assert_last_event::<T>(Event::Sniped { by: sniper, contract_id, rewards });
 	}
 
-	impl_benchmark_test_suite!(
-		Pallet,
-		crate::mock::new_test_ext(),
-		crate::mock::Runtime
-	);
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Runtime);
 }

--- a/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
+++ b/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
@@ -101,20 +101,19 @@ fn assert_last_event<T: Config>(avatars_event: Event<T>) {
 
 fn create_creator<T: Config>(reward_item: Option<Vec<u16>>) -> Result<T::AccountId, DispatchError> {
 	let creator = account::<T>("creator");
-	create_contract_collection::<T>(&creator).expect("Account should be created"); // reserve CONTRACT_COLLECTION
-	create_collections::<T>(&creator, 1).expect("Account should be created"); // reserve REWARD_COLLECTION
+	create_contract_collection::<T>(&creator)?; // reserve CONTRACT_COLLECTION
+	create_collections::<T>(&creator, 1)?; // reserve REWARD_COLLECTION
 	if let Some(item_ids) = reward_item {
 		item_ids
 			.into_iter()
-			.try_for_each(|item_id| mint_item::<T>(&creator, REWARD_COLLECTION, item_id))
-			.expect("Account should be created");
+			.try_for_each(|item_id| mint_item::<T>(&creator, REWARD_COLLECTION, item_id))?;
 	}
 	Creator::<T>::put(&creator);
 	Ok(creator)
 }
 
 fn create_contract_collection<T: Config>(creator: &T::AccountId) -> DispatchResult {
-	create_collection::<T>(creator).expect("Account should be created");
+	create_collection::<T>(creator)?;
 	ContractCollectionId::<T>::put(CollectionIdOf::<T>::from(CONTRACT_COLLECTION));
 	Ok(())
 }
@@ -133,8 +132,7 @@ fn create_collection<T: Config>(owner: &T::AccountId) -> DispatchResult {
 			max_supply: Default::default(),
 			mint_settings: Default::default(),
 		},
-	)
-	.expect("Account should be created");
+	)?;
 	Ok(())
 }
 
@@ -159,8 +157,7 @@ fn accept_contract<T: Config>(
 	contract_id: ItemIdOf<T>,
 	mode: Mode,
 ) -> DispatchResult {
-	let (stakes, fees) = stakes_and_fees::<T>(num_stake_clauses, num_fee_clauses, &staker, mode)
-		.expect("Account should be created");
+	let (stakes, fees) = stakes_and_fees::<T>(num_stake_clauses, num_fee_clauses, &staker, mode)?;
 	pallet_ajuna_nft_staking::Pallet::<T>::accept(
 		RawOrigin::Signed(staker).into(),
 		contract_id,
@@ -179,8 +176,7 @@ fn mint_item<T: Config>(owner: &T::AccountId, collection_id: u16, item_id: u16) 
 		owner,
 		&ItemConfig::default(),
 		false,
-	)
-	.expect("Account should be created");
+	)?;
 	Ok(())
 }
 
@@ -197,8 +193,7 @@ fn set_attribute<T: Config>(
 		item_id,
 		&[key],
 		&[value],
-	)
-	.expect("Account should be created");
+	)?;
 	Ok(())
 }
 
@@ -214,9 +209,8 @@ fn stakes_and_fees<T: Config>(
 	for i in 0..num_stake_clauses {
 		let item_id = i as u16;
 		let attr_key = i;
-		mint_item::<T>(who, stake_collection, item_id).expect("Account should be created");
-		set_attribute::<T>(stake_collection, item_id, (attr_key as u8) * 3, ATTRIBUTE_VALUE)
-			.expect("Account should be created");
+		mint_item::<T>(who, stake_collection, item_id)?;
+		set_attribute::<T>(stake_collection, item_id, (attr_key as u8) * 3, ATTRIBUTE_VALUE)?;
 		stakes.push(NftId(
 			CollectionIdOf::<T>::unique_saturated_from(stake_collection),
 			T::BenchmarkHelper::item_id(item_id),
@@ -225,9 +219,8 @@ fn stakes_and_fees<T: Config>(
 	for i in num_stake_clauses..num_stake_clauses + num_fee_clauses {
 		let item_id = i as u16;
 		let attr_key = i;
-		mint_item::<T>(who, fee_collection, item_id).expect("Account should be created");
-		set_attribute::<T>(fee_collection, item_id, (attr_key as u8) * 3, ATTRIBUTE_VALUE)
-			.expect("Account should be created");
+		mint_item::<T>(who, fee_collection, item_id)?;
+		set_attribute::<T>(fee_collection, item_id, (attr_key as u8) * 3, ATTRIBUTE_VALUE)?;
 		fees.push(NftId(
 			CollectionIdOf::<T>::unique_saturated_from(fee_collection),
 			T::BenchmarkHelper::item_id(item_id),

--- a/pallets/ajuna-nft-transfer/src/benchmarking.rs
+++ b/pallets/ajuna-nft-transfer/src/benchmarking.rs
@@ -16,7 +16,7 @@
 
 use crate::{traits::IpfsUrl, *};
 use ajuna_primitives::account_manager::AccountManager;
-use frame_benchmarking::benchmarks;
+use frame_benchmarking::v2::*;
 use frame_support::{pallet_prelude::DispatchError, traits::Currency};
 use frame_system::RawOrigin;
 use sp_runtime::SaturatedConversion;
@@ -57,60 +57,74 @@ fn assert_last_event<T: Config>(avatars_event: Event<T>) {
 	frame_system::Pallet::<T>::assert_last_event(event.into());
 }
 
-benchmarks! {
-	where_clause { where T: pallet_nfts::Config }
+#[benchmarks(where T: pallet_nfts::Config)]
+mod benchmarks {
+	use super::*;
 
-	set_collection_id {
+	#[benchmark]
+	fn set_collection_id() {
 		let organizer = account::<T>("organizer");
 		let collection_id = CollectionIdOf::<T>::from(u32::MAX);
 		T::AccountManager::set_organizer(organizer.clone());
-	}: _(RawOrigin::Signed(organizer), collection_id)
-	verify {
-		assert_last_event::<T>(Event::CollectionIdSet { collection_id })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(organizer), collection_id);
+
+		assert_last_event::<T>(Event::CollectionIdSet { collection_id });
 	}
 
-	set_service_account {
+	#[benchmark]
+	fn set_service_account() {
 		let service_account = account::<T>("sa");
-	}: _(RawOrigin::Root, service_account.clone())
-	verify {
-		assert_last_event::<T>(Event::<T>::ServiceAccountSet { service_account })
+
+		#[extrinsic_call]
+		_(RawOrigin::Root, service_account.clone());
+
+		assert_last_event::<T>(Event::<T>::ServiceAccountSet { service_account });
 	}
 
-	prepare_asset {
+	#[benchmark]
+	fn prepare_asset() {
 		let name = "player";
 		let player = account::<T>(name);
 		let asset_id = T::BenchmarkHelper::create_items(player.clone(), 1)[0];
 		let _ = create_service_account::<T>();
 		enable_fee_payment::<T>(&player);
-	}: _(RawOrigin::Signed(player), asset_id)
-	verify {
-		assert_last_event::<T>(Event::<T>::PreparedAsset { asset_id })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(player), asset_id);
+
+		assert_last_event::<T>(Event::<T>::PreparedAsset { asset_id });
 	}
 
-	unprepare_asset {
+	#[benchmark]
+	fn unprepare_asset() {
 		let name = "player";
 		let player = account::<T>(name);
 		let asset_id = T::BenchmarkHelper::create_items(player.clone(), 1)[0];
-		let _ = create_service_account_and_prepare_avatar::<T>(player.clone(), asset_id)?;
-	}: _(RawOrigin::Signed(player), asset_id)
-	verify {
-		assert_last_event::<T>(Event::<T>::UnpreparedAsset { asset_id })
+		let _ = create_service_account_and_prepare_avatar::<T>(player.clone(), asset_id)
+			.expect("Should create account");
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(player), asset_id);
+
+		assert_last_event::<T>(Event::<T>::UnpreparedAsset { asset_id });
 	}
 
-	prepare_ipfs {
+	#[benchmark]
+	fn prepare_ipfs() {
 		let name = "player";
 		let player = account::<T>(name);
 		let asset_id = T::BenchmarkHelper::create_items(player.clone(), 1)[0];
-		let service_account = create_service_account_and_prepare_avatar::<T>(player, asset_id)?;
+		let service_account = create_service_account_and_prepare_avatar::<T>(player, asset_id)
+			.expect("Should create account");
 		let url = IpfsUrl::try_from(b"ipfs://".to_vec()).unwrap();
-	}: _(RawOrigin::Signed(service_account), asset_id, url.clone())
-	verify {
-		assert_last_event::<T>(Event::<T>::PreparedIpfsUrl { url })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(service_account), asset_id, url.clone());
+
+		assert_last_event::<T>(Event::<T>::PreparedIpfsUrl { url });
 	}
 
-	impl_benchmark_test_suite!(
-		Pallet,
-		crate::mock::new_test_ext(),
-		crate::mock::Test
-	);
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/pallets/ajuna-seasons/src/benchmarking.rs
+++ b/pallets/ajuna-seasons/src/benchmarking.rs
@@ -17,7 +17,7 @@
 use crate::{Pallet as Seasons, *};
 use ajuna_primitives::season_manager::SeasonFeeConfig;
 
-use frame_benchmarking::benchmarks_instance_pallet;
+use frame_benchmarking::v2::*;
 use frame_support::BoundedVec;
 use frame_system::RawOrigin;
 use sp_runtime::Saturating;
@@ -53,87 +53,91 @@ fn run_to_block<T: Config<I>, I: 'static>(n: BlockNumberFor<T>) {
 	}
 }
 
-benchmarks_instance_pallet! {
-	update_season {
+#[instance_benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn update_season() {
 		let season_id = T::BenchmarkHelper::create_season_id(1_u32);
 		let acc_1 = account::<T, I>(ACC_1);
 		setup_organizer::<T, I>(acc_1.clone());
 		let config = SeasonConfigOf::<T, I> {
-				fee: SeasonFeeConfig {
-					transfer_asset: 10_u32.into(),
-					buy_asset_min: 5_u32.into(),
-					buy_percent: 10,
-					upgrade_asset_inventory: 5_u32.into(),
-					unlock_trade_asset: 9_u32.into(),
-					unlock_transfer_asset: 13_u32.into(),
-					state_transition_base_fee: 20_u32.into(),
-				},
-				data: T::BenchmarkHelper::create_default_season_data(),
-			};
+			fee: SeasonFeeConfig {
+				transfer_asset: 10_u32.into(),
+				buy_asset_min: 5_u32.into(),
+				buy_percent: 10,
+				upgrade_asset_inventory: 5_u32.into(),
+				unlock_trade_asset: 9_u32.into(),
+				unlock_transfer_asset: 13_u32.into(),
+				state_transition_base_fee: 20_u32.into(),
+			},
+			data: T::BenchmarkHelper::create_default_season_data(),
+		};
 		let metadata = SeasonMetadata {
 			name: BoundedVec::try_from(b"Season-1".to_vec()).expect("Should create vec"),
 			description: BoundedVec::try_from(b"The first season".to_vec())
 				.expect("Should create vec"),
 		};
-		let schedule = SeasonSchedule {
-			early_start: 20_u32.into(),
-			start: 25_u32.into(),
-			end: 30_u32.into()
-		};
-	}: _(RawOrigin::Signed(acc_1), season_id.clone(), Some(config.clone()), Some(metadata.clone()), Some(schedule.clone()))
-	verify {
+		let schedule =
+			SeasonSchedule { early_start: 20_u32.into(), start: 25_u32.into(), end: 30_u32.into() };
+
+		#[extrinsic_call]
+		_(
+			RawOrigin::Signed(acc_1),
+			season_id.clone(),
+			Some(config.clone()),
+			Some(metadata.clone()),
+			Some(schedule.clone()),
+		);
+
 		assert_last_event::<T, I>(Event::UpdatedSeason {
 			season_id,
 			config: Some(config),
 			metadata: Some(metadata),
-			schedule: Some(schedule)
-		})
+			schedule: Some(schedule),
+		});
 	}
 
-	interrupt_active_season {
+	#[benchmark]
+	fn interrupt_active_season() {
 		let season_id = T::BenchmarkHelper::create_season_id(2_u32);
 		let acc_1 = account::<T, I>(ACC_1);
 		setup_organizer::<T, I>(acc_1.clone());
 		let config = SeasonConfigOf::<T, I> {
-				fee: SeasonFeeConfig {
-					transfer_asset: 10_u32.into(),
-					buy_asset_min: 5_u32.into(),
-					buy_percent: 10,
-					upgrade_asset_inventory: 5_u32.into(),
-					unlock_trade_asset: 9_u32.into(),
-					unlock_transfer_asset: 13_u32.into(),
-					state_transition_base_fee: 20_u32.into(),
-				},
-				data: T::BenchmarkHelper::create_default_season_data(),
-			};
+			fee: SeasonFeeConfig {
+				transfer_asset: 20_u32.into(),
+				buy_asset_min: 5_u32.into(),
+				buy_percent: 10,
+				upgrade_asset_inventory: 5_u32.into(),
+				unlock_trade_asset: 9_u32.into(),
+				unlock_transfer_asset: 13_u32.into(),
+				state_transition_base_fee: 20_u32.into(),
+			},
+			data: T::BenchmarkHelper::create_default_season_data(),
+		};
 		let metadata = SeasonMetadata {
 			name: BoundedVec::try_from(b"Season-1".to_vec()).expect("Should create vec"),
 			description: BoundedVec::try_from(b"The first season".to_vec())
 				.expect("Should create vec"),
 		};
-		let schedule = SeasonSchedule {
-			early_start: 20_u32.into(),
-			start: 25_u32.into(),
-			end: 30_u32.into()
-		};
+		let schedule =
+			SeasonSchedule { early_start: 20_u32.into(), start: 25_u32.into(), end: 30_u32.into() };
 		Seasons::<T, I>::update_season(
 			RawOrigin::Signed(acc_1.clone()).into(),
 			season_id.clone(),
 			Some(config),
 			Some(metadata),
-			Some(schedule)
-		).expect("Should update season");
+			Some(schedule),
+		)
+		.expect("Should update season");
 		run_to_block::<T, I>(25_u32.into());
-	}: _(RawOrigin::Signed(acc_1))
-	verify {
-		assert_last_event::<T, I>(Event::SeasonEarlyEnded {
-			season_id,
-		})
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1));
+
+		assert_last_event::<T, I>(Event::SeasonEarlyEnded { season_id });
 	}
 
-	impl_benchmark_test_suite!(
-		Seasons,
-		crate::mock::new_test_ext(),
-		crate::mock::Test
-	);
+	impl_benchmark_test_suite!(Seasons, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/pallets/ajuna-tournament/src/benchmarking.rs
+++ b/pallets/ajuna-tournament/src/benchmarking.rs
@@ -16,7 +16,7 @@
 
 use crate::{Pallet as Tournament, *};
 use ajuna_primitives::account_manager::AccountManager;
-use frame_benchmarking::benchmarks_instance_pallet;
+use frame_benchmarking::v2::*;
 use frame_support::traits::Currency;
 use frame_system::RawOrigin;
 use sp_arithmetic::traits::Saturating;
@@ -63,69 +63,111 @@ fn run_to_block<T: Config<I>, I: 'static>(n: BlockNumberFor<T>) {
 	}
 }
 
-benchmarks_instance_pallet! {
-	create_tournament {
+#[instance_benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn create_tournament() {
 		let acc_1 = account::<T, I>(ACC_1);
 		setup_organizer::<T, I>(acc_1.clone());
 		set_account_balance::<T, I>(&acc_1, 1000_u32.into());
 		let category_id = T::BenchmarkHelper::create_category_id(1);
 		let tournament_config = T::BenchmarkHelper::create_default_tournament_config();
-	}: _(RawOrigin::Signed(acc_1), category_id, tournament_config)
-	verify {
-		assert_last_event::<T, I>(Event::TournamentCreated { category_id, tournament_id: 0 })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), category_id, tournament_config);
+
+		assert_last_event::<T, I>(Event::TournamentCreated { category_id, tournament_id: 0 });
 	}
 
-	remove_latest_tournament {
+	#[benchmark]
+	fn remove_latest_tournament() {
 		let acc_1 = account::<T, I>(ACC_1);
 		setup_organizer::<T, I>(acc_1.clone());
 		set_account_balance::<T, I>(&acc_1, 1000_u32.into());
 		let category_id = T::BenchmarkHelper::create_category_id(1);
 		let tournament_config = T::BenchmarkHelper::create_default_tournament_config();
-		Tournament::<T, I>::create_tournament(RawOrigin::Signed(acc_1.clone()).into(), category_id, tournament_config)?;
-	}: _(RawOrigin::Signed(acc_1), category_id)
-	verify {
-		assert_last_event::<T, I>(Event::TournamentRemoved { category_id, tournament_id: 0 })
+		Tournament::<T, I>::create_tournament(
+			RawOrigin::Signed(acc_1.clone()).into(),
+			category_id,
+			tournament_config,
+		)
+		.expect("Should create tournament");
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), category_id);
+
+		assert_last_event::<T, I>(Event::TournamentRemoved { category_id, tournament_id: 0 });
 	}
 
-	claim_tournament_reward_for {
+	#[benchmark]
+	fn claim_tournament_reward_for() {
 		let acc_1 = account::<T, I>(ACC_1);
 		setup_organizer::<T, I>(acc_1.clone());
 		set_account_balance::<T, I>(&acc_1, 1000_u32.into());
 		let category_id = T::BenchmarkHelper::create_category_id(1);
 		let (entity_id, entity) = create_owned_entity::<T, I>(acc_1.clone());
 		let tournament_config = T::BenchmarkHelper::create_default_tournament_config();
-		Tournament::<T, I>::create_tournament(RawOrigin::Signed(acc_1.clone()).into(), category_id, tournament_config)?;
+		Tournament::<T, I>::create_tournament(
+			RawOrigin::Signed(acc_1.clone()).into(),
+			category_id,
+			tournament_config,
+		)
+		.expect("Should create tournament");
 		run_to_block::<T, I>(20_u32.into());
-		<Tournament<T, I> as TournamentRanker<T::TournamentCategoryId, T::RankedEntity, T::EntityId>>::try_rank_entity_in_tournament_for(
-			&category_id, &entity_id, &entity
-		)?;
+		<Tournament<T, I> as TournamentRanker<
+			T::TournamentCategoryId,
+			T::RankedEntity,
+			T::EntityId,
+		>>::try_rank_entity_in_tournament_for(&category_id, &entity_id, &entity)
+		.expect("Should rank entity");
 		run_to_block::<T, I>(60_u32.into());
-	}: _(RawOrigin::Signed(acc_1.clone()), category_id, entity_id.clone())
-	verify {
-		assert_last_event::<T, I>(Event::RankingRewardClaimed { category_id, tournament_id: 0, entity_id ,account: acc_1 })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1.clone()), category_id, entity_id.clone());
+
+		assert_last_event::<T, I>(Event::RankingRewardClaimed {
+			category_id,
+			tournament_id: 0,
+			entity_id,
+			account: acc_1,
+		});
 	}
 
-	claim_golden_duck_for {
+	#[benchmark]
+	fn claim_golden_duck_for() {
 		let acc_1 = account::<T, I>(ACC_1);
 		setup_organizer::<T, I>(acc_1.clone());
 		set_account_balance::<T, I>(&acc_1, 1000_u32.into());
 		let category_id = T::BenchmarkHelper::create_category_id(1);
 		let (entity_id, _) = create_owned_entity::<T, I>(acc_1.clone());
 		let tournament_config = T::BenchmarkHelper::create_default_tournament_config();
-		Tournament::<T, I>::create_tournament(RawOrigin::Signed(acc_1.clone()).into(), category_id, tournament_config)?;
+		Tournament::<T, I>::create_tournament(
+			RawOrigin::Signed(acc_1.clone()).into(),
+			category_id,
+			tournament_config,
+		)
+		.expect("Should create tournament");
 		run_to_block::<T, I>(20_u32.into());
-		<Tournament<T, I> as TournamentRanker<T::TournamentCategoryId, T::RankedEntity, T::EntityId>>::try_rank_entity_for_golden_duck(
-			&category_id, &entity_id
-		)?;
+		<Tournament<T, I> as TournamentRanker<
+			T::TournamentCategoryId,
+			T::RankedEntity,
+			T::EntityId,
+		>>::try_rank_entity_for_golden_duck(&category_id, &entity_id)
+		.expect("Should rank entity");
 		run_to_block::<T, I>(60_u32.into());
-	}: _(RawOrigin::Signed(acc_1.clone()), category_id, entity_id.clone())
-	verify {
-		assert_last_event::<T, I>(Event::GoldenDuckRewardClaimed { category_id, tournament_id: 0, entity_id ,account: acc_1 })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1.clone()), category_id, entity_id.clone());
+
+		assert_last_event::<T, I>(Event::GoldenDuckRewardClaimed {
+			category_id,
+			tournament_id: 0,
+			entity_id,
+			account: acc_1,
+		});
 	}
 
-	impl_benchmark_test_suite!(
-		Tournament,
-		crate::mock::new_test_ext(),
-		crate::mock::Test
-	);
+	impl_benchmark_test_suite!(Tournament, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/sage/pallet/src/benchmarking.rs
+++ b/sage/pallet/src/benchmarking.rs
@@ -70,37 +70,37 @@ fn unlock_player_features_for<T: Config<I>, I: 'static>(
 	});
 }
 
-#[benchmarks]
+#[instance_benchmarks]
 mod benchmarks {
 	use super::*;
 
 	#[benchmark]
 	fn set_organizer() {
-		let acc_2 = account::<T, ()>(ACC_2);
+		let acc_2 = account::<T, I>(ACC_2);
 
 		#[extrinsic_call]
 		_(RawOrigin::Root, acc_2.clone());
 
-		assert_last_event::<T, ()>(Event::OrganizerSet { organizer: acc_2 });
+		assert_last_event::<T, I>(Event::OrganizerSet { organizer: acc_2 });
 	}
 
 	#[benchmark]
 	fn update_general_config() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		setup_organizer::<T, ()>(acc_1.clone());
-		let general_config = GeneralConfigOf::<T, ()>::default();
+		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
+		let general_config = GeneralConfigOf::<T, I>::default();
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_1), general_config.clone());
 
-		assert_last_event::<T, ()>(Event::UpdatedGeneralConfig { updated_config: general_config });
+		assert_last_event::<T, I>(Event::UpdatedGeneralConfig { updated_config: general_config });
 	}
 
 	#[benchmark]
 	fn update_unlock_rule() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		setup_organizer::<T, ()>(acc_1.clone());
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let feature = LockableFeature::TradeAsset;
 		let unlock_rule: UnlockRule = [10, 10, 10, 10, 10];
@@ -108,7 +108,7 @@ mod benchmarks {
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_1), season_id.clone(), feature, unlock_rule);
 
-		assert_last_event::<T, ()>(Event::UpdatedUnlockRule {
+		assert_last_event::<T, I>(Event::UpdatedUnlockRule {
 			season_id,
 			feature,
 			updated_rule: unlock_rule,
@@ -117,11 +117,11 @@ mod benchmarks {
 
 	#[benchmark]
 	fn upgrade_asset_inventory() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		setup_organizer::<T, ()>(acc_1.clone());
-		set_account_balance::<T, ()>(&acc_1, 100_u32.into());
-		let acc_2 = account::<T, ()>(ACC_2);
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
+		set_account_balance::<T, I>(&acc_1, 100_u32.into());
+		let acc_2 = account::<T, I>(ACC_2);
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let in_season = Some(season_id.clone());
 		let payment = T::BenchmarkHelper::create_payment_kind();
@@ -129,7 +129,7 @@ mod benchmarks {
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_1), Some(acc_2.clone()), in_season, Some(payment));
 
-		assert_last_event::<T, ()>(Event::InventoryTierUpgraded {
+		assert_last_event::<T, I>(Event::InventoryTierUpgraded {
 			account: acc_2,
 			season_id,
 			new_tier: InventoryTier::Two,
@@ -138,106 +138,106 @@ mod benchmarks {
 
 	#[benchmark]
 	fn update_asset_trade_filter() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		setup_organizer::<T, ()>(acc_1.clone());
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
-		let filter = TradeFilterOf::<T, ()>::default();
-		let trade_filter = AssetFilterOf::<T, ()>::Trade(filter.clone());
+		let filter = TradeFilterOf::<T, I>::default();
+		let trade_filter = AssetFilterOf::<T, I>::Trade(filter.clone());
 
 		#[extrinsic_call]
 		update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), trade_filter);
 
-		assert_last_event::<T, ()>(Event::UpdatedTradeFilter { season_id, filter });
+		assert_last_event::<T, I>(Event::UpdatedTradeFilter { season_id, filter });
 	}
 
 	#[benchmark]
 	fn update_asset_transfer_filter() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		setup_organizer::<T, ()>(acc_1.clone());
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
-		let filter = TransferFilterOf::<T, ()>::default();
-		let transfer_filter = AssetFilterOf::<T, ()>::Transfer(filter.clone());
+		let filter = TransferFilterOf::<T, I>::default();
+		let transfer_filter = AssetFilterOf::<T, I>::Transfer(filter.clone());
 
 		#[extrinsic_call]
 		update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), transfer_filter);
 
-		assert_last_event::<T, ()>(Event::UpdatedTransferFilter { season_id, filter });
+		assert_last_event::<T, I>(Event::UpdatedTransferFilter { season_id, filter });
 	}
 
 	#[benchmark]
 	fn transfer_asset() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		set_account_balance::<T, ()>(&acc_1, 100_u32.into());
-		let acc_2 = account::<T, ()>(ACC_2);
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		set_account_balance::<T, I>(&acc_1, 100_u32.into());
+		let acc_2 = account::<T, I>(ACC_2);
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
-		unlock_season_features_for::<T, ()>(&season_id);
-		unlock_player_features_for::<T, ()>(&acc_1, &season_id);
+		unlock_season_features_for::<T, I>(&season_id);
+		unlock_player_features_for::<T, I>(&acc_1, &season_id);
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 2);
 		let payment = T::BenchmarkHelper::create_payment_kind();
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_1.clone()), acc_2.clone(), asset_id.clone(), Some(payment));
 
-		assert_last_event::<T, ()>(Event::AssetTransferred { from: acc_1, to: acc_2, asset_id });
+		assert_last_event::<T, I>(Event::AssetTransferred { from: acc_1, to: acc_2, asset_id });
 	}
 
 	#[benchmark]
 	fn set_asset_price() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
-		unlock_season_features_for::<T, ()>(&season_id);
-		unlock_player_features_for::<T, ()>(&acc_1, &season_id);
+		unlock_season_features_for::<T, I>(&season_id);
+		unlock_player_features_for::<T, I>(&acc_1, &season_id);
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let price = 45_242_u32;
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_1), asset_id.clone(), price.into());
 
-		assert_last_event::<T, ()>(Event::AssetPriceSet { asset_id, price: price.into() });
+		assert_last_event::<T, I>(Event::AssetPriceSet { asset_id, price: price.into() });
 	}
 
 	#[benchmark]
 	fn remove_asset_price() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
-		unlock_season_features_for::<T, ()>(&season_id);
+		unlock_season_features_for::<T, I>(&season_id);
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
-		let price = BalanceOf::<T, ()>::from(45_242_u32);
-		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, price);
+		let price = BalanceOf::<T, I>::from(45_242_u32);
+		AssetTradePrices::<T, I>::insert(&season_id, &asset_id, price);
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_1), asset_id.clone());
 
-		assert_last_event::<T, ()>(Event::AssetPriceUnset { asset_id });
+		assert_last_event::<T, I>(Event::AssetPriceUnset { asset_id });
 	}
 
 	#[benchmark]
 	fn buy_asset() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		let acc_2 = account::<T, ()>(ACC_2);
-		set_account_balance::<T, ()>(&acc_2, 100_000_u32.into());
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		let acc_2 = account::<T, I>(ACC_2);
+		set_account_balance::<T, I>(&acc_2, 100_000_u32.into());
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
-		let price = BalanceOf::<T, ()>::from(45_242_u32);
-		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, price);
+		let price = BalanceOf::<T, I>::from(45_242_u32);
+		AssetTradePrices::<T, I>::insert(&season_id, &asset_id, price);
 		let payment = T::BenchmarkHelper::create_payment_kind();
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_2.clone()), asset_id.clone(), Some(payment));
 
-		assert_last_event::<T, ()>(Event::AssetTraded { asset_id, from: acc_1, to: acc_2, price });
+		assert_last_event::<T, I>(Event::AssetTraded { asset_id, from: acc_1, to: acc_2, price });
 	}
 
 	#[benchmark]
 	fn lock_asset() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let expected_lock = Lock::new(*SAGE_LOCK_ID, acc_1.clone());
@@ -245,33 +245,33 @@ mod benchmarks {
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_1), asset_id.clone());
 
-		assert_last_event::<T, ()>(Event::AssetLocked { asset_id, lock: expected_lock });
+		assert_last_event::<T, I>(Event::AssetLocked { asset_id, lock: expected_lock });
 	}
 
 	#[benchmark]
 	fn unlock_asset() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let expected_lock = Lock::new(*SAGE_LOCK_ID, acc_1.clone());
-		Pallet::<T, ()>::lock_asset(RawOrigin::Signed(acc_1.clone()).into(), asset_id.clone())
+		Pallet::<T, I>::lock_asset(RawOrigin::Signed(acc_1.clone()).into(), asset_id.clone())
 			.expect("Should lock asset");
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_1), asset_id.clone());
 
-		assert_last_event::<T, ()>(Event::AssetUnlocked { asset_id, lock: expected_lock });
+		assert_last_event::<T, I>(Event::AssetUnlocked { asset_id, lock: expected_lock });
 	}
 
 	#[benchmark]
 	fn unlock_trade_asset_feature() {
-		let acc_1 = account::<T, ()>(ACC_1);
+		let acc_1 = account::<T, I>(ACC_1);
 		let target = UnlockTarget::OneselfFree;
 		let feature = LockableFeature::TradeAsset;
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
-		unlock_season_features_for::<T, ()>(&season_id);
+		unlock_season_features_for::<T, I>(&season_id);
 		let payment = T::BenchmarkHelper::create_payment_kind();
 
 		#[extrinsic_call]
@@ -283,17 +283,17 @@ mod benchmarks {
 			Some(payment),
 		);
 
-		assert_last_event::<T, ()>(Event::FeatureUnlocked { feature, season_id, account: acc_1 });
+		assert_last_event::<T, I>(Event::FeatureUnlocked { feature, season_id, account: acc_1 });
 	}
 
 	#[benchmark]
 	fn unlock_transfer_asset_feature() {
-		let acc_1 = account::<T, ()>(ACC_1);
+		let acc_1 = account::<T, I>(ACC_1);
 		let target = UnlockTarget::OneselfFree;
 		let feature = LockableFeature::TransferAsset;
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
-		unlock_season_features_for::<T, ()>(&season_id);
+		unlock_season_features_for::<T, I>(&season_id);
 		let payment = T::BenchmarkHelper::create_payment_kind();
 
 		#[extrinsic_call]
@@ -305,24 +305,24 @@ mod benchmarks {
 			Some(payment),
 		);
 
-		assert_last_event::<T, ()>(Event::FeatureUnlocked { feature, season_id, account: acc_1 });
+		assert_last_event::<T, I>(Event::FeatureUnlocked { feature, season_id, account: acc_1 });
 	}
 
 	#[benchmark]
 	fn state_transition() {
-		let acc_1 = account::<T, ()>(ACC_1);
-		set_account_balance::<T, ()>(&acc_1, 100_u32.into());
-		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
+		let acc_1 = account::<T, I>(ACC_1);
+		set_account_balance::<T, I>(&acc_1, 100_u32.into());
+		let season_id = <T as Config<I>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let (transition_id, asset_ids) =
 			T::BenchmarkHelper::create_bench_transition_for(&acc_1, &season_id, 99);
-		let extra = ExtraOf::<T, ()>::default();
+		let extra = ExtraOf::<T, I>::default();
 		let payment = T::BenchmarkHelper::create_payment_kind();
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_1.clone()), transition_id.clone(), asset_ids, extra, Some(payment));
 
-		assert_last_event::<T, ()>(Event::TransitionExecuted { account: acc_1, id: transition_id });
+		assert_last_event::<T, I>(Event::TransitionExecuted { account: acc_1, id: transition_id });
 	}
 
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/sage/pallet/src/benchmarking.rs
+++ b/sage/pallet/src/benchmarking.rs
@@ -22,7 +22,7 @@ use crate::{
 	SeasonUnlocks, UnlockRule, UnlockTarget, SAGE_LOCK_ID,
 };
 use ajuna_primitives::{asset_manager::Lock, season_manager::SeasonManager};
-use frame_benchmarking::benchmarks;
+use frame_benchmarking::v2::*;
 use frame_support::traits::Currency;
 use frame_system::RawOrigin;
 
@@ -70,40 +70,53 @@ fn unlock_player_features_for<T: Config<I>, I: 'static>(
 	});
 }
 
-benchmarks! {
-	set_organizer {
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn set_organizer() {
 		let acc_2 = account::<T, ()>(ACC_2);
-	}: _(RawOrigin::Root, acc_2.clone())
-	verify {
-		assert_last_event::<T, ()>(Event::OrganizerSet { organizer: acc_2 })
+
+		#[extrinsic_call]
+		_(RawOrigin::Root, acc_2.clone());
+
+		assert_last_event::<T, ()>(Event::OrganizerSet { organizer: acc_2 });
 	}
 
-	update_general_config {
+	#[benchmark]
+	fn update_general_config() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		setup_organizer::<T, ()>(acc_1.clone());
 		let general_config = GeneralConfigOf::<T, ()>::default();
-	}: _(RawOrigin::Signed(acc_1), general_config.clone())
-	verify {
-		assert_last_event::<T, ()>(Event::UpdatedGeneralConfig { updated_config: general_config })
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), general_config.clone());
+
+		assert_last_event::<T, ()>(Event::UpdatedGeneralConfig { updated_config: general_config });
 	}
 
-	update_unlock_rule {
+	#[benchmark]
+	fn update_unlock_rule() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		setup_organizer::<T, ()>(acc_1.clone());
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let feature = LockableFeature::TradeAsset;
 		let unlock_rule: UnlockRule = [10, 10, 10, 10, 10];
-	}: _(RawOrigin::Signed(acc_1), season_id.clone(), feature, unlock_rule)
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), season_id.clone(), feature, unlock_rule);
+
 		assert_last_event::<T, ()>(Event::UpdatedUnlockRule {
 			season_id,
 			feature,
 			updated_rule: unlock_rule,
-		})
+		});
 	}
 
-	upgrade_asset_inventory {
+	#[benchmark]
+	fn upgrade_asset_inventory() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		setup_organizer::<T, ()>(acc_1.clone());
 		set_account_balance::<T, ()>(&acc_1, 100_u32.into());
@@ -112,46 +125,49 @@ benchmarks! {
 			.expect("Should get current season");
 		let in_season = Some(season_id.clone());
 		let payment = T::BenchmarkHelper::create_payment_kind();
-	}: _(RawOrigin::Signed(acc_1), Some(acc_2.clone()), in_season, Some(payment))
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), Some(acc_2.clone()), in_season, Some(payment));
+
 		assert_last_event::<T, ()>(Event::InventoryTierUpgraded {
 			account: acc_2,
 			season_id,
 			new_tier: InventoryTier::Two,
-		})
+		});
 	}
 
-	update_asset_trade_filter {
+	#[benchmark]
+	fn update_asset_trade_filter() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		setup_organizer::<T, ()>(acc_1.clone());
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let filter = TradeFilterOf::<T, ()>::default();
 		let trade_filter = AssetFilterOf::<T, ()>::Trade(filter.clone());
-	}: update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), trade_filter)
-	verify {
-		assert_last_event::<T, ()>(Event::UpdatedTradeFilter {
-			season_id,
-			filter,
-		})
+
+		#[extrinsic_call]
+		update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), trade_filter);
+
+		assert_last_event::<T, ()>(Event::UpdatedTradeFilter { season_id, filter });
 	}
 
-	update_asset_transfer_filter {
+	#[benchmark]
+	fn update_asset_transfer_filter() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		setup_organizer::<T, ()>(acc_1.clone());
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let filter = TransferFilterOf::<T, ()>::default();
 		let transfer_filter = AssetFilterOf::<T, ()>::Transfer(filter.clone());
-	}: update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), transfer_filter)
-	verify {
-		assert_last_event::<T, ()>(Event::UpdatedTransferFilter {
-			season_id,
-			filter,
-		})
+
+		#[extrinsic_call]
+		update_asset_filter(RawOrigin::Signed(acc_1), season_id.clone(), transfer_filter);
+
+		assert_last_event::<T, ()>(Event::UpdatedTransferFilter { season_id, filter });
 	}
 
-	transfer_asset {
+	#[benchmark]
+	fn transfer_asset() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		set_account_balance::<T, ()>(&acc_1, 100_u32.into());
 		let acc_2 = account::<T, ()>(ACC_2);
@@ -161,16 +177,15 @@ benchmarks! {
 		unlock_player_features_for::<T, ()>(&acc_1, &season_id);
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 2);
 		let payment = T::BenchmarkHelper::create_payment_kind();
-	}: _(RawOrigin::Signed(acc_1.clone()), acc_2.clone(), asset_id.clone(), Some(payment))
-	verify {
-		assert_last_event::<T, ()>(Event::AssetTransferred {
-			from: acc_1,
-			to: acc_2,
-			asset_id,
-		})
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1.clone()), acc_2.clone(), asset_id.clone(), Some(payment));
+
+		assert_last_event::<T, ()>(Event::AssetTransferred { from: acc_1, to: acc_2, asset_id });
 	}
 
-	set_asset_price {
+	#[benchmark]
+	fn set_asset_price() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
@@ -178,15 +193,15 @@ benchmarks! {
 		unlock_player_features_for::<T, ()>(&acc_1, &season_id);
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let price = 45_242_u32;
-	}: _(RawOrigin::Signed(acc_1), asset_id.clone(), price.into())
-	verify {
-		assert_last_event::<T, ()>(Event::AssetPriceSet {
-			asset_id,
-			price: price.into(),
-		})
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), asset_id.clone(), price.into());
+
+		assert_last_event::<T, ()>(Event::AssetPriceSet { asset_id, price: price.into() });
 	}
 
-	remove_asset_price {
+	#[benchmark]
+	fn remove_asset_price() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
@@ -194,14 +209,15 @@ benchmarks! {
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let price = BalanceOf::<T, ()>::from(45_242_u32);
 		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, price);
-	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
-	verify {
-		assert_last_event::<T, ()>(Event::AssetPriceUnset {
-			asset_id,
-		})
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), asset_id.clone());
+
+		assert_last_event::<T, ()>(Event::AssetPriceUnset { asset_id });
 	}
 
-	buy_asset {
+	#[benchmark]
+	fn buy_asset() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let acc_2 = account::<T, ()>(ACC_2);
 		set_account_balance::<T, ()>(&acc_2, 100_000_u32.into());
@@ -211,49 +227,45 @@ benchmarks! {
 		let price = BalanceOf::<T, ()>::from(45_242_u32);
 		AssetTradePrices::<T, ()>::insert(&season_id, &asset_id, price);
 		let payment = T::BenchmarkHelper::create_payment_kind();
-	}: _(RawOrigin::Signed(acc_2.clone()), asset_id.clone(), Some(payment))
-	verify {
-		assert_last_event::<T, ()>(Event::AssetTraded {
-			asset_id,
-			from: acc_1,
-			to: acc_2,
-			price,
-		})
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_2.clone()), asset_id.clone(), Some(payment));
+
+		assert_last_event::<T, ()>(Event::AssetTraded { asset_id, from: acc_1, to: acc_2, price });
 	}
 
-	lock_asset {
+	#[benchmark]
+	fn lock_asset() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let expected_lock = Lock::new(*SAGE_LOCK_ID, acc_1.clone());
-	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
-	verify {
-		assert_last_event::<T, ()>(Event::AssetLocked {
-			asset_id,
-			lock: expected_lock,
-		})
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), asset_id.clone());
+
+		assert_last_event::<T, ()>(Event::AssetLocked { asset_id, lock: expected_lock });
 	}
 
-	unlock_asset {
+	#[benchmark]
+	fn unlock_asset() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
 		let asset_id = T::BenchmarkHelper::create_asset_for(&acc_1, &season_id, 31);
 		let expected_lock = Lock::new(*SAGE_LOCK_ID, acc_1.clone());
-		Pallet::<T, ()>::lock_asset(
-			RawOrigin::Signed(acc_1.clone()).into(),
-			asset_id.clone())
-		.expect("Should lock asset");
-	}: _(RawOrigin::Signed(acc_1), asset_id.clone())
-	verify {
-		assert_last_event::<T, ()>(Event::AssetUnlocked {
-			asset_id,
-			lock: expected_lock,
-		})
+		Pallet::<T, ()>::lock_asset(RawOrigin::Signed(acc_1.clone()).into(), asset_id.clone())
+			.expect("Should lock asset");
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), asset_id.clone());
+
+		assert_last_event::<T, ()>(Event::AssetUnlocked { asset_id, lock: expected_lock });
 	}
 
-	unlock_trade_asset_feature {
+	#[benchmark]
+	fn unlock_trade_asset_feature() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let target = UnlockTarget::OneselfFree;
 		let feature = LockableFeature::TradeAsset;
@@ -261,16 +273,21 @@ benchmarks! {
 			.expect("Should get current season");
 		unlock_season_features_for::<T, ()>(&season_id);
 		let payment = T::BenchmarkHelper::create_payment_kind();
-	}: unlock_feature(RawOrigin::Signed(acc_1.clone()), target, feature, season_id.clone(), Some(payment))
-	verify {
-		assert_last_event::<T, ()>(Event::FeatureUnlocked {
+
+		#[extrinsic_call]
+		unlock_feature(
+			RawOrigin::Signed(acc_1.clone()),
+			target,
 			feature,
-			season_id,
-			account: acc_1,
-		})
+			season_id.clone(),
+			Some(payment),
+		);
+
+		assert_last_event::<T, ()>(Event::FeatureUnlocked { feature, season_id, account: acc_1 });
 	}
 
-	unlock_transfer_asset_feature {
+	#[benchmark]
+	fn unlock_transfer_asset_feature() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		let target = UnlockTarget::OneselfFree;
 		let feature = LockableFeature::TransferAsset;
@@ -278,34 +295,35 @@ benchmarks! {
 			.expect("Should get current season");
 		unlock_season_features_for::<T, ()>(&season_id);
 		let payment = T::BenchmarkHelper::create_payment_kind();
-	}: unlock_feature(RawOrigin::Signed(acc_1.clone()), target, feature, season_id.clone(), Some(payment))
-	verify {
-		assert_last_event::<T, ()>(Event::FeatureUnlocked {
+
+		#[extrinsic_call]
+		unlock_feature(
+			RawOrigin::Signed(acc_1.clone()),
+			target,
 			feature,
-			season_id,
-			account: acc_1,
-		})
+			season_id.clone(),
+			Some(payment),
+		);
+
+		assert_last_event::<T, ()>(Event::FeatureUnlocked { feature, season_id, account: acc_1 });
 	}
 
-	state_transition {
+	#[benchmark]
+	fn state_transition() {
 		let acc_1 = account::<T, ()>(ACC_1);
 		set_account_balance::<T, ()>(&acc_1, 100_u32.into());
 		let season_id = <T as Config<()>>::SeasonHandler::get_current_season_id()
 			.expect("Should get current season");
-		let (transition_id, asset_ids) = T::BenchmarkHelper::create_bench_transition_for(&acc_1, &season_id, 99);
+		let (transition_id, asset_ids) =
+			T::BenchmarkHelper::create_bench_transition_for(&acc_1, &season_id, 99);
 		let extra = ExtraOf::<T, ()>::default();
 		let payment = T::BenchmarkHelper::create_payment_kind();
-	}: _(RawOrigin::Signed(acc_1.clone()), transition_id.clone(), asset_ids, extra, Some(payment))
-	verify {
-		assert_last_event::<T, ()>(Event::TransitionExecuted {
-			account: acc_1,
-			id: transition_id,
-		})
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1.clone()), transition_id.clone(), asset_ids, extra, Some(payment));
+
+		assert_last_event::<T, ()>(Event::TransitionExecuted { account: acc_1, id: transition_id });
 	}
 
-	impl_benchmark_test_suite!(
-		Pallet,
-		crate::mock::new_test_ext(),
-		crate::mock::Test
-	);
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
 }


### PR DESCRIPTION
## Description

Updates all benchmarking code in the repo to use the `frame_benchmarking::v2` syntax

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
