### PR TITLE
[CI] more explicit use of nightly version in fmt job

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -24,18 +24,24 @@ env:
   CARGO_ARGS: ${{ github.ref == 'refs/heads/develop' && '--release' || '' }}
   CARGO_TERM_COLOR: always
   SKIP_WASM_BUILD: 1
+  RUST_NIGHTLY_VERSION: 2024-11-19
 
 jobs:
   fmt:
     if: ${{ !startsWith(github.head_ref, 'release/') }}
     name: Rustfmt
     runs-on: ubuntu-latest
-    container:
-      # contains the nightly-toolchain
-      image: docker.io/paritytech/ci-unified:bullseye-1.75.0-2024-01-22-v20240109
     continue-on-error: false
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          targets: "wasm32-unknown-unknown"
+          components: "rustfmt"
+          toolchain: "nightly-${{env.RUST_NIGHTLY_VERSION}}"
+
         # some settings are only available in nightly.
       - run: cargo +nightly fmt --all -- --check
 

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -43,7 +43,7 @@ jobs:
           toolchain: "nightly-${{env.RUST_NIGHTLY_VERSION}}"
 
         # some settings are only available in nightly.
-      - run: cargo +nightly fmt --all -- --check
+      - run: cargo +nightly-$RUST_NIGHTLY_VERSION fmt --all -- --check
 
   lint:
     if: ${{ !startsWith(github.head_ref, 'release/') }}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/assemble.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/assemble.rs
@@ -888,10 +888,11 @@ mod test {
 			let sac_3 = create_random_toolbox([0; 32], &ALICE, 100);
 			let sac_4 = create_random_toolbox([0; 32], &ALICE, 100);
 
-			let total_souls =
-				leader.1.get_souls() +
-					sac_1.1.get_souls() + sac_2.1.get_souls() +
-					sac_3.1.get_souls() + sac_4.1.get_souls();
+			let total_souls = leader.1.get_souls() +
+				sac_1.1.get_souls() +
+				sac_2.1.get_souls() +
+				sac_3.1.get_souls() +
+				sac_4.1.get_souls();
 
 			let expected_dna = [
 				0x41, 0x12, 0x02, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -1174,10 +1175,11 @@ mod test {
 			let sac_3 = create_random_avatar::<Test, _>(&ALICE, Some(hash_base[3]), Some(unit_fn));
 			let sac_4 = create_random_avatar::<Test, _>(&ALICE, Some(hash_base[4]), Some(unit_fn));
 
-			let total_souls =
-				leader.1.get_souls() +
-					sac_1.1.get_souls() + sac_2.1.get_souls() +
-					sac_3.1.get_souls() + sac_4.1.get_souls();
+			let total_souls = leader.1.get_souls() +
+				sac_1.1.get_souls() +
+				sac_2.1.get_souls() +
+				sac_3.1.get_souls() +
+				sac_4.1.get_souls();
 
 			assert_eq!(
 				ForgerV2::<Test>::determine_forge_type(
@@ -1262,10 +1264,11 @@ mod test {
 			let sac_3 = create_random_avatar::<Test, _>(&ALICE, Some(hash_base[3]), avatar_fn(31));
 			let sac_4 = create_random_avatar::<Test, _>(&ALICE, Some(hash_base[4]), avatar_fn(73));
 
-			let total_souls =
-				leader.1.get_souls() +
-					sac_1.1.get_souls() + sac_2.1.get_souls() +
-					sac_3.1.get_souls() + sac_4.1.get_souls();
+			let total_souls = leader.1.get_souls() +
+				sac_1.1.get_souls() +
+				sac_2.1.get_souls() +
+				sac_3.1.get_souls() +
+				sac_4.1.get_souls();
 
 			let leader_progress = leader.1.get_progress();
 			let lowest_count = DnaUtils::<BlockNumberFor<Test>>::lowest_progress_indexes(

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/build.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/build.rs
@@ -757,10 +757,11 @@ mod test {
 			let sac_3 = create_random_avatar::<Test, _>(&ALICE, Some(hash_base[3]), avatar_fn(250));
 			let sac_4 = create_random_avatar::<Test, _>(&ALICE, Some(hash_base[4]), avatar_fn(239));
 
-			let total_souls =
-				leader.1.get_souls() +
-					sac_1.1.get_souls() + sac_2.1.get_souls() +
-					sac_3.1.get_souls() + sac_4.1.get_souls();
+			let total_souls = leader.1.get_souls() +
+				sac_1.1.get_souls() +
+				sac_2.1.get_souls() +
+				sac_3.1.get_souls() +
+				sac_4.1.get_souls();
 			assert_eq!(total_souls, 953);
 
 			assert_eq!(leader.1.get_quantity(), 5);
@@ -864,10 +865,11 @@ mod test {
 			let sac_3 = create_random_avatar::<Test, _>(&ALICE, Some(hash_base[3]), avatar_fn(940));
 			let sac_4 = create_random_avatar::<Test, _>(&ALICE, Some(hash_base[4]), avatar_fn(717));
 
-			let total_souls =
-				leader.1.get_souls() +
-					sac_1.1.get_souls() + sac_2.1.get_souls() +
-					sac_3.1.get_souls() + sac_4.1.get_souls();
+			let total_souls = leader.1.get_souls() +
+				sac_1.1.get_souls() +
+				sac_2.1.get_souls() +
+				sac_3.1.get_souls() +
+				sac_4.1.get_souls();
 			assert_eq!(total_souls, 2475);
 
 			assert_eq!(

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/glimmer.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/glimmer.rs
@@ -176,7 +176,8 @@ mod test {
 						ForgeOutput::Minted(avatar) => avatar.souls,
 						_ => 0,
 					})
-					.sum::<SoulCount>() + wrapped.get_souls();
+					.sum::<SoulCount>() +
+					wrapped.get_souls();
 				assert_eq!(output_souls + GLIMMER_SP as u32, total_soul_points);
 
 				assert_eq!(wrapped.get_quantity(), 9);
@@ -276,7 +277,8 @@ mod test {
 						ForgeOutput::Minted(avatar) => avatar.souls,
 						_ => 0,
 					})
-					.sum::<SoulCount>() + wrapped.get_souls();
+					.sum::<SoulCount>() +
+					wrapped.get_souls();
 				assert_eq!(output_souls + 4 * GLIMMER_SP as u32, total_soul_points);
 
 				assert_eq!(wrapped.get_quantity(), 96);
@@ -385,7 +387,8 @@ mod test {
 						ForgeOutput::Minted(avatar) => avatar.souls,
 						_ => 0,
 					})
-					.sum::<SoulCount>() + wrapped.get_souls();
+					.sum::<SoulCount>() +
+					wrapped.get_souls();
 				assert_eq!(output_souls + 4 * GLIMMER_SP as u32, total_soul_points);
 
 				assert_eq!(wrapped.get_quantity(), 96);
@@ -531,7 +534,8 @@ mod test {
 						ForgeOutput::Minted(avatar) => avatar.souls,
 						_ => 0,
 					})
-					.sum::<SoulCount>() + leader_avatar.souls;
+					.sum::<SoulCount>() +
+					leader_avatar.souls;
 				assert_eq!(output_souls, total_soul_points);
 
 				if let ForgeOutput::Minted(avatar) = sacrifice_output.into_iter().nth(1).unwrap() {
@@ -586,7 +590,8 @@ mod test {
 						ForgeOutput::Minted(avatar) => avatar.souls,
 						_ => 0,
 					})
-					.sum::<SoulCount>() + leader_avatar.souls;
+					.sum::<SoulCount>() +
+					leader_avatar.souls;
 				assert_eq!(output_souls, total_soul_points);
 
 				if let ForgeOutput::Minted(avatar) = sacrifice_output.into_iter().nth(1).unwrap() {
@@ -641,7 +646,8 @@ mod test {
 						ForgeOutput::Minted(avatar) => avatar.souls,
 						_ => 0,
 					})
-					.sum::<SoulCount>() + leader_avatar.souls;
+					.sum::<SoulCount>() +
+					leader_avatar.souls;
 				assert_eq!(output_souls, total_soul_points);
 
 				if let ForgeOutput::Minted(avatar) = sacrifice_output.into_iter().nth(1).unwrap() {
@@ -693,7 +699,8 @@ mod test {
 						ForgeOutput::Minted(avatar) => avatar.souls,
 						_ => 0,
 					})
-					.sum::<SoulCount>() + leader_avatar.souls;
+					.sum::<SoulCount>() +
+					leader_avatar.souls;
 				assert_eq!(output_souls, total_soul_points);
 
 				if let ForgeOutput::Minted(avatar) = sacrifice_output.into_iter().nth(1).unwrap() {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/statue.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/statue.rs
@@ -58,7 +58,8 @@ impl<T: Config> AvatarCombinator<T> {
 				PET_MOON_PHASE_SIZE,
 				PET_MOON_PHASE_AMOUNT,
 				block_number,
-			) % 7) as usize + 9;
+			) % 7) as usize +
+				9;
 			leader_spec_bytes[pet_type_index] = leader_spec_bytes[pet_type_index].saturating_add(1);
 
 			leader.set_specs(leader_spec_bytes);

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/tinker.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/tinker.rs
@@ -643,10 +643,11 @@ mod test {
 				Some(unit_fn),
 			);
 
-			let total_soul_points =
-				leader.1.get_souls() +
-					sac_1.1.get_souls() + sac_2.1.get_souls() +
-					sac_3.1.get_souls() + sac_4.1.get_souls();
+			let total_soul_points = leader.1.get_souls() +
+				sac_1.1.get_souls() +
+				sac_2.1.get_souls() +
+				sac_3.1.get_souls() +
+				sac_4.1.get_souls();
 			assert_eq!(total_soul_points, 5);
 
 			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::tinker_avatars(

--- a/pallets/ajuna-battle-mogs/src/algorithm.rs
+++ b/pallets/ajuna-battle-mogs/src/algorithm.rs
@@ -457,7 +457,8 @@ impl Generation {
 
 			resulting_rarity = RarityType::from(
 				((out_rarity_1 as u16 +
-					out_rarity_2 as u16 + ((input_rarity_1 as u16 + input_rarity_2 as u16) / 2)) /
+					out_rarity_2 as u16 +
+					((input_rarity_1 as u16 + input_rarity_2 as u16) / 2)) /
 					2) % 5,
 			)
 		}


### PR DESCRIPTION
This updates the nightly, which has slightly different fmt settings. Hence, some files had to be formatted.

I have always been bothered that I got different results on my machine, but this should be resolved now.

Side-effect:
* The fmt job takes now 17secs instead of 50 secs 🥳 