### PR TITLE
Integrate adding funds to hero jam asset

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -24,6 +24,7 @@ pub mod account_manager;
 pub mod asset_manager;
 pub mod chain_inspector;
 pub mod runtime_types;
+pub mod sage_api;
 pub mod season_manager;
 pub mod trade_manager;
 pub mod treasury_manager;

--- a/primitives/src/sage_api.rs
+++ b/primitives/src/sage_api.rs
@@ -1,0 +1,5 @@
+pub trait SageApi {
+	type TransitionConfig;
+
+	fn get_transition_config() -> Self::TransitionConfig;
+}

--- a/sage/example-transition/src/asset/hero_jam.rs
+++ b/sage/example-transition/src/asset/hero_jam.rs
@@ -35,7 +35,7 @@ pub struct HeroJamAsset<BlockNumber> {
 	pub state_sub_value: u8,
 	pub state_change_block_number: BlockNumber,
 	// TODO: Use proper balance type in final version
-	pub balance: u32,
+	pub balance: u64,
 }
 
 impl<BlockNumber> GetId<AssetId> for HeroJamAsset<BlockNumber> {

--- a/sage/example-transition/src/transition/hero_jam.rs
+++ b/sage/example-transition/src/transition/hero_jam.rs
@@ -220,9 +220,10 @@ where
 				);
 
 				if work_type == &WorkType::Hunt {
+					let hunting_reward = Sage::get_transition_config().hunting_reward;
+
 					// Also do the accounting on the asset, but this is not necessary per se.
-					asset.balance = asset.balance.saturating_add(10);
-					let transition_config = Sage::get_transition_config();
+					asset.balance = asset.balance.saturating_add(hunting_reward);
 
 					// Todo: how to handle dispatch errors in transitions
 					Sage::deposit_funds_to_asset(
@@ -231,7 +232,7 @@ where
 						// Todo: how to pass the FungibleAssetId that was used as payment for this
 						<Sage::FungiblesAssetId as NativeId>::get_native_id(),
 						// Todo: use balance type in transition config
-						transition_config.hunting_reward,
+						hunting_reward,
 					)
 					.expect("transferring to asset failed");
 				}

--- a/sage/example-transition/src/transition/hero_jam.rs
+++ b/sage/example-transition/src/transition/hero_jam.rs
@@ -14,7 +14,9 @@ use sage_api::{
 };
 
 use crate::transition::GameTransitionConfig;
-use ajuna_primitives::sage_api::SageApi;
+use ajuna_primitives::{
+	asset_manager::AssetFundsManager, payment_handler::NativeId, sage_api::SageApi,
+};
 use core::marker::PhantomData;
 use frame_support::{
 	pallet_prelude::{Decode, Encode, MaxEncodedLen, TypeInfo},
@@ -111,7 +113,9 @@ where
 	AssetHandler: AssetManager<AccountId = AccountId, AssetId = AssetId, Asset = Asset<BlockNumber>>
 		+ AssetInspector<AccountId = AccountId, AssetId = AssetId, Asset = Asset<BlockNumber>>,
 	ChainHandler: ChainInspector<BlockNumber = BlockNumber>,
-	Sage: SageApi<TransitionConfig = GameTransitionConfig>,
+	Sage: SageApi<TransitionConfig = GameTransitionConfig>
+		+ AssetFundsManager<AccountId = AccountId, AssetId = AssetId, Balance = u64>,
+	<Sage as AssetFundsManager>::FungiblesAssetId: NativeId,
 {
 	fn try_get_hero_jam(asset_id: &AssetId) -> Result<HeroJamAsset<BlockNumber>, TransitionError> {
 		let asset = AssetHandler::get_asset(asset_id)
@@ -171,7 +175,7 @@ where
 
 	fn transition_assets(
 		transition_id: &HeroAction,
-		_account_id: &AccountId,
+		account_id: &AccountId,
 		assets: Vec<(AssetId, HeroJamAsset<BlockNumber>)>,
 	) -> Result<Vec<TransitionOutput<AssetId, Asset<BlockNumber>>>, TransitionError> {
 		match transition_id {
@@ -216,7 +220,20 @@ where
 				);
 
 				if work_type == &WorkType::Hunt {
+					// Also do the accounting on the asset, but this is not necessary per se.
 					asset.balance = asset.balance.saturating_add(10);
+					let transition_config = Sage::get_transition_config();
+
+					// Todo: how to handle dispatch errors in transitions
+					Sage::deposit_funds_to_asset(
+						&asset_id,
+						&account_id,
+						// Todo: how to pass the FungibleAssetId that was used as payment for this
+						<Sage::FungiblesAssetId as NativeId>::get_native_id(),
+						// Todo: use balance type in transition config
+						transition_config.game_fee,
+					)
+					.expect("transferring to asset failed");
 				}
 
 				asset.fatigue = (asset.fatigue as i32).saturating_add(fatigue).clamp(0, 255) as u8;
@@ -266,14 +283,17 @@ where
 	}
 }
 
-impl<AccountId, BlockNumber, AssetHandler, ChainHandler> SageGameTransition
-	for HeroJamTransition<AccountId, BlockNumber, AssetHandler, ChainHandler>
+impl<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage> SageGameTransition
+	for HeroJamTransition<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage>
 where
 	AccountId: Member + Codec,
 	BlockNumber: BlockNumberT,
 	AssetHandler: AssetManager<AccountId = AccountId, AssetId = AssetId, Asset = Asset<BlockNumber>>
 		+ AssetInspector<AccountId = AccountId, AssetId = AssetId, Asset = Asset<BlockNumber>>,
 	ChainHandler: ChainInspector<BlockNumber = BlockNumber>,
+	Sage: SageApi<TransitionConfig = GameTransitionConfig>
+		+ AssetFundsManager<AccountId = AccountId, AssetId = AssetId, Balance = u64>,
+	<Sage as AssetFundsManager>::FungiblesAssetId: NativeId,
 {
 	type TransitionId = HeroAction;
 	type TransitionConfig = ();

--- a/sage/example-transition/src/transition/hero_jam.rs
+++ b/sage/example-transition/src/transition/hero_jam.rs
@@ -231,7 +231,7 @@ where
 						// Todo: how to pass the FungibleAssetId that was used as payment for this
 						<Sage::FungiblesAssetId as NativeId>::get_native_id(),
 						// Todo: use balance type in transition config
-						transition_config.game_fee,
+						transition_config.hunting_reward,
 					)
 					.expect("transferring to asset failed");
 				}

--- a/sage/example-transition/src/transition/hero_jam.rs
+++ b/sage/example-transition/src/transition/hero_jam.rs
@@ -13,6 +13,8 @@ use sage_api::{
 	SageGameTransition, TransitionError,
 };
 
+use crate::transition::GameTransitionConfig;
+use ajuna_primitives::sage_api::SageApi;
 use core::marker::PhantomData;
 use frame_support::{
 	pallet_prelude::{Decode, Encode, MaxEncodedLen, TypeInfo},
@@ -97,18 +99,19 @@ impl From<u8> for SleepType {
 	}
 }
 
-pub(super) struct HeroJamTransition<AccountId, BlockNumber, AssetHandler, ChainHandler> {
-	_phantom: PhantomData<(AccountId, BlockNumber, AssetHandler, ChainHandler)>,
+pub(super) struct HeroJamTransition<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage> {
+	_phantom: PhantomData<(AccountId, BlockNumber, AssetHandler, ChainHandler, Sage)>,
 }
 
-impl<AccountId, BlockNumber, AssetHandler, ChainHandler>
-	HeroJamTransition<AccountId, BlockNumber, AssetHandler, ChainHandler>
+impl<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage>
+	HeroJamTransition<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage>
 where
 	AccountId: Member + Codec,
 	BlockNumber: BlockNumberT,
 	AssetHandler: AssetManager<AccountId = AccountId, AssetId = AssetId, Asset = Asset<BlockNumber>>
 		+ AssetInspector<AccountId = AccountId, AssetId = AssetId, Asset = Asset<BlockNumber>>,
 	ChainHandler: ChainInspector<BlockNumber = BlockNumber>,
+	Sage: SageApi<TransitionConfig = GameTransitionConfig>,
 {
 	fn try_get_hero_jam(asset_id: &AssetId) -> Result<HeroJamAsset<BlockNumber>, TransitionError> {
 		let asset = AssetHandler::get_asset(asset_id)

--- a/sage/example-transition/src/transition/hero_jam.rs
+++ b/sage/example-transition/src/transition/hero_jam.rs
@@ -227,7 +227,7 @@ where
 					// Todo: how to handle dispatch errors in transitions
 					Sage::deposit_funds_to_asset(
 						&asset_id,
-						&account_id,
+						account_id,
 						// Todo: how to pass the FungibleAssetId that was used as payment for this
 						<Sage::FungiblesAssetId as NativeId>::get_native_id(),
 						// Todo: use balance type in transition config

--- a/sage/example-transition/src/transition/mod.rs
+++ b/sage/example-transition/src/transition/mod.rs
@@ -6,6 +6,7 @@ use ajuna_primitives::{
 };
 use sage_api::{traits::TransitionOutput, SageGameTransition, TransitionError};
 
+use ajuna_primitives::sage_api::SageApi;
 use core::marker::PhantomData;
 use frame_support::pallet_prelude::{Decode, Encode, MaxEncodedLen, TypeInfo};
 use parity_scale_codec::Codec;
@@ -18,8 +19,8 @@ pub enum TransitionIdentifier {
 	HeroJam(hero_jam::HeroAction),
 }
 
-pub struct GameTransition<AccountId, BlockNumber, AssetHandler, ChainHandler> {
-	_phantom: PhantomData<(AccountId, BlockNumber, AssetHandler, ChainHandler)>,
+pub struct GameTransition<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage> {
+	_phantom: PhantomData<(AccountId, BlockNumber, AssetHandler, ChainHandler, Sage)>,
 }
 
 /// This is an example how a transition config custom to a game could look like.
@@ -28,8 +29,8 @@ pub struct GameTransitionConfig {
 	pub game_fee: u128,
 }
 
-impl<AccountId, BlockNumber, AssetHandler, ChainHandler> SageGameTransition
-	for GameTransition<AccountId, BlockNumber, AssetHandler, ChainHandler>
+impl<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage> SageGameTransition
+	for GameTransition<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage>
 where
 	AccountId: Member + Codec,
 	BlockNumber: BlockNumberT,
@@ -43,6 +44,7 @@ where
 			Asset = asset::Asset<BlockNumber>,
 		>,
 	ChainHandler: ChainInspector<BlockNumber = BlockNumber>,
+	Sage: SageApi<TransitionConfig = GameTransitionConfig>,
 {
 	type TransitionId = TransitionIdentifier;
 	type TransitionConfig = GameTransitionConfig;
@@ -58,17 +60,14 @@ where
 		extra: &Self::Extra,
 	) -> Result<Vec<TransitionOutput<Self::AssetId, Self::Asset>>, TransitionError> {
 		match transition_id {
-			TransitionIdentifier::HeroJam(hero_action) => hero_jam::HeroJamTransition::<
-				AccountId,
-				BlockNumber,
-				AssetHandler,
-				ChainHandler,
-			>::do_transition(
-				hero_action,
-				account_id,
-				assets_ids,
-				extra,
-			),
+			TransitionIdentifier::HeroJam(hero_action) =>
+				hero_jam::HeroJamTransition::<
+					AccountId,
+					BlockNumber,
+					AssetHandler,
+					ChainHandler,
+					Sage,
+				>::do_transition(hero_action, account_id, assets_ids, extra),
 		}
 	}
 }

--- a/sage/example-transition/src/transition/mod.rs
+++ b/sage/example-transition/src/transition/mod.rs
@@ -22,6 +22,12 @@ pub struct GameTransition<AccountId, BlockNumber, AssetHandler, ChainHandler> {
 	_phantom: PhantomData<(AccountId, BlockNumber, AssetHandler, ChainHandler)>,
 }
 
+/// This is an example how a transition config custom to a game could look like.
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct GameTransitionConfig {
+	pub game_fee: u128,
+}
+
 impl<AccountId, BlockNumber, AssetHandler, ChainHandler> SageGameTransition
 	for GameTransition<AccountId, BlockNumber, AssetHandler, ChainHandler>
 where
@@ -39,7 +45,7 @@ where
 	ChainHandler: ChainInspector<BlockNumber = BlockNumber>,
 {
 	type TransitionId = TransitionIdentifier;
-	type TransitionConfig = ();
+	type TransitionConfig = GameTransitionConfig;
 	type AccountId = AccountId;
 	type AssetId = asset::AssetId;
 	type Asset = asset::Asset<BlockNumber>;

--- a/sage/example-transition/src/transition/mod.rs
+++ b/sage/example-transition/src/transition/mod.rs
@@ -6,7 +6,10 @@ use ajuna_primitives::{
 };
 use sage_api::{traits::TransitionOutput, SageGameTransition, TransitionError};
 
-use ajuna_primitives::sage_api::SageApi;
+use crate::asset::AssetId;
+use ajuna_primitives::{
+	asset_manager::AssetFundsManager, payment_handler::NativeId, sage_api::SageApi,
+};
 use core::marker::PhantomData;
 use frame_support::pallet_prelude::{Decode, Encode, MaxEncodedLen, TypeInfo};
 use parity_scale_codec::Codec;
@@ -26,7 +29,7 @@ pub struct GameTransition<AccountId, BlockNumber, AssetHandler, ChainHandler, Sa
 /// This is an example how a transition config custom to a game could look like.
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct GameTransitionConfig {
-	pub game_fee: u128,
+	pub game_fee: u64,
 }
 
 impl<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage> SageGameTransition
@@ -34,17 +37,12 @@ impl<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage> SageGameTransitio
 where
 	AccountId: Member + Codec,
 	BlockNumber: BlockNumberT,
-	AssetHandler: AssetManager<
-			AccountId = AccountId,
-			AssetId = asset::AssetId,
-			Asset = asset::Asset<BlockNumber>,
-		> + AssetInspector<
-			AccountId = AccountId,
-			AssetId = asset::AssetId,
-			Asset = asset::Asset<BlockNumber>,
-		>,
+	AssetHandler: AssetManager<AccountId = AccountId, AssetId = AssetId, Asset = asset::Asset<BlockNumber>>
+		+ AssetInspector<AccountId = AccountId, AssetId = AssetId, Asset = asset::Asset<BlockNumber>>,
 	ChainHandler: ChainInspector<BlockNumber = BlockNumber>,
-	Sage: SageApi<TransitionConfig = GameTransitionConfig>,
+	Sage: SageApi<TransitionConfig = GameTransitionConfig>
+		+ AssetFundsManager<AccountId = AccountId, AssetId = AssetId, Balance = u64>,
+	<Sage as AssetFundsManager>::FungiblesAssetId: NativeId,
 {
 	type TransitionId = TransitionIdentifier;
 	type TransitionConfig = GameTransitionConfig;

--- a/sage/example-transition/src/transition/mod.rs
+++ b/sage/example-transition/src/transition/mod.rs
@@ -27,7 +27,7 @@ pub struct GameTransition<AccountId, BlockNumber, AssetHandler, ChainHandler, Sa
 }
 
 /// This is an example how a transition config custom to a game could look like.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Default, Clone, PartialEq, Eq)]
 pub struct GameTransitionConfig {
 	pub hunting_reward: u64,
 }

--- a/sage/example-transition/src/transition/mod.rs
+++ b/sage/example-transition/src/transition/mod.rs
@@ -29,7 +29,7 @@ pub struct GameTransition<AccountId, BlockNumber, AssetHandler, ChainHandler, Sa
 /// This is an example how a transition config custom to a game could look like.
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct GameTransitionConfig {
-	pub game_fee: u64,
+	pub hunting_reward: u64,
 }
 
 impl<AccountId, BlockNumber, AssetHandler, ChainHandler, Sage> SageGameTransition

--- a/sage/pallet/src/benchmarking.rs
+++ b/sage/pallet/src/benchmarking.rs
@@ -18,8 +18,8 @@ use crate::{
 	config::{InventoryTier, Locks},
 	pallet::AssetFilterOf,
 	AssetIdOf, AssetOf, AssetOwners, AssetTradePrices, Assets, BalanceOf, Config, Event, ExtraOf,
-	GeneralConfigOf, GeneralConfigStore, LockableFeature, Organizer, Pallet, PlayerSeasonConfigs,
-	SeasonIdOf, SeasonUnlocks, UnlockRule, UnlockTarget, SAGE_LOCK_ID,
+	GeneralConfigStore, LockableFeature, Organizer, Pallet, PlayerSeasonConfigs, SeasonIdOf,
+	SeasonUnlocks, UnlockRule, UnlockTarget, SAGE_LOCK_ID,
 };
 use ajuna_primitives::{asset_manager::Lock, season_manager::SeasonManager};
 use frame_benchmarking::v2::*;
@@ -84,7 +84,7 @@ fn unlock_player_features_for<T: Config<I>, I: 'static>(
 #[instance_benchmarks]
 mod benchmarks {
 	use super::*;
-	use crate::Call;
+	use crate::{Call, GeneralConfig, TransitionConfigOf};
 	use sage_api::benchmarks::SageBenchmarkHelper;
 
 	#[benchmark]
@@ -101,12 +101,24 @@ mod benchmarks {
 	fn update_general_config() {
 		let acc_1 = account::<T, I>(ACC_1);
 		setup_organizer::<T, I>(acc_1.clone());
-		let general_config = GeneralConfigOf::<T, I>::default();
+		let general_config = GeneralConfig::default();
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(acc_1), general_config.clone());
 
-		assert_last_event::<T, I>(Event::UpdatedGeneralConfig { updated_config: general_config });
+		assert_last_event::<T, I>(Event::UpdatedGeneralConfig { new_config: general_config });
+	}
+
+	#[benchmark]
+	fn update_transition_config() {
+		let acc_1 = account::<T, I>(ACC_1);
+		setup_organizer::<T, I>(acc_1.clone());
+		let transition_config = TransitionConfigOf::<T, I>::default();
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(acc_1), transition_config.clone());
+
+		assert_last_event::<T, I>(Event::UpdatedTransitionConfig { new_config: transition_config });
 	}
 
 	#[benchmark]

--- a/sage/pallet/src/config/mod.rs
+++ b/sage/pallet/src/config/mod.rs
@@ -44,10 +44,7 @@ pub struct TradeConfig {
 }
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
-pub struct GeneralConfig<
-	TransitionConfig: Member + Encode + Decode + MaxEncodedLen + TypeInfo + Default,
-> {
-	pub transition: TransitionConfig,
+pub struct GeneralConfig {
 	pub transfer: TransferConfig,
 	pub trade: TradeConfig,
 }

--- a/sage/pallet/src/lib.rs
+++ b/sage/pallet/src/lib.rs
@@ -88,7 +88,6 @@ pub mod pallet {
 	pub type TransitionConfigOf<T, I> =
 		<<T as Config<I>>::SageGameTransition as SageGameTransition>::TransitionConfig;
 	pub(crate) type TransitionOutputOf<T, I> = TransitionOutput<AssetIdOf<T, I>, AssetOf<T, I>>;
-	pub type GeneralConfigOf<T, I> = GeneralConfig<TransitionConfigOf<T, I>>;
 	pub type PlayerStatsOf<T> = PlayerStats<BlockNumberFor<T>>;
 
 	pub type SeasonConfigOf<T, I> = SeasonConfig<BalanceOf<T, I>, SeasonDataOf<T, I>>;
@@ -118,10 +117,9 @@ pub mod pallet {
 			if let Some(ref organizer) = self.organizer {
 				Organizer::<T, I>::set(Some(organizer.clone()));
 
-				GeneralConfigStore::<T, I>::set(GeneralConfigOf::<T, I> {
+				GeneralConfigStore::<T, I>::set(GeneralConfig {
 					transfer: TransferConfig { open: true },
 					trade: TradeConfig { open: true },
-					..Default::default()
 				});
 
 				if let Some(ref season_id) = self.season {
@@ -209,7 +207,12 @@ pub mod pallet {
 	/// Tracks global configuration values that can be changed by the organizer only.
 	#[pallet::storage]
 	pub type GeneralConfigStore<T: Config<I>, I: 'static = ()> =
-		StorageValue<_, GeneralConfigOf<T, I>, ValueQuery>;
+		StorageValue<_, GeneralConfig, ValueQuery>;
+
+	/// Configuration values specific to the transition being used.
+	#[pallet::storage]
+	pub type TransitionConfigStore<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, TransitionConfigOf<T, I>, ValueQuery>;
 
 	/// Some features need to be unlocked fulfilling certain criteria.
 	///
@@ -332,7 +335,9 @@ pub mod pallet {
 		/// An organizer has been set.
 		OrganizerSet { organizer: AccountIdOf<T> },
 		/// General configuration updated.
-		UpdatedGeneralConfig { updated_config: GeneralConfigOf<T, I> },
+		UpdatedGeneralConfig { new_config: GeneralConfig },
+		/// Transition configuration updated.
+		UpdatedTransitionConfig { new_config: TransitionConfigOf<T, I> },
 		/// Unlock configuration updated for feature.
 		UpdatedUnlockRule {
 			season_id: SeasonIdOf<T, I>,
@@ -467,20 +472,35 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::update_general_config())]
 		pub fn update_general_config(
 			origin: OriginFor<T>,
-			new_config: GeneralConfigOf<T, I>,
+			new_config: GeneralConfig,
 		) -> DispatchResult {
 			let signer = ensure_signed(origin)?;
 			Self::ensure_organizer(&signer)?;
 
 			GeneralConfigStore::<T, I>::put(&new_config);
-			Self::deposit_event(Event::UpdatedGeneralConfig { updated_config: new_config });
+			Self::deposit_event(Event::UpdatedGeneralConfig { new_config });
+			Ok(())
+		}
+
+		/// Update general configuration.
+		#[pallet::call_index(2)]
+		#[pallet::weight(T::WeightInfo::update_general_config())]
+		pub fn update_transition_config(
+			origin: OriginFor<T>,
+			new_config: TransitionConfigOf<T, I>,
+		) -> DispatchResult {
+			let signer = ensure_signed(origin)?;
+			Self::ensure_organizer(&signer)?;
+
+			TransitionConfigStore::<T, I>::put(&new_config);
+			Self::deposit_event(Event::UpdatedTransitionConfig { new_config });
 			Ok(())
 		}
 
 		/// Updates an unlock rule for the given season.
 		///
 		/// It doesn't affect already unlocked features.
-		#[pallet::call_index(2)]
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::update_unlock_rule())]
 		pub fn update_unlock_rule(
 			origin: OriginFor<T>,
@@ -502,7 +522,7 @@ pub mod pallet {
 		}
 
 		/// Upgrade the asset inventory space.
-		#[pallet::call_index(3)]
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::upgrade_asset_inventory())]
 		pub fn upgrade_asset_inventory(
 			origin: OriginFor<T>,
@@ -550,7 +570,7 @@ pub mod pallet {
 		}
 
 		/// Updates the filter that assets need to pass for certain actions.
-		#[pallet::call_index(4)]
+		#[pallet::call_index(5)]
 		#[pallet::weight(
 			T::WeightInfo::update_asset_trade_filter()
 				.max(T::WeightInfo::update_asset_transfer_filter())
@@ -581,7 +601,7 @@ pub mod pallet {
 		///
 		/// It will fail if the asset transfer is disabled, the asset doesn't pass the filter
 		/// or if the asset is on the market.
-		#[pallet::call_index(5)]
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::transfer_asset())]
 		pub fn transfer_asset(
 			origin: OriginFor<T>,
@@ -632,7 +652,7 @@ pub mod pallet {
 		}
 
 		/// Set the price of a given asset, putting it on sale for others to buy.
-		#[pallet::call_index(6)]
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::set_asset_price())]
 		pub fn set_asset_price(
 			origin: OriginFor<T>,
@@ -664,7 +684,7 @@ pub mod pallet {
 		}
 
 		/// Remove the price of an asset, and thereby remove it from the market.
-		#[pallet::call_index(7)]
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::remove_asset_price())]
 		pub fn remove_asset_price(
 			origin: OriginFor<T>,
@@ -681,7 +701,7 @@ pub mod pallet {
 		}
 
 		/// Attempt to buy the selected asset.
-		#[pallet::call_index(8)]
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::WeightInfo::buy_asset())]
 		pub fn buy_asset(
 			origin: OriginFor<T>,
@@ -736,7 +756,7 @@ pub mod pallet {
 		}
 
 		/// Locks an asset, making it unavailable for use.
-		#[pallet::call_index(9)]
+		#[pallet::call_index(10)]
 		#[pallet::weight(T::WeightInfo::lock_asset())]
 		pub fn lock_asset(origin: OriginFor<T>, asset_id: AssetIdOf<T, I>) -> DispatchResult {
 			let player = ensure_signed(origin)?;
@@ -745,7 +765,7 @@ pub mod pallet {
 		}
 
 		/// Unlocks an asset, making it available for use again.
-		#[pallet::call_index(10)]
+		#[pallet::call_index(11)]
 		#[pallet::weight(T::WeightInfo::unlock_asset())]
 		pub fn unlock_asset(origin: OriginFor<T>, asset_id: AssetIdOf<T, I>) -> DispatchResult {
 			let player = ensure_signed(origin)?;
@@ -754,7 +774,7 @@ pub mod pallet {
 		}
 
 		/// Attempts to unlock the selected feature for the `target`.
-		#[pallet::call_index(11)]
+		#[pallet::call_index(12)]
 		#[pallet::weight(
 			T::WeightInfo::unlock_trade_asset_feature()
 				.max(T::WeightInfo::unlock_transfer_asset_feature())
@@ -779,7 +799,7 @@ pub mod pallet {
 		}
 
 		/// Entry point for the custom state transition.
-		#[pallet::call_index(12)]
+		#[pallet::call_index(13)]
 		#[pallet::weight(T::WeightInfo::state_transition(6))]
 		pub fn state_transition(
 			origin: OriginFor<T>,

--- a/sage/pallet/src/mock.rs
+++ b/sage/pallet/src/mock.rs
@@ -23,6 +23,7 @@ use ajuna_primitives::{
 		TransferFungibleAssets, VoucherHandler, WithdrawCreditOrVoucher, WithdrawFungibles,
 		WithdrawKind, WithdrawWhitelistedCredit,
 	},
+	sage_api::SageApi,
 	season_manager::{SeasonConfig, SeasonFeeConfig, SeasonManager},
 };
 use frame_support::{
@@ -102,7 +103,7 @@ pub const NATIVE_PAYMENT: WithdrawKind<NativeOrWithId<AssetId>> =
 	WithdrawKind::Payment(NativeOrWithId::Native);
 pub const SOME_NATIVE_PAYMENT: Option<WithdrawKind<NativeOrWithId<AssetId>>> = Some(NATIVE_PAYMENT);
 
-use example_transition::prelude::*;
+use example_transition::{prelude::*, transition::GameTransitionConfig};
 
 parameter_types! {
 	pub const ExamplePalletId: PalletId = PalletId(*b"sage/exi");
@@ -176,9 +177,11 @@ impl SeasonManager for MockSeasonManager {
 	}
 }
 
-pub struct MockAssetMediator;
+/// Facade around Sage to prevent recursion errors during build
+/// when sage would be also a field in its associated types.
+pub struct SageFacade;
 
-impl AssetManager for MockAssetMediator {
+impl AssetManager for SageFacade {
 	type AccountId = MockAccountId;
 	type AssetId = AssetId;
 	type Asset = MockAsset;
@@ -211,7 +214,7 @@ impl AssetManager for MockAssetMediator {
 	}
 }
 
-impl AssetInspector for MockAssetMediator {
+impl AssetInspector for SageFacade {
 	type AccountId = MockAccountId;
 	type AssetId = AssetId;
 	type Asset = MockAsset;
@@ -227,11 +230,69 @@ impl AssetInspector for MockAssetMediator {
 	}
 }
 
-impl ChainInspector for MockAssetMediator {
+impl AssetFundsManager for SageFacade {
+	type AccountId = MockAccountId;
+	type AssetId = AssetId;
+	type FungiblesAssetId = FungiblesAssetId;
+	type Balance = MockBalance;
+
+	fn inspect_asset_funds(
+		asset_id: &Self::AssetId,
+		fungibles_asset_id: &Self::FungiblesAssetId,
+	) -> Self::Balance {
+		<Sage as AssetFundsManager>::inspect_asset_funds(asset_id, fungibles_asset_id)
+	}
+
+	fn deposit_funds_to_asset(
+		asset_id: &Self::AssetId,
+		from: &Self::AccountId,
+		fungibles_asset_id: Self::FungiblesAssetId,
+		amount: Self::Balance,
+	) -> Result<(), DispatchError> {
+		<Sage as AssetFundsManager>::deposit_funds_to_asset(
+			asset_id,
+			from,
+			fungibles_asset_id,
+			amount,
+		)
+	}
+
+	fn transfer_funds_from_asset(
+		asset_id: &Self::AssetId,
+		to: &Self::AccountId,
+		fungibles_asset_id: Self::FungiblesAssetId,
+		amount: Self::Balance,
+	) -> Result<(), DispatchError> {
+		<Sage as AssetFundsManager>::transfer_funds_from_asset(
+			asset_id,
+			to,
+			fungibles_asset_id,
+			amount,
+		)
+	}
+
+	fn transfer_all_from_asset(
+		asset_id: &Self::AssetId,
+		to: &Self::AccountId,
+		fungibles_asset_id: Self::FungiblesAssetId,
+	) -> Result<(), DispatchError> {
+		<Sage as AssetFundsManager>::transfer_all_from_asset(asset_id, to, fungibles_asset_id)
+	}
+}
+
+impl ChainInspector for SageFacade {
 	type BlockNumber = BlockNumberFor<Test>;
 
 	fn get_current_block_number() -> Self::BlockNumber {
 		System::block_number()
+	}
+}
+
+impl SageApi for SageFacade {
+	type TransitionConfig = GameTransitionConfig;
+
+	fn get_transition_config() -> Self::TransitionConfig {
+		<Sage as SageApi>::get_transition_config()
 	}
 }
 
@@ -250,7 +311,7 @@ impl VoucherHandler for MockVoucherHandler {
 }
 
 pub type GameTransitionOf =
-	GameTransition<MockAccountId, BlockNumberFor<Test>, MockAssetMediator, MockAssetMediator>;
+	GameTransition<MockAccountId, BlockNumberFor<Test>, SageFacade, SageFacade, SageFacade>;
 
 pub type WithdrawAllCreditOrVoucher = WithdrawCreditOrVoucher<
 	WithdrawWhitelistedCredit<

--- a/sage/pallet/src/mock.rs
+++ b/sage/pallet/src/mock.rs
@@ -412,7 +412,6 @@ impl ExtBuilder {
 
 			// Setting initial general config for tests
 			let config = GeneralConfig {
-				transition: (),
 				transfer: TransferConfig { open: true },
 				trade: TradeConfig { open: true },
 			};

--- a/sage/pallet/src/tests/extrinsics/mod.rs
+++ b/sage/pallet/src/tests/extrinsics/mod.rs
@@ -27,5 +27,6 @@ mod unlock_asset;
 mod unlock_feature;
 mod update_asset_filter;
 mod update_general_config;
+mod update_transition_config;
 mod update_unlock_rule;
 mod upgrade_asset_inventory;

--- a/sage/pallet/src/tests/extrinsics/state_transition.rs
+++ b/sage/pallet/src/tests/extrinsics/state_transition.rs
@@ -5,18 +5,19 @@
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use super::*;
+use ajuna_primitives::sage_api::SageApi;
 
 use example_transition::transition::{
-	hero_jam::{ActionTime, HeroAction, SleepType},
+	hero_jam::{ActionTime, HeroAction, SleepType, WorkType},
 	TransitionIdentifier,
 };
 
@@ -161,4 +162,47 @@ fn state_transition_should_reject_too_many_input_assets() {
 				Error::<Test, ()>::TooManyAssetsInTransition
 			);
 		})
+}
+
+#[test]
+fn hero_hunt_transition_add_funds_to_balance_works() {
+	let initial_balance = 100_000;
+	ExtBuilder::default()
+		.balances(&[(ALICE, initial_balance)])
+		.build()
+		.execute_with(|| {
+			let asset_ids = create_assets::<()>(SEASON_ID_0, ALICE, 1);
+			let season_id = <Test as Config<()>>::SeasonHandler::get_current_season_id()
+				.expect("Should get season_id");
+			let season_config =
+				<Test as Config<()>>::SeasonHandler::get_season_config_for(&season_id)
+					.expect("Should get season config");
+			let transition_id =
+				TransitionIdentifier::HeroJam(HeroAction::Work(WorkType::Hunt, ActionTime::Short));
+
+			assert_eq!(Balances::free_balance(ALICE), initial_balance);
+			assert_ok!(Sage::state_transition(
+				RuntimeOrigin::signed(ALICE),
+				transition_id,
+				asset_ids.clone(),
+				(),
+				SOME_NATIVE_PAYMENT
+			));
+			System::assert_last_event(RuntimeEvent::Sage(Event::TransitionExecuted {
+				account: ALICE,
+				id: transition_id,
+			}));
+			let transition_fee = season_config.fee.state_transition_base_fee;
+			let transition_config = Sage::get_transition_config();
+			let hunting_reward = transition_config.hunting_reward;
+			assert_eq!(
+				Balances::free_balance(ALICE),
+				initial_balance - transition_fee - hunting_reward
+			);
+			assert_eq!(Balances::free_balance(Sage::assets_funds_pot()), hunting_reward);
+			assert_eq!(
+				AssetFunds::<Test, _>::get(asset_ids[0], NATIVE_PAYMENT),
+				Some(hunting_reward)
+			);
+		});
 }

--- a/sage/pallet/src/tests/extrinsics/update_transition_config.rs
+++ b/sage/pallet/src/tests/extrinsics/update_transition_config.rs
@@ -15,23 +15,27 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
+use example_transition::transition::GameTransitionConfig;
 
 #[test]
-fn update_general_config_should_work() {
+fn update_transition_config_should_work() {
 	ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
-		let config = GeneralConfig::default();
-		assert_ok!(Sage::update_general_config(RuntimeOrigin::signed(ALICE), config.clone()));
-		System::assert_last_event(RuntimeEvent::Sage(Event::UpdatedGeneralConfig {
+		let config = GameTransitionConfig { game_fee: 10 };
+		assert_ok!(Sage::update_transition_config(RuntimeOrigin::signed(ALICE), config.clone()));
+		System::assert_last_event(RuntimeEvent::Sage(Event::UpdatedTransitionConfig {
 			new_config: config,
 		}));
 	});
 }
 
 #[test]
-fn update_general_config_should_reject_non_organizer_calls() {
+fn update_transition_config_should_reject_non_organizer_calls() {
 	ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
 		assert_noop!(
-			Sage::update_general_config(RuntimeOrigin::signed(BOB), GeneralConfig::default()),
+			Sage::update_transition_config(
+				RuntimeOrigin::signed(BOB),
+				TransitionConfigOf::<Test, _>::default()
+			),
 			DispatchError::BadOrigin
 		);
 	});

--- a/sage/pallet/src/tests/extrinsics/update_transition_config.rs
+++ b/sage/pallet/src/tests/extrinsics/update_transition_config.rs
@@ -20,7 +20,7 @@ use example_transition::transition::GameTransitionConfig;
 #[test]
 fn update_transition_config_should_work() {
 	ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
-		let config = GameTransitionConfig { game_fee: 10 };
+		let config = GameTransitionConfig { hunting_reward: 10 };
 		assert_ok!(Sage::update_transition_config(RuntimeOrigin::signed(ALICE), config.clone()));
 		System::assert_last_event(RuntimeEvent::Sage(Event::UpdatedTransitionConfig {
 			new_config: config,

--- a/sage/pallet/src/trait_impls/mod.rs
+++ b/sage/pallet/src/trait_impls/mod.rs
@@ -18,3 +18,4 @@ use super::*;
 
 mod account_manager;
 mod asset_manager;
+mod sage_api;

--- a/sage/pallet/src/trait_impls/sage_api.rs
+++ b/sage/pallet/src/trait_impls/sage_api.rs
@@ -1,0 +1,10 @@
+use crate::{Config, Pallet, TransitionConfigOf, TransitionConfigStore};
+use ajuna_primitives::sage_api::SageApi;
+
+impl<T: Config<I>, I: 'static> SageApi for Pallet<T, I> {
+	type TransitionConfig = TransitionConfigOf<T, I>;
+
+	fn get_transition_config() -> Self::TransitionConfig {
+		TransitionConfigStore::<T, I>::get()
+	}
+}


### PR DESCRIPTION
This PR also extracts the `TransitionConfig` as its standalone storage type. I think this is better in a separate of concerns, and it is best practice to separate storage values wherever they are not inherently tied together.

I think that we should separate custom game types from our types in general, so that we can decouple our changes from their changes better.

There are a few todos that emerged during this PR, but I consider this out of scope and I have created JIRA issues for that.