### PR TITLE
[SAGE/Seasons] Infinite seasons

### DIFF
--- a/pallets/ajuna-seasons/src/benchmarking.rs
+++ b/pallets/ajuna-seasons/src/benchmarking.rs
@@ -78,8 +78,11 @@ mod benchmarks {
 			description: BoundedVec::try_from(b"The first season".to_vec())
 				.expect("Should create vec"),
 		};
-		let schedule =
-			SeasonSchedule { early_start: 20_u32.into(), start: 25_u32.into(), end: 30_u32.into() };
+		let schedule = SeasonSchedule {
+			early_start: 20_u32.into(),
+			start: 25_u32.into(),
+			end: Some(30_u32.into()),
+		};
 
 		#[extrinsic_call]
 		_(
@@ -119,8 +122,11 @@ mod benchmarks {
 			description: BoundedVec::try_from(b"The first season".to_vec())
 				.expect("Should create vec"),
 		};
-		let schedule =
-			SeasonSchedule { early_start: 20_u32.into(), start: 25_u32.into(), end: 30_u32.into() };
+		let schedule = SeasonSchedule {
+			early_start: 20_u32.into(),
+			start: 25_u32.into(),
+			end: Some(30_u32.into()),
+		};
 		Seasons::<T, I>::update_season(
 			RawOrigin::Signed(acc_1.clone()).into(),
 			season_id.clone(),

--- a/pallets/ajuna-seasons/src/lib.rs
+++ b/pallets/ajuna-seasons/src/lib.rs
@@ -114,7 +114,7 @@ pub mod pallet {
 				let end = duration.saturating_add(5_u32.into());
 				SeasonSchedules::<T, I>::insert(
 					season_id,
-					SeasonSchedule { early_start, start, end },
+					SeasonSchedule { early_start, start, end: Some(end) },
 				);
 
 				SeasonScheduledActions::<T, I>::insert(
@@ -229,8 +229,14 @@ pub mod pallet {
 	pub enum Error<T, I = ()> {
 		/// There is currently no active season
 		NoActiveSeason,
-		/// Cannot set season schedule wihout season config first.
+		/// Cannot set season schedule without season config first.
 		CannotScheduleSeasonWithoutConfig,
+		/// The previous season has no end, making it so that no
+		/// new seasons can be added after it.
+		CannotScheduleSeasonIfPreviousSeasonIsInfinite,
+		/// Cannot modify a season to be infinite if a season after it has already
+		/// been scheduled.
+		CannotScheduleInfiniteSeasonIfNextSeasonExists,
 		/// The season's early start is before the current block.
 		SeasonStartBeforeCurrentBlock,
 		/// The season starts before the previous season starts.
@@ -390,6 +396,23 @@ pub mod pallet {
 					Self::ensure_valid_schedule(&season_id, schedule_update)?;
 					Self::update_season_scheduled_actions(&season_id, schedule_update)?;
 				}
+			} else if Self::is_active_season_and_infinite(&season_id) {
+				// If the season we want to update is the current active season,
+				// and it has infinite duration (no end block).
+				// We only allow to add an end ot it once.
+				if let Some(SeasonSchedule { end: Some(end), .. }) = schedule {
+					Self::add_season_end_action_at(&season_id, end)?;
+					SeasonSchedules::<T, I>::mutate(&season_id, |maybe_schedule| {
+						if let Some(ref mut schedule) = maybe_schedule {
+							schedule.end = Some(end);
+						} else {
+							log::error!(target: LOG_TARGET,
+								"Updating schedule for active infinite season [{:?}], found no schedule data!",
+								&season_id,
+							);
+						}
+					});
+				}
 			}
 
 			if let Some(ref meta_update) = metadata {
@@ -418,7 +441,10 @@ pub mod pallet {
 						.ok_or(Error::<T, I>::InvalidSeason)?;
 					SeasonScheduledActions::<T, I>::remove(season_schedule.early_start);
 					SeasonScheduledActions::<T, I>::remove(season_schedule.start);
-					SeasonScheduledActions::<T, I>::remove(season_schedule.end);
+
+					if let Some(ref end) = season_schedule.end {
+						SeasonScheduledActions::<T, I>::remove(end);
+					}
 
 					// TODO: Maybe we could try to early start the next season if
 					// it exists and its early start was skipped
@@ -464,6 +490,18 @@ pub mod pallet {
 			}
 		}
 
+		fn is_active_season_and_infinite(season_id: &SeasonIdOf<T, I>) -> bool {
+			if let Ok(current_season) = CurrentSeasonStatus::<T, I>::get() {
+				if &current_season.season_id == season_id {
+					if let Some(schedule) = SeasonSchedules::<T, I>::get(season_id) {
+						return schedule.end.is_none();
+					}
+				}
+			}
+
+			false
+		}
+
 		fn ensure_valid_schedule(
 			season_id: &SeasonIdOf<T, I>,
 			schedule: &SeasonScheduleOf<T>,
@@ -477,7 +515,10 @@ pub mod pallet {
 				schedule.early_start < schedule.start,
 				Error::<T, I>::SeasonStartBeforeEarlyStart
 			);
-			ensure!(schedule.start < schedule.end, Error::<T, I>::SeasonEndBeforeStart);
+
+			if let Some(ref end) = schedule.end {
+				ensure!(schedule.start < *end, Error::<T, I>::SeasonEndBeforeStart);
+			}
 
 			if let Some(prev_season_id) = PrevSeasonChain::<T, I>::get(season_id) {
 				if let Some(prev_schedule) = SeasonSchedules::<T, I>::get(prev_season_id) {
@@ -485,6 +526,12 @@ pub mod pallet {
 						prev_schedule.start < schedule.early_start,
 						Error::<T, I>::SeasonStartOverlapsPreviousSeason
 					);
+
+					if prev_schedule.end.is_none() {
+						return Err(
+							Error::<T, I>::CannotScheduleSeasonIfPreviousSeasonIsInfinite.into()
+						);
+					}
 				}
 			}
 
@@ -494,6 +541,12 @@ pub mod pallet {
 						schedule.start < next_schedule.early_start,
 						Error::<T, I>::SeasonStartOverlapsNextSeason
 					);
+
+					if schedule.end.is_none() {
+						return Err(
+							Error::<T, I>::CannotScheduleInfiniteSeasonIfNextSeasonExists.into()
+						);
+					}
 				}
 			}
 
@@ -508,7 +561,9 @@ pub mod pallet {
 				if let Some(ref prev_schedule) = maybe_prev_schedule {
 					SeasonScheduledActions::<T, I>::remove(prev_schedule.early_start);
 					SeasonScheduledActions::<T, I>::remove(prev_schedule.start);
-					SeasonScheduledActions::<T, I>::remove(prev_schedule.end);
+					if let Some(ref prev_end) = prev_schedule.end {
+						SeasonScheduledActions::<T, I>::remove(prev_end);
+					}
 				}
 
 				SeasonScheduledActions::<T, I>::try_mutate(schedule.early_start, |maybe_action| {
@@ -525,18 +580,27 @@ pub mod pallet {
 
 					Ok::<(), DispatchError>(())
 				})?;
-				SeasonScheduledActions::<T, I>::try_mutate(schedule.end, |maybe_action| {
-					ensure!(maybe_action.is_none(), Error::<T, I>::ScheduleSlotAlreadyInUse);
-
-					*maybe_action = Some(SeasonScheduledAction::End(season_id.clone()));
-
-					Ok::<(), DispatchError>(())
-				})?;
+				if let Some(end) = schedule.end {
+					Self::add_season_end_action_at(season_id, end)?;
+				}
 
 				*maybe_prev_schedule = Some(schedule.clone());
 
 				Ok::<(), DispatchError>(())
 			})
+		}
+
+		fn add_season_end_action_at(
+			season_id: &SeasonIdOf<T, I>,
+			end: BlockNumberFor<T>,
+		) -> DispatchResult {
+			SeasonScheduledActions::<T, I>::try_mutate(end, |maybe_action| {
+				ensure!(maybe_action.is_none(), Error::<T, I>::ScheduleSlotAlreadyInUse);
+				*maybe_action = Some(SeasonScheduledAction::End(season_id.clone()));
+				Ok::<(), DispatchError>(())
+			})?;
+
+			Ok(())
 		}
 	}
 }

--- a/pallets/ajuna-seasons/src/test_impls.rs
+++ b/pallets/ajuna-seasons/src/test_impls.rs
@@ -31,7 +31,7 @@ fn start_season(organizer: MockAccountId, season_id: MockSeasonId) {
 		},
 	};
 	let early_start = 20;
-	let schedule = SeasonSchedule { early_start, start: 25, end: 30 };
+	let schedule = SeasonSchedule { early_start, start: 25, end: Some(30) };
 
 	assert_ok!(SeasonsAlpha::update_season(
 		RuntimeOrigin::signed(organizer),
@@ -112,7 +112,7 @@ mod season_manager {
 					state_transition_base_fee: 20_u64,
 				},
 			};
-			let schedule = SeasonSchedule { early_start: 20, start: 25, end: 30 };
+			let schedule = SeasonSchedule { early_start: 20, start: 25, end: Some(30) };
 
 			assert_ok!(SeasonsAlpha::update_season(
 				RuntimeOrigin::signed(ALICE),

--- a/pallets/ajuna-seasons/src/tests.rs
+++ b/pallets/ajuna-seasons/src/tests.rs
@@ -45,7 +45,7 @@ fn test_seasons_full_workflow() {
 			description: BoundedVec::try_from(b"The first season".to_vec())
 				.expect("Should create vec"),
 		};
-		let schedule = SeasonSchedule { early_start: 20, start: 25, end: 30 };
+		let schedule = SeasonSchedule { early_start: 20, start: 25, end: Some(30) };
 
 		// Initially there is no data in storage
 		assert_err!(CurrentSeasonStatus::<Test, _>::get(), Error::<Test, _>::NoActiveSeason);
@@ -111,7 +111,7 @@ fn test_seasons_full_workflow() {
 			description: BoundedVec::try_from(b"The second season".to_vec())
 				.expect("Should create vec"),
 		};
-		let schedule = SeasonSchedule { early_start: 28, start: 40, end: 60 };
+		let schedule = SeasonSchedule { early_start: 28, start: 40, end: Some(60) };
 
 		// We create a new season with its early_start overlapping season 1
 		assert_ok!(SeasonsAlpha::update_season(
@@ -236,7 +236,7 @@ mod update_season {
 			let schedule = SeasonSchedule {
 				early_start: season_early_start,
 				start: season_start,
-				end: season_end,
+				end: Some(season_end),
 			};
 
 			assert_eq!(Seasons::<Test, _>::get(SEASON_ID_1), None);
@@ -325,7 +325,7 @@ mod update_season {
 					state_transition_base_fee: 20_u64,
 				},
 			};
-			let schedule = SeasonSchedule { early_start: 7, start: 10, end: 11 };
+			let schedule = SeasonSchedule { early_start: 7, start: 10, end: Some(11) };
 			assert_noop!(
 				SeasonsAlpha::update_season(
 					RuntimeOrigin::signed(ALICE),
@@ -338,7 +338,7 @@ mod update_season {
 			);
 
 			// Season start is before early_start
-			let schedule = SeasonSchedule { early_start: 11, start: 10, end: 13 };
+			let schedule = SeasonSchedule { early_start: 11, start: 10, end: Some(13) };
 			assert_noop!(
 				SeasonsAlpha::update_season(
 					RuntimeOrigin::signed(ALICE),
@@ -351,7 +351,7 @@ mod update_season {
 			);
 
 			// Season end is before start
-			let schedule = SeasonSchedule { early_start: 11, start: 15, end: 13 };
+			let schedule = SeasonSchedule { early_start: 11, start: 15, end: Some(13) };
 			assert_noop!(
 				SeasonsAlpha::update_season(
 					RuntimeOrigin::signed(ALICE),
@@ -364,7 +364,7 @@ mod update_season {
 			);
 
 			// Season early_start is before previous season start
-			let schedule_1 = SeasonSchedule { early_start: 15, start: 17, end: 20 };
+			let schedule_1 = SeasonSchedule { early_start: 15, start: 17, end: Some(20) };
 			assert_ok!(SeasonsAlpha::update_season(
 				RuntimeOrigin::signed(ALICE),
 				SEASON_ID_1,
@@ -372,7 +372,7 @@ mod update_season {
 				None,
 				Some(schedule_1)
 			));
-			let schedule_2 = SeasonSchedule { early_start: 13, start: 20, end: 25 };
+			let schedule_2 = SeasonSchedule { early_start: 13, start: 20, end: Some(25) };
 			assert_noop!(
 				SeasonsAlpha::update_season(
 					RuntimeOrigin::signed(ALICE),
@@ -402,7 +402,7 @@ mod update_season {
 					state_transition_base_fee: 20_u64,
 				},
 			};
-			let schedule = SeasonSchedule { early_start: 20, start: 25, end: 30 };
+			let schedule = SeasonSchedule { early_start: 20, start: 25, end: Some(30) };
 
 			// We set up the first season but with no schedule
 			assert_ok!(SeasonsAlpha::update_season(
@@ -435,7 +435,7 @@ mod update_season {
 			assert_eq!(CurrentSeasonStatus::<Test, _>::get(), Ok(expected_status));
 
 			// Trying to insert a schedule for season 1 fails since 2 is already active
-			let schedule = SeasonSchedule { early_start: 40, start: 50, end: 60 };
+			let schedule = SeasonSchedule { early_start: 40, start: 50, end: Some(60) };
 			assert_noop!(
 				SeasonsAlpha::update_season(
 					RuntimeOrigin::signed(ALICE),
@@ -472,7 +472,7 @@ mod update_season {
 			// Trying again after the previous season block end also doesn't work
 			run_to_block(40);
 
-			let schedule = SeasonSchedule { early_start: 45, start: 50, end: 60 };
+			let schedule = SeasonSchedule { early_start: 45, start: 50, end: Some(60) };
 			assert_noop!(
 				SeasonsAlpha::update_season(
 					RuntimeOrigin::signed(ALICE),
@@ -491,7 +491,7 @@ mod update_season {
 		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
 			run_to_block(10);
 
-			let schedule = SeasonSchedule { early_start: 20, start: 25, end: 30 };
+			let schedule = SeasonSchedule { early_start: 20, start: 25, end: Some(30) };
 			assert_noop!(
 				SeasonsAlpha::update_season(
 					RuntimeOrigin::signed(ALICE),
@@ -539,7 +539,7 @@ mod update_season {
 					state_transition_base_fee: 20_u64,
 				},
 			};
-			let schedule = SeasonSchedule { early_start: 20, start: 25, end: 30 };
+			let schedule = SeasonSchedule { early_start: 20, start: 25, end: Some(30) };
 
 			// We set up the first season but with no schedule
 			assert_ok!(SeasonsAlpha::update_season(
@@ -567,7 +567,7 @@ mod update_season {
 					state_transition_base_fee: 23_u64,
 				},
 			};
-			let new_schedule = SeasonSchedule { early_start: 20, start: 25, end: 30 };
+			let new_schedule = SeasonSchedule { early_start: 20, start: 25, end: Some(30) };
 
 			assert_ok!(SeasonsAlpha::update_season(
 				RuntimeOrigin::signed(ALICE),
@@ -624,6 +624,72 @@ mod update_season {
 			}
 		});
 	}
+
+	#[test]
+	fn update_season_should_allow_updating_infinite_active_season() {
+		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
+			run_to_block(10);
+
+			let config = SeasonConfigOf::<Test, _> {
+				fee: SeasonFeeConfig {
+					transfer_asset: 10_u64,
+					buy_asset_min: 5_u64,
+					buy_percent: 10,
+					upgrade_asset_inventory: 5_u64,
+					unlock_trade_asset: 9_u64,
+					unlock_transfer_asset: 13_u64,
+					state_transition_base_fee: 20_u64,
+				},
+			};
+			let schedule = SeasonSchedule { early_start: 20, start: 25, end: None };
+
+			// We set an infinite season
+			assert_ok!(SeasonsAlpha::update_season(
+				RuntimeOrigin::signed(ALICE),
+				SEASON_ID_1,
+				Some(config.clone()),
+				None,
+				Some(schedule.clone())
+			));
+
+			run_to_block(40);
+
+			let expected_status = SeasonStatus {
+				season_id: SEASON_ID_1,
+				early: true,
+				active: true,
+				early_ended: false,
+			};
+			assert_eq!(CurrentSeasonStatus::<Test, _>::get(), Ok(expected_status));
+
+			let schedule = SeasonSchedule { early_start: 30, start: 35, end: Some(60) };
+			assert_ok!(SeasonsAlpha::update_season(
+				RuntimeOrigin::signed(ALICE),
+				SEASON_ID_1,
+				None,
+				None,
+				Some(schedule.clone())
+			));
+
+			// Only the end schedule has changed
+			let expected_schedule = SeasonSchedule { early_start: 20, start: 25, end: Some(60) };
+			assert_eq!(SeasonSchedules::<Test, _>::get(SEASON_ID_1), Some(expected_schedule));
+
+			run_to_block(60);
+
+			System::assert_last_event(RuntimeEvent::SeasonsAlpha(Event::SeasonEnded {
+				season_id: SEASON_ID_1,
+			}));
+
+			let expected_status = SeasonStatus {
+				season_id: SEASON_ID_1,
+				early: true,
+				active: false,
+				early_ended: false,
+			};
+			assert_eq!(CurrentSeasonStatus::<Test, _>::get(), Ok(expected_status));
+		});
+	}
 }
 
 mod interrupt_active_season {
@@ -645,7 +711,7 @@ mod interrupt_active_season {
 					state_transition_base_fee: 20_u64,
 				},
 			};
-			let schedule = SeasonSchedule { early_start: 20, start: 25, end: 30 };
+			let schedule = SeasonSchedule { early_start: 20, start: 25, end: Some(30) };
 
 			assert_ok!(SeasonsAlpha::update_season(
 				RuntimeOrigin::signed(ALICE),
@@ -702,7 +768,7 @@ mod interrupt_active_season {
 					state_transition_base_fee: 20_u64,
 				},
 			};
-			let schedule = SeasonSchedule { early_start: 20, start: 25, end: 30 };
+			let schedule = SeasonSchedule { early_start: 20, start: 25, end: Some(30) };
 
 			assert_ok!(SeasonsAlpha::update_season(
 				RuntimeOrigin::signed(ALICE),

--- a/pallets/ajuna-seasons/src/types.rs
+++ b/pallets/ajuna-seasons/src/types.rs
@@ -44,5 +44,5 @@ pub struct SeasonMetadata {
 pub struct SeasonSchedule<BlockNumber> {
 	pub early_start: BlockNumber,
 	pub start: BlockNumber,
-	pub end: BlockNumber,
+	pub end: Option<BlockNumber>,
 }


### PR DESCRIPTION
## Description

Added the ability to define seasons with no `end` block, making them potentially infinite.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
