### PR TITLE
[sage] more ergonomic error handling for downstream

### DIFF
--- a/sage/api/src/error.rs
+++ b/sage/api/src/error.rs
@@ -10,6 +10,10 @@ pub enum TransitionError {
 	CouldNotCreateAssetId,
 	AssetLength,
 	AssetOwnership,
+	/// The asset could not be decoded. Maybe it was the wrong asset type.
+	AssetCouldNotBeDecoded,
+	/// The asset data was too long and could be written back to the asset.
+	AssetDataTooLong,
 	Transition { code: u8 },
 	Dispatch { error: DispatchError },
 }

--- a/sage/api/src/error.rs
+++ b/sage/api/src/error.rs
@@ -1,9 +1,8 @@
 use frame_support::pallet_prelude::{Decode, Encode, MaxEncodedLen, TypeInfo};
+use sp_runtime::DispatchError;
 
 /// Errors that may happen during the execution of a SAGE transition.
-#[derive(
-	Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord,
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TransitionError {
 	TransferError,
 	FeeError,
@@ -12,4 +11,17 @@ pub enum TransitionError {
 	AssetLength,
 	AssetOwnership,
 	Transition { code: u8 },
+	Dispatch { error: DispatchError },
+}
+
+impl From<DispatchError> for TransitionError {
+	fn from(error: DispatchError) -> TransitionError {
+		TransitionError::Dispatch { error }
+	}
+}
+
+impl From<u8> for TransitionError {
+	fn from(error: u8) -> TransitionError {
+		TransitionError::Transition { code: error }
+	}
 }

--- a/sage/api/src/error.rs
+++ b/sage/api/src/error.rs
@@ -14,8 +14,12 @@ pub enum TransitionError {
 	AssetCouldNotBeDecoded,
 	/// The asset data was too long and could be written back to the asset.
 	AssetDataTooLong,
-	Transition { code: u8 },
-	Dispatch { error: DispatchError },
+	Transition {
+		code: u8,
+	},
+	Dispatch {
+		error: DispatchError,
+	},
 }
 
 impl From<DispatchError> for TransitionError {

--- a/sage/pallet/src/lib.rs
+++ b/sage/pallet/src/lib.rs
@@ -465,17 +465,16 @@ pub mod pallet {
 		Transition { code: u8 },
 	}
 
-	impl<T, I> From<TransitionError> for Error<T, I> {
-		fn from(e: TransitionError) -> Self {
-			match e {
-				TransitionError::TransferError => Error::<T, I>::TransferError,
-				TransitionError::FeeError => Error::<T, I>::FeeError,
-				TransitionError::CouldNotCreateAssetId => Error::<T, I>::CouldNotCreateAssetId,
-				TransitionError::AssetLength => Error::<T, I>::AssetLength,
-				TransitionError::AssetOwnership => Error::<T, I>::AssetOwnership,
-				TransitionError::VoucherNotAllowed => Error::<T, I>::VoucherNotAllowed,
-				TransitionError::Transition { code } => Error::<T, I>::Transition { code },
-			}
+	fn transform_error<T: Config<I>, I: 'static>(e: TransitionError) -> DispatchError {
+		match e {
+			TransitionError::TransferError => Error::<T, I>::TransferError.into(),
+			TransitionError::FeeError => Error::<T, I>::FeeError.into(),
+			TransitionError::CouldNotCreateAssetId => Error::<T, I>::CouldNotCreateAssetId.into(),
+			TransitionError::AssetLength => Error::<T, I>::AssetLength.into(),
+			TransitionError::AssetOwnership => Error::<T, I>::AssetOwnership.into(),
+			TransitionError::VoucherNotAllowed => Error::<T, I>::VoucherNotAllowed.into(),
+			TransitionError::Transition { code } => Error::<T, I>::Transition { code }.into(),
+			TransitionError::Dispatch { error } => error,
 		}
 	}
 
@@ -849,7 +848,7 @@ pub mod pallet {
 				&extra,
 				payment_kind.clone(),
 			)
-			.map_err(<Error<T, I>>::from)?;
+			.map_err(transform_error::<T, _>)?;
 			let current_season_id = T::SeasonHandler::get_current_season_id()?;
 			let payment = payment_kind.unwrap_or_else(FungiblesAssetIdOf::<T, I>::get_native_id);
 			Self::process_transition_results(

--- a/sage/pallet/src/lib.rs
+++ b/sage/pallet/src/lib.rs
@@ -457,6 +457,10 @@ pub mod pallet {
 		CouldNotCreateAssetId,
 		/// Invalid number of assets for this transition.
 		AssetLength,
+		/// The asset could not be decoded.
+		AssetCouldNotBeDecoded,
+		/// The asset data was too long to be written back to the asset.
+		AssetDataTooLong,
 		/// Asset Ownership error.
 		AssetOwnership,
 		/// Voucher is not allowed for that transition.
@@ -475,6 +479,8 @@ pub mod pallet {
 			TransitionError::VoucherNotAllowed => Error::<T, I>::VoucherNotAllowed.into(),
 			TransitionError::Transition { code } => Error::<T, I>::Transition { code }.into(),
 			TransitionError::Dispatch { error } => error,
+			TransitionError::AssetCouldNotBeDecoded => Error::<T, I>::AssetCouldNotBeDecoded.into(),
+			TransitionError::AssetDataTooLong => Error::<T, I>::AssetDataTooLong.into(),
 		}
 	}
 


### PR DESCRIPTION
The key idea is that we can simply use `?` for dispatch errors in the transition implementation